### PR TITLE
fix: HuntFinder shows 0 results — merge techniques into tags after frontmatter migration

### DIFF
--- a/.github/workflows/update-hunts.yml
+++ b/.github/workflows/update-hunts.yml
@@ -31,7 +31,7 @@ jobs:
         run: |
           git config --global user.name 'github-actions[bot]'
           git config --global user.email 'github-actions[bot]@users.noreply.github.com'
-          git add hunts-data.js
+          git add hunts-data.js public/hunts-data.json
           # Commit only if there are changes
           if ! git diff --staged --quiet; then
             git commit -m "chore: Auto-update hunt database"

--- a/hunts-data.js
+++ b/hunts-data.js
@@ -9,7 +9,9 @@ const HUNTS_DATA = [
     "tags": [
       "baseline",
       "networktraffic",
-      "anomalydetection"
+      "anomalydetection",
+      "T1071.001",
+      "T1041"
     ],
     "techniques": [
       "T1071.001",
@@ -35,7 +37,8 @@ const HUNTS_DATA = [
     "tags": [
       "baseline",
       "persistence",
-      "anomalydetection"
+      "anomalydetection",
+      "T1219"
     ],
     "techniques": [
       "T1219"
@@ -60,7 +63,8 @@ const HUNTS_DATA = [
     "tags": [
       "baseline",
       "persistence",
-      "anomalydetection"
+      "anomalydetection",
+      "T1547.001"
     ],
     "techniques": [
       "T1547.001"
@@ -86,7 +90,8 @@ const HUNTS_DATA = [
       "baseline",
       "persistence",
       "anomalydetection",
-      "sus"
+      "sus",
+      "T1136"
     ],
     "techniques": [
       "T1136"
@@ -112,7 +117,8 @@ const HUNTS_DATA = [
       "execution",
       "defenseevasion",
       "lolbin",
-      "rundll32"
+      "rundll32",
+      "T1218.011"
     ],
     "techniques": [
       "T1218.011"
@@ -137,7 +143,9 @@ const HUNTS_DATA = [
     "tags": [
       "collection",
       "exfiltration",
-      "browserextensions"
+      "browserextensions",
+      "T1176",
+      "T1005"
     ],
     "techniques": [
       "T1176",
@@ -164,7 +172,9 @@ const HUNTS_DATA = [
       "collection",
       "exfiltration",
       "email",
-      "mailforwarding"
+      "mailforwarding",
+      "T1114.003",
+      "T1020"
     ],
     "techniques": [
       "T1114.003",
@@ -190,7 +200,8 @@ const HUNTS_DATA = [
     "tags": [
       "baseline",
       "privilege_escalation",
-      "anomalydetection"
+      "anomalydetection",
+      "T1098"
     ],
     "techniques": [
       "T1098"
@@ -216,7 +227,10 @@ const HUNTS_DATA = [
       "defenseevasion",
       "masquerading",
       "trusteddeveloperutilities",
-      "proxyexecution"
+      "proxyexecution",
+      "T1036",
+      "T1127",
+      "T1211"
     ],
     "techniques": [
       "T1036",
@@ -241,7 +255,9 @@ const HUNTS_DATA = [
     "tactic": "Lateral Movement",
     "notes": "Explore typical peering requests, initiators, unusual IPs, and connection events.",
     "tags": [
-      "lateralmovement"
+      "lateralmovement",
+      "T1599",
+      "T1021"
     ],
     "techniques": [
       "T1599",
@@ -266,7 +282,8 @@ const HUNTS_DATA = [
     "notes": "Indicators of Xcode usage can be found in EDR telemetry and potential for detection if Xcode is not utilized/approved in the environment.",
     "tags": [
       "initialaccess",
-      "baseline"
+      "baseline",
+      "T1195.001"
     ],
     "techniques": [
       "T1195.001"
@@ -294,7 +311,8 @@ const HUNTS_DATA = [
       "service_account",
       "ai_agent",
       "orphan_account",
-      "lifecycle"
+      "lifecycle",
+      "T1078.004"
     ],
     "techniques": [
       "T1078.004"
@@ -321,7 +339,8 @@ const HUNTS_DATA = [
       "credential_access",
       "lsass",
       "sysmon",
-      "process_access"
+      "process_access",
+      "T1003.001"
     ],
     "techniques": [
       "T1003.001"
@@ -348,7 +367,8 @@ const HUNTS_DATA = [
       "defense_evasion",
       "msiexec",
       "msi",
-      "software_installation"
+      "software_installation",
+      "T1218.007"
     ],
     "techniques": [
       "T1218.007"
@@ -377,7 +397,8 @@ const HUNTS_DATA = [
       "wbadmin",
       "vssadmin",
       "domain_controller",
-      "active_directory"
+      "active_directory",
+      "T1003.003"
     ],
     "techniques": [
       "T1003.003"
@@ -427,7 +448,8 @@ const HUNTS_DATA = [
     "tags": [
       "credentialaccess",
       "bruteforce",
-      "vpn"
+      "vpn",
+      "T1110"
     ],
     "techniques": [
       "T1110"
@@ -453,7 +475,8 @@ const HUNTS_DATA = [
       "commandandcontrol",
       "remoteaccess",
       "edr",
-      "lolbin"
+      "lolbin",
+      "T1219"
     ],
     "techniques": [
       "T1219"
@@ -476,7 +499,9 @@ const HUNTS_DATA = [
     "tactic": "Exfiltration",
     "notes": "Attackers often need to get data out, 1MB chunks sneak beneath big file anomaly detection. Consider different file sizes and types based on normal in your environment.",
     "tags": [
-      "exfiltration"
+      "exfiltration",
+      "T1030",
+      "T1560.001"
     ],
     "techniques": [
       "T1030",
@@ -502,7 +527,8 @@ const HUNTS_DATA = [
     "tags": [
       "persistence",
       "lolbin",
-      "windows"
+      "windows",
+      "T1197"
     ],
     "techniques": [
       "T1197"
@@ -527,7 +553,8 @@ const HUNTS_DATA = [
     "tags": [
       "persistence",
       "lolbas",
-      "linux"
+      "linux",
+      "T1546.004"
     ],
     "techniques": [
       "T1546.004"
@@ -551,7 +578,8 @@ const HUNTS_DATA = [
     "notes": "Adversaries often abuse legitimate remote access features (such as RDP and SSH) already enabled in the environment.",
     "tags": [
       "lateralmovement",
-      "sus"
+      "sus",
+      "T1021"
     ],
     "techniques": [
       "T1021"
@@ -575,7 +603,8 @@ const HUNTS_DATA = [
     "notes": "Adversaries often abuse legitimate command interpreters/applications, such as CMD, PowerShell, or bash/zsh.",
     "tags": [
       "execution",
-      "sus"
+      "sus",
+      "T1059"
     ],
     "techniques": [
       "T1059"
@@ -599,7 +628,8 @@ const HUNTS_DATA = [
     "notes": "Domain Accounts can cover user, administrator, and service accounts.",
     "tags": [
       "persistence",
-      "activedirectory"
+      "activedirectory",
+      "T1136.002"
     ],
     "techniques": [
       "T1136.002"
@@ -623,7 +653,8 @@ const HUNTS_DATA = [
     "notes": "Data requirements: Windows Sysmon, EDR telemetry, Proxy logs",
     "tags": [
       "defenseevasion",
-      "systembinaryproxyexecutionmshta"
+      "systembinaryproxyexecutionmshta",
+      "T1218.005"
     ],
     "techniques": [
       "T1218.005"
@@ -647,7 +678,8 @@ const HUNTS_DATA = [
     "notes": "<ul><li>Data requirements: EDR telemetry, Windows event logs id 5140</li></br><li>Implementation examples in SIGMA:</li></br>Title: Suspicious Network Share Enumeration and Access</br>Id:xxxxx</br>Status: test</br>Description: Detects commands used for network share enumeration and correlates with Event ID 5140 for access to shared resources.</br>Author: Your Name</br>Date:2024/11/14</br>Tags:</br><ul><li>attack.discovery</br><li>attack.t1135</li></ul></br>logsource:</br>category: process_creation</br>product:windows</br>detection:</br>selection_cmd:</br>Image&#124;endswith:</br><ul><li>'\\cmd.exe'</br><li>'\\powershell.exe'</br>ComandLine&#124;contains&#124;all:</br><li>'net view'</br><li>'&bsol;'</br>selection_event:</br>EventID: 5140</br>condition: selection_cmd or selection_event</br>falsepositives:</br><li>Legitimate administrative tasks</br><li>Regular file-sharing activities</br>level: medium #T1039",
     "tags": [
       "collection",
-      "datafromnetworkshareddrive"
+      "datafromnetworkshareddrive",
+      "T1039"
     ],
     "techniques": [
       "T1039"
@@ -673,7 +705,8 @@ const HUNTS_DATA = [
       "persistence",
       "privilege_escalation",
       "defense_evasion",
-      "dllsideloading"
+      "dllsideloading",
+      "T1574.002"
     ],
     "techniques": [
       "T1574.002"
@@ -698,7 +731,9 @@ const HUNTS_DATA = [
     "tags": [
       "dns",
       "tunneling",
-      "exfiltration"
+      "exfiltration",
+      "T1048",
+      "T1071.004"
     ],
     "techniques": [
       "T1048",
@@ -725,7 +760,8 @@ const HUNTS_DATA = [
       "powershell",
       "sysmon",
       "execution",
-      "ta0002"
+      "ta0002",
+      "T1059.001"
     ],
     "techniques": [
       "T1059.001"
@@ -752,7 +788,9 @@ const HUNTS_DATA = [
       "namedpipes",
       "commandandcontrol",
       "sysmon",
-      "threathunting"
+      "threathunting",
+      "T1559",
+      "T1090"
     ],
     "techniques": [
       "T1559",
@@ -779,7 +817,9 @@ const HUNTS_DATA = [
       "registry",
       "edr",
       "dns",
-      "defenseevasion"
+      "defenseevasion",
+      "T1562.001",
+      "T1112"
     ],
     "techniques": [
       "T1562.001",
@@ -804,7 +844,8 @@ const HUNTS_DATA = [
     "notes": "Based on ATT&CK technique T1078, using compromised credentials.",
     "tags": [
       "initialaccess",
-      "sonicwall"
+      "sonicwall",
+      "T1078"
     ],
     "techniques": [
       "T1078"
@@ -829,7 +870,8 @@ const HUNTS_DATA = [
     "tags": [
       "privilegeescalation",
       "exploit",
-      "apache"
+      "apache",
+      "T1068"
     ],
     "techniques": [
       "T1068"
@@ -854,7 +896,8 @@ const HUNTS_DATA = [
     "tags": [
       "credentialaccess",
       "serverlessfunctions",
-      "cloud"
+      "cloud",
+      "T1098"
     ],
     "techniques": [
       "T1098"
@@ -880,7 +923,8 @@ const HUNTS_DATA = [
       "persistence",
       "initialaccess",
       "userexecution",
-      "elf"
+      "elf",
+      "T1204"
     ],
     "techniques": [
       "T1204"
@@ -904,7 +948,8 @@ const HUNTS_DATA = [
     "notes": "Based on ATT&CK technique T1047, using WMI for execution of PowerShell commands.",
     "tags": [
       "execution",
-      "wmi"
+      "wmi",
+      "T1047"
     ],
     "techniques": [
       "T1047"
@@ -928,7 +973,8 @@ const HUNTS_DATA = [
     "notes": "Based on ATT&CK technique T1562.001, using the undocumented Windows Security Center (WSC) APIs",
     "tags": [
       "defenseevasion",
-      "wsc"
+      "wsc",
+      "T1562.001"
     ],
     "techniques": [
       "T1562.001"
@@ -952,7 +998,8 @@ const HUNTS_DATA = [
     "notes": "Based on ATT&CK technique T1110. Generated by [hearth-auto-intel](https://github.com/THORCollective/HEARTH).",
     "tags": [
       "credentialaccess",
-      "socialengineering"
+      "socialengineering",
+      "T1110"
     ],
     "techniques": [
       "T1110"
@@ -976,7 +1023,8 @@ const HUNTS_DATA = [
     "notes": "Based on ATT&CK technique T1564. Generated by [hearth-auto-intel](https://github.com/THORCollective/HEARTH).",
     "tags": [
       "defenseevasion",
-      "attribcommand"
+      "attribcommand",
+      "T1564"
     ],
     "techniques": [
       "T1564"
@@ -1001,7 +1049,9 @@ const HUNTS_DATA = [
     "tags": [
       "initialaccess",
       "phishing",
-      "spearphishinglink"
+      "spearphishinglink",
+      "T1566.001",
+      "T1204.002"
     ],
     "techniques": [
       "T1566.001",
@@ -1028,7 +1078,9 @@ const HUNTS_DATA = [
       "initialaccess",
       "execution",
       "userexecution",
-      "commandandscriptinginterpreter"
+      "commandandscriptinginterpreter",
+      "T1204.002",
+      "T1059.006"
     ],
     "techniques": [
       "T1204.002",
@@ -1053,7 +1105,8 @@ const HUNTS_DATA = [
     "notes": "Based on ATT&CK technique T1070.004. Generated by [hearth-auto-intel](https://github.com/THORCollective/HEARTH).",
     "tags": [
       "defenseevasion",
-      "cipher_exe"
+      "cipher_exe",
+      "T1070.004"
     ],
     "techniques": [
       "T1070.004"
@@ -1078,7 +1131,8 @@ const HUNTS_DATA = [
     "tags": [
       "initialaccess",
       "applescript",
-      "bluenoroff"
+      "bluenoroff",
+      "T1566.002"
     ],
     "techniques": [
       "T1566.002"
@@ -1103,7 +1157,8 @@ const HUNTS_DATA = [
     "tags": [
       "defenseevasion",
       "evasion",
-      "macos"
+      "macos",
+      "T1497.003"
     ],
     "techniques": [
       "T1497.003"
@@ -1128,7 +1183,8 @@ const HUNTS_DATA = [
     "tags": [
       "defenseevasion",
       "processinjection",
-      "macos"
+      "macos",
+      "T1055"
     ],
     "techniques": [
       "T1055"
@@ -1153,7 +1209,8 @@ const HUNTS_DATA = [
     "tags": [
       "persistence",
       "launchdaemon",
-      "macos"
+      "macos",
+      "T1543.004"
     ],
     "techniques": [
       "T1543.004"
@@ -1178,7 +1235,8 @@ const HUNTS_DATA = [
     "tags": [
       "collection",
       "cryptocurrency",
-      "bluenoroff"
+      "bluenoroff",
+      "T1005"
     ],
     "techniques": [
       "T1005"
@@ -1204,7 +1262,8 @@ const HUNTS_DATA = [
       "defense_evasion",
       "command_and_scripting_interpreter",
       "applescript",
-      "malware"
+      "malware",
+      "T1059.002"
     ],
     "techniques": [
       "T1059.002"
@@ -1230,7 +1289,8 @@ const HUNTS_DATA = [
       "execution",
       "command_and_scripting_interpreter",
       "powershell",
-      "ransomware"
+      "ransomware",
+      "T1059.001"
     ],
     "techniques": [
       "T1059.001"
@@ -1256,7 +1316,8 @@ const HUNTS_DATA = [
       "persistence",
       "lateral_movement",
       "ide_plugin",
-      "event_triggered_execution"
+      "event_triggered_execution",
+      "T1546.016"
     ],
     "techniques": [
       "T1546.016"
@@ -1281,7 +1342,10 @@ const HUNTS_DATA = [
     "tags": [
       "initial_access",
       "hardware_additions",
-      "air_gap"
+      "air_gap",
+      "T0847",
+      "T1091",
+      "T1200"
     ],
     "techniques": [
       "T0847",
@@ -1308,7 +1372,8 @@ const HUNTS_DATA = [
     "tags": [
       "defense_evasion",
       "proxy",
-      "chisel"
+      "chisel",
+      "T1090.001"
     ],
     "techniques": [
       "T1090.001"
@@ -1334,7 +1399,8 @@ const HUNTS_DATA = [
       "defense_evasion",
       "obfuscated_files_or_information",
       "javascript",
-      "malvertising"
+      "malvertising",
+      "T1027"
     ],
     "techniques": [
       "T1027"
@@ -1359,7 +1425,8 @@ const HUNTS_DATA = [
     "tags": [
       "collection",
       "archive_collected_data",
-      "powershell"
+      "powershell",
+      "T1560"
     ],
     "techniques": [
       "T1560"
@@ -1384,7 +1451,8 @@ const HUNTS_DATA = [
     "tags": [
       "reconnaissance",
       "active_scanning",
-      "network_service_scanning"
+      "network_service_scanning",
+      "T1595.001"
     ],
     "techniques": [
       "T1595.001"
@@ -1409,7 +1477,8 @@ const HUNTS_DATA = [
     "tags": [
       "initial_access",
       "password_spraying",
-      "rdp"
+      "rdp",
+      "T1110.003"
     ],
     "techniques": [
       "T1110.003"
@@ -1434,7 +1503,8 @@ const HUNTS_DATA = [
     "tags": [
       "privilege_escalation",
       "tinyshell",
-      "juniper"
+      "juniper",
+      "T1055"
     ],
     "techniques": [
       "T1055"
@@ -1459,7 +1529,8 @@ const HUNTS_DATA = [
     "tags": [
       "defense_evasion",
       "deobfuscate_files",
-      "earth_estries"
+      "earth_estries",
+      "T1140"
     ],
     "techniques": [
       "T1140"
@@ -1484,7 +1555,8 @@ const HUNTS_DATA = [
     "tags": [
       "defense_evasion",
       "registry_modification",
-      "persistence"
+      "persistence",
+      "T1112"
     ],
     "techniques": [
       "T1112"
@@ -1509,7 +1581,8 @@ const HUNTS_DATA = [
     "tags": [
       "execution",
       "powershell",
-      "rat"
+      "rat",
+      "T1059.001"
     ],
     "techniques": [
       "T1059.001"
@@ -1534,7 +1607,8 @@ const HUNTS_DATA = [
     "tags": [
       "execution",
       "mshta",
-      "living_off_the_land"
+      "living_off_the_land",
+      "T1218.005"
     ],
     "techniques": [
       "T1218.005"
@@ -1561,7 +1635,8 @@ const HUNTS_DATA = [
       "networktraffic",
       "ssh",
       "linux",
-      "windows"
+      "windows",
+      "T1572"
     ],
     "techniques": [
       "T1572"
@@ -1586,7 +1661,8 @@ const HUNTS_DATA = [
     "tags": [
       "command_and_control",
       "ingress_tool_transfer",
-      "powershell"
+      "powershell",
+      "T1105"
     ],
     "techniques": [
       "T1105"
@@ -1612,7 +1688,10 @@ const HUNTS_DATA = [
       "defenseevasion",
       "execution",
       "masquerading",
-      "proxyexecution"
+      "proxyexecution",
+      "T1036",
+      "T1218",
+      "T1105"
     ],
     "techniques": [
       "T1036",
@@ -1639,7 +1718,9 @@ const HUNTS_DATA = [
     "tags": [
       "defenseevasion",
       "phishing",
-      "collection"
+      "collection",
+      "T1564.008",
+      "T1114"
     ],
     "techniques": [
       "T1564.008",
@@ -1666,7 +1747,8 @@ const HUNTS_DATA = [
       "credentialaccess",
       "activedirectory",
       "identity",
-      "secretsdump"
+      "secretsdump",
+      "T1003.006"
     ],
     "techniques": [
       "T1003.006"
@@ -1692,7 +1774,8 @@ const HUNTS_DATA = [
       "commandandcontrol",
       "hvnc",
       "remoteaccess",
-      "glassworm"
+      "glassworm",
+      "T1219"
     ],
     "techniques": [
       "T1219"
@@ -1718,7 +1801,8 @@ const HUNTS_DATA = [
       "command_and_control",
       "backconnect",
       "vnc",
-      "dllhost"
+      "dllhost",
+      "T1219"
     ],
     "techniques": [
       "T1219"
@@ -1743,7 +1827,8 @@ const HUNTS_DATA = [
     "tags": [
       "discovery",
       "networkscan",
-      "ai_powered"
+      "ai_powered",
+      "T1046"
     ],
     "techniques": [
       "T1046"
@@ -1769,7 +1854,8 @@ const HUNTS_DATA = [
       "defense_evasion",
       "macos",
       "gatekeeper",
-      "applescript"
+      "applescript",
+      "T1553.001"
     ],
     "techniques": [
       "T1553.001"
@@ -1795,7 +1881,8 @@ const HUNTS_DATA = [
       "discovery",
       "gootloader",
       "powershell",
-      "systeminfo"
+      "systeminfo",
+      "T1082"
     ],
     "techniques": [
       "T1082"
@@ -1820,7 +1907,8 @@ const HUNTS_DATA = [
     "tags": [
       "defense_evasion",
       "oauth",
-      "session_hijacking"
+      "session_hijacking",
+      "T1550.001"
     ],
     "techniques": [
       "T1550.001"
@@ -1845,7 +1933,8 @@ const HUNTS_DATA = [
     "tags": [
       "discovery",
       "financial",
-      "powershell"
+      "powershell",
+      "T1135"
     ],
     "techniques": [
       "T1135"
@@ -1871,7 +1960,8 @@ const HUNTS_DATA = [
       "privilege_escalation",
       "byovd",
       "edr_killer",
-      "ransomware"
+      "ransomware",
+      "T1068"
     ],
     "techniques": [
       "T1068"
@@ -1897,7 +1987,8 @@ const HUNTS_DATA = [
       "exfiltration",
       "insider",
       "if001_006",
-      "if018_002"
+      "if018_002",
+      "T1567"
     ],
     "techniques": [
       "T1567"
@@ -1923,7 +2014,8 @@ const HUNTS_DATA = [
       "netsh",
       "powershell",
       "ta0005",
-      "firewall"
+      "firewall",
+      "T1562.004"
     ],
     "techniques": [
       "T1562.004"
@@ -1949,7 +2041,8 @@ const HUNTS_DATA = [
       "defense_evasion",
       "esxi",
       "hypervisor",
-      "ransomware"
+      "ransomware",
+      "T1562.001"
     ],
     "techniques": [
       "T1562.001"
@@ -1975,7 +2068,8 @@ const HUNTS_DATA = [
       "c2",
       "tunnel",
       "ta0011",
-      "t1102"
+      "t1102",
+      "T1572"
     ],
     "techniques": [
       "T1572"
@@ -2001,7 +2095,8 @@ const HUNTS_DATA = [
       "defense_evasion",
       "macos",
       "tcc",
-      "unc1069"
+      "unc1069",
+      "T1562.001"
     ],
     "techniques": [
       "T1562.001"
@@ -2027,7 +2122,8 @@ const HUNTS_DATA = [
       "defense_evasion",
       "punycode",
       "idn",
-      "dns"
+      "dns",
+      "T1036.005"
     ],
     "techniques": [
       "T1036.005"
@@ -2054,7 +2150,8 @@ const HUNTS_DATA = [
       "vmware",
       "vsphere",
       "rogue_vm",
-      "muddled_libra"
+      "muddled_libra",
+      "T1564.006"
     ],
     "techniques": [
       "T1564.006"
@@ -2081,7 +2178,9 @@ const HUNTS_DATA = [
       "browser_extension",
       "ai_tokens",
       "chatgpt",
-      "session_hijack"
+      "session_hijack",
+      "T1528",
+      "T1185"
     ],
     "techniques": [
       "T1528",
@@ -2110,7 +2209,8 @@ const HUNTS_DATA = [
       "supply_chain",
       "typosquatting",
       "tool_poisoning",
-      "ai_agent"
+      "ai_agent",
+      "T1195.002"
     ],
     "techniques": [
       "T1195.002"
@@ -2161,7 +2261,10 @@ const HUNTS_DATA = [
       "command_and_control",
       "finger_exe",
       "lolbin",
-      "crashfix"
+      "crashfix",
+      "T1105",
+      "T1036.003",
+      "T1218"
     ],
     "techniques": [
       "T1105",
@@ -2264,7 +2367,10 @@ const HUNTS_DATA = [
       "command_and_control",
       "cloud_c2",
       "apt28",
-      "filen"
+      "filen",
+      "T1102.002",
+      "T1203",
+      "T1055"
     ],
     "techniques": [
       "T1102.002",
@@ -2294,7 +2400,9 @@ const HUNTS_DATA = [
       "esxi",
       "vmware",
       "ghost_nic",
-      "unc6201"
+      "unc6201",
+      "T1021",
+      "T1497"
     ],
     "techniques": [
       "T1021",
@@ -2323,7 +2431,9 @@ const HUNTS_DATA = [
       "iptables",
       "port_knocking",
       "spa",
-      "unc6201"
+      "unc6201",
+      "T1205.001",
+      "T1562.004"
     ],
     "techniques": [
       "T1205.001",
@@ -2352,7 +2462,10 @@ const HUNTS_DATA = [
       "outlook",
       "office_addin",
       "supply_chain",
-      "agreetosteal"
+      "agreetosteal",
+      "T1195.002",
+      "T1056.002",
+      "T1114"
     ],
     "techniques": [
       "T1195.002",
@@ -2382,7 +2495,10 @@ const HUNTS_DATA = [
       "esxi",
       "vmware",
       "ghost_nic",
-      "unc6201"
+      "unc6201",
+      "T1021",
+      "T1599",
+      "T1049"
     ],
     "techniques": [
       "T1021",
@@ -2413,7 +2529,11 @@ const HUNTS_DATA = [
       "command_and_control",
       "apt28",
       "notdoor",
-      "com_hijacking"
+      "com_hijacking",
+      "T1566.001",
+      "T1059.005",
+      "T1546.015",
+      "T1102"
     ],
     "techniques": [
       "T1566.001",
@@ -2444,7 +2564,10 @@ const HUNTS_DATA = [
       "byovd",
       "gpo",
       "ransomware",
-      "crazyhunter"
+      "crazyhunter",
+      "T1484.001",
+      "T1562.001",
+      "T1106"
     ],
     "techniques": [
       "T1484.001",
@@ -2474,7 +2597,10 @@ const HUNTS_DATA = [
       "command_and_control",
       "clickfix",
       "social_engineering",
-      "rat"
+      "rat",
+      "T1566.002",
+      "T1204.002",
+      "T1219"
     ],
     "techniques": [
       "T1566.002",
@@ -2505,7 +2631,10 @@ const HUNTS_DATA = [
       "npm",
       "supply_chain",
       "mcp",
-      "ai_coding_assistant"
+      "ai_coding_assistant",
+      "T1195.002",
+      "T1555",
+      "T1119"
     ],
     "techniques": [
       "T1195.002",
@@ -2535,7 +2664,9 @@ const HUNTS_DATA = [
       "supply_chain",
       "mcp",
       "ai_coding_tools",
-      "claude_code"
+      "claude_code",
+      "T1195.001",
+      "T1059.004"
     ],
     "techniques": [
       "T1195.001",
@@ -2564,7 +2695,9 @@ const HUNTS_DATA = [
       "mshtml",
       "motw_bypass",
       "lnk",
-      "apt28"
+      "apt28",
+      "T1566.001",
+      "T1553.005"
     ],
     "techniques": [
       "T1566.001",
@@ -2594,7 +2727,10 @@ const HUNTS_DATA = [
       "usb",
       "air_gap",
       "apt37",
-      "rubyjumper"
+      "rubyjumper",
+      "T1091",
+      "T1092",
+      "T1036.005"
     ],
     "techniques": [
       "T1091",
@@ -2623,7 +2759,8 @@ const HUNTS_DATA = [
       "google_drive",
       "cloud_c2",
       "apt41",
-      "silver_dragon"
+      "silver_dragon",
+      "T1102.002"
     ],
     "techniques": [
       "T1102.002"
@@ -2651,7 +2788,9 @@ const HUNTS_DATA = [
       "dll_sideloading",
       "supply_chain",
       "notepadpp",
-      "chrysalis"
+      "chrysalis",
+      "T1574.002",
+      "T1195.002"
     ],
     "techniques": [
       "T1574.002",
@@ -2680,7 +2819,9 @@ const HUNTS_DATA = [
       "npm",
       "supply_chain",
       "worm",
-      "shai_hulud"
+      "shai_hulud",
+      "T1195.001",
+      "T1552.001"
     ],
     "techniques": [
       "T1195.001",
@@ -2710,7 +2851,10 @@ const HUNTS_DATA = [
       "clickfix",
       "windows_terminal",
       "ransomware",
-      "velvet_tempest"
+      "velvet_tempest",
+      "T1204.002",
+      "T1059.001",
+      "T1027.004"
     ],
     "techniques": [
       "T1204.002",
@@ -2740,7 +2884,10 @@ const HUNTS_DATA = [
       "clickfix",
       "windows_terminal",
       "lumma_stealer",
-      "infostealer"
+      "infostealer",
+      "T1204.002",
+      "T1059.001",
+      "T1555"
     ],
     "techniques": [
       "T1204.002",
@@ -2771,7 +2918,9 @@ const HUNTS_DATA = [
       "lolbin",
       "finger_exe",
       "ransomware",
-      "velvet_tempest"
+      "velvet_tempest",
+      "T1204.002",
+      "T1218"
     ],
     "techniques": [
       "T1204.002",
@@ -2801,7 +2950,10 @@ const HUNTS_DATA = [
       "vscode",
       "supply_chain",
       "glassworm",
-      "developer_tooling"
+      "developer_tooling",
+      "T1195.001",
+      "T1554",
+      "T1555"
     ],
     "techniques": [
       "T1195.001",
@@ -2831,7 +2983,8 @@ const HUNTS_DATA = [
       "ai_agent_security",
       "api_key_exfil",
       "openclaw",
-      "clawdbot"
+      "clawdbot",
+      "T1552"
     ],
     "techniques": [
       "T1552"
@@ -2860,7 +3013,8 @@ const HUNTS_DATA = [
       "crystal",
       "obscure_language_malware",
       "apt36",
-      "ai_generated_malware"
+      "ai_generated_malware",
+      "T1027"
     ],
     "techniques": [
       "T1027"
@@ -2889,7 +3043,8 @@ const HUNTS_DATA = [
       "infostealer",
       "amos",
       "agentic_ai",
-      "openclaw"
+      "openclaw",
+      "T1195.001"
     ],
     "techniques": [
       "T1195.001"
@@ -2919,7 +3074,8 @@ const HUNTS_DATA = [
       "cve_2025_68613",
       "workflow_automation",
       "lateral_movement",
-      "credential_access"
+      "credential_access",
+      "T1059"
     ],
     "techniques": [
       "T1059"
@@ -2951,7 +3107,8 @@ const HUNTS_DATA = [
       "healthcare",
       "government",
       "cve_2024_47575",
-      "cve_2024_55591"
+      "cve_2024_55591",
+      "T1552.001"
     ],
     "techniques": [
       "T1552.001"
@@ -2981,7 +3138,8 @@ const HUNTS_DATA = [
       "odyssey_stealer",
       "social_engineering",
       "credential_theft",
-      "session_hijacking"
+      "session_hijacking",
+      "T1204.002"
     ],
     "techniques": [
       "T1204.002"
@@ -3011,7 +3169,8 @@ const HUNTS_DATA = [
       "hive0163",
       "slopoly",
       "backdoor",
-      "financial_crime"
+      "financial_crime",
+      "T1059.001"
     ],
     "techniques": [
       "T1059.001"
@@ -3041,7 +3200,8 @@ const HUNTS_DATA = [
       "ai_agent",
       "zero_click",
       "document_delivery",
-      "patch_tuesday"
+      "patch_tuesday",
+      "T1048"
     ],
     "techniques": [
       "T1048"
@@ -3071,7 +3231,8 @@ const HUNTS_DATA = [
       "auth_bypass",
       "cve_2026_27896",
       "ai_agent",
-      "tool_execution"
+      "tool_execution",
+      "T1078"
     ],
     "techniques": [
       "T1078"
@@ -3097,7 +3258,8 @@ const HUNTS_DATA = [
       "impact",
       "intune",
       "mdm",
-      "wiper"
+      "wiper",
+      "T1485"
     ],
     "techniques": [
       "T1485"
@@ -3123,7 +3285,8 @@ const HUNTS_DATA = [
       "defense_evasion",
       "iocontrol",
       "ot_iot",
-      "upx"
+      "upx",
+      "T1027.002"
     ],
     "techniques": [
       "T1027.002"
@@ -3149,7 +3312,8 @@ const HUNTS_DATA = [
       "execution",
       "supply_chain",
       "npm",
-      "cicd"
+      "cicd",
+      "T1059.007"
     ],
     "techniques": [
       "T1059.007"
@@ -3174,7 +3338,8 @@ const HUNTS_DATA = [
     "tags": [
       "defense_evasion",
       "forticlient",
-      "authentication_bypass"
+      "authentication_bypass",
+      "T1550.004"
     ],
     "techniques": [
       "T1550.004"
@@ -3201,7 +3366,8 @@ const HUNTS_DATA = [
       "cve_2023_46604",
       "activemq",
       "exploit",
-      "rce"
+      "rce",
+      "T1190"
     ],
     "techniques": [
       "T1190"
@@ -3227,7 +3393,9 @@ const HUNTS_DATA = [
       "privilege_escalation",
       "named_pipe",
       "getsystem",
-      "token_impersonation"
+      "token_impersonation",
+      "T1134.005",
+      "T1134"
     ],
     "techniques": [
       "T1134.005",
@@ -3253,7 +3421,8 @@ const HUNTS_DATA = [
     "tags": [
       "defense_evasion",
       "event_log_clearing",
-      "anti_forensics"
+      "anti_forensics",
+      "T1070.001"
     ],
     "techniques": [
       "T1070.001"
@@ -3279,7 +3448,8 @@ const HUNTS_DATA = [
       "credential_access",
       "lsass",
       "credential_dumping",
-      "mimikatz"
+      "mimikatz",
+      "T1003.001"
     ],
     "techniques": [
       "T1003.001"
@@ -3305,7 +3475,8 @@ const HUNTS_DATA = [
       "discovery",
       "smb_scanning",
       "network_enumeration",
-      "reconnaissance"
+      "reconnaissance",
+      "T1018"
     ],
     "techniques": [
       "T1018"
@@ -3331,7 +3502,9 @@ const HUNTS_DATA = [
       "discovery",
       "account_enumeration",
       "active_directory",
-      "net_commands"
+      "net_commands",
+      "T1087.002",
+      "T1087"
     ],
     "techniques": [
       "T1087.002",
@@ -3358,7 +3531,8 @@ const HUNTS_DATA = [
       "discovery",
       "port_scanning",
       "network_scanning",
-      "advanced_ip_scanner"
+      "advanced_ip_scanner",
+      "T1046"
     ],
     "techniques": [
       "T1046"
@@ -3385,7 +3559,8 @@ const HUNTS_DATA = [
       "ransomware",
       "encryption",
       "lockbit",
-      "data_encrypted_for_impact"
+      "data_encrypted_for_impact",
+      "T1486"
     ],
     "techniques": [
       "T1486"
@@ -3412,7 +3587,8 @@ const HUNTS_DATA = [
       "defacement",
       "ransom_note",
       "wallpaper",
-      "extortion"
+      "extortion",
+      "T1491.001"
     ],
     "techniques": [
       "T1491.001"
@@ -3439,7 +3615,8 @@ const HUNTS_DATA = [
       "seo_poisoning",
       "malvertising",
       "trojanized_installer",
-      "drive_by"
+      "drive_by",
+      "T1189"
     ],
     "techniques": [
       "T1189"
@@ -3466,7 +3643,8 @@ const HUNTS_DATA = [
       "execution",
       "msiexec",
       "signed_binary_proxy",
-      "lolbin"
+      "lolbin",
+      "T1218.007"
     ],
     "techniques": [
       "T1218.007"
@@ -3495,7 +3673,8 @@ const HUNTS_DATA = [
       "ntdsutil",
       "wbadmin",
       "vssadmin",
-      "credential_dumping"
+      "credential_dumping",
+      "T1003.003"
     ],
     "techniques": [
       "T1003.003"
@@ -3521,7 +3700,8 @@ const HUNTS_DATA = [
       "collection",
       "data_staging",
       "exfiltration_prep",
-      "archive"
+      "archive",
+      "T1074.001"
     ],
     "techniques": [
       "T1074.001"
@@ -3547,7 +3727,8 @@ const HUNTS_DATA = [
       "initial_access",
       "phishing_via_service",
       "teams",
-      "social_engineering"
+      "social_engineering",
+      "T1566.003"
     ],
     "techniques": [
       "T1566.003"
@@ -3573,7 +3754,8 @@ const HUNTS_DATA = [
       "lateral_movement",
       "smb",
       "admin_shares",
-      "psexec"
+      "psexec",
+      "T1021.002"
     ],
     "techniques": [
       "T1021.002"
@@ -3599,7 +3781,8 @@ const HUNTS_DATA = [
       "lateral_movement",
       "dcom",
       "wmi",
-      "wmiexec"
+      "wmiexec",
+      "T1021.003"
     ],
     "techniques": [
       "T1021.003"
@@ -3626,7 +3809,9 @@ const HUNTS_DATA = [
       "persistence",
       "scheduled_task",
       "domain_controller",
-      "ntds"
+      "ntds",
+      "T1003.003",
+      "T1053.005"
     ],
     "techniques": [
       "T1003.003",
@@ -3654,7 +3839,8 @@ const HUNTS_DATA = [
       "email_collection",
       "exchange",
       "mailbox_delegation",
-      "oauth"
+      "oauth",
+      "T1114.002"
     ],
     "techniques": [
       "T1114.002"
@@ -3680,7 +3866,8 @@ const HUNTS_DATA = [
       "persistence",
       "web_shell",
       "godzilla",
-      "exchange"
+      "exchange",
+      "T1505.003"
     ],
     "techniques": [
       "T1505.003"
@@ -3706,7 +3893,8 @@ const HUNTS_DATA = [
       "defense_evasion",
       "dll_search_order_hijacking",
       "sideloading",
-      "cryptbase"
+      "cryptbase",
+      "T1574.001"
     ],
     "techniques": [
       "T1574.001"
@@ -3732,7 +3920,8 @@ const HUNTS_DATA = [
       "defense_evasion",
       "installutil",
       "lolbin",
-      "proxy_execution"
+      "proxy_execution",
+      "T1218.004"
     ],
     "techniques": [
       "T1218.004"
@@ -3758,7 +3947,8 @@ const HUNTS_DATA = [
       "credential_access",
       "browser_credentials",
       "infostealer",
-      "chrome"
+      "chrome",
+      "T1555.003"
     ],
     "techniques": [
       "T1555.003"
@@ -3785,7 +3975,8 @@ const HUNTS_DATA = [
       "rclone",
       "qemu",
       "data_exfiltration",
-      "vm_tunnel"
+      "vm_tunnel",
+      "T1048.001"
     ],
     "techniques": [
       "T1048.001"
@@ -3811,7 +4002,8 @@ const HUNTS_DATA = [
       "credential_access",
       "api_hooking",
       "credential_interception",
-      "process_injection"
+      "process_injection",
+      "T1056.004"
     ],
     "techniques": [
       "T1056.004"
@@ -3838,7 +4030,8 @@ const HUNTS_DATA = [
       "reflective_loading",
       "memory_only",
       "fileless",
-      "windows"
+      "windows",
+      "T1620"
     ],
     "techniques": [
       "T1620"
@@ -3864,7 +4057,8 @@ const HUNTS_DATA = [
       "defense_evasion",
       "tcc_bypass",
       "macos",
-      "privacy_controls"
+      "privacy_controls",
+      "T1562.001"
     ],
     "techniques": [
       "T1562.001"
@@ -3890,7 +4084,8 @@ const HUNTS_DATA = [
       "persistence",
       "launch_daemon",
       "macos",
-      "masquerading"
+      "masquerading",
+      "T1543.004"
     ],
     "techniques": [
       "T1543.004"
@@ -3917,7 +4112,8 @@ const HUNTS_DATA = [
       "applescript",
       "curl_pipe",
       "macos",
-      "fileless"
+      "fileless",
+      "T1059.002"
     ],
     "techniques": [
       "T1059.002"
@@ -3943,7 +4139,8 @@ const HUNTS_DATA = [
       "persistence",
       "launch_agent",
       "plist",
-      "macos"
+      "macos",
+      "T1543.001"
     ],
     "techniques": [
       "T1543.001"
@@ -3969,7 +4166,8 @@ const HUNTS_DATA = [
       "defense_evasion",
       "sandbox_evasion",
       "environmental_keying",
-      "vm_detection"
+      "vm_detection",
+      "T1497.001"
     ],
     "techniques": [
       "T1497.001"
@@ -3996,7 +4194,8 @@ const HUNTS_DATA = [
       "encrypted_channel",
       "aes",
       "custom_crypto",
-      "c2"
+      "c2",
+      "T1573.001"
     ],
     "techniques": [
       "T1573.001"
@@ -4023,7 +4222,8 @@ const HUNTS_DATA = [
       "reflective_loading",
       "macos",
       "fileless",
-      "gatekeeper_bypass"
+      "gatekeeper_bypass",
+      "T1620"
     ],
     "techniques": [
       "T1620"
@@ -4051,7 +4251,8 @@ const HUNTS_DATA = [
       "imds",
       "cloud",
       "ssrf",
-      "service_account"
+      "service_account",
+      "T1552.005"
     ],
     "techniques": [
       "T1552.005"
@@ -4078,7 +4279,10 @@ const HUNTS_DATA = [
       "gcp",
       "cloud",
       "iam_enumeration",
-      "service_account"
+      "service_account",
+      "T1580",
+      "T1526",
+      "T1069.003"
     ],
     "techniques": [
       "T1580",
@@ -4107,7 +4311,8 @@ const HUNTS_DATA = [
       "defense_evasion",
       "gcp",
       "cloud",
-      "service_account_impersonation"
+      "service_account_impersonation",
+      "T1548.005"
     ],
     "techniques": [
       "T1548.005"
@@ -4135,7 +4340,9 @@ const HUNTS_DATA = [
       "gcp",
       "cloud",
       "bigquery",
-      "cloud_storage"
+      "cloud_storage",
+      "T1537",
+      "T1619"
     ],
     "techniques": [
       "T1537",
@@ -4164,7 +4371,9 @@ const HUNTS_DATA = [
       "supply_chain",
       "npm",
       "developer_endpoint",
-      "ci_cd"
+      "ci_cd",
+      "T1195.002",
+      "T1555"
     ],
     "techniques": [
       "T1195.002",
@@ -4191,7 +4400,8 @@ const HUNTS_DATA = [
       "exfiltration",
       "snowflake",
       "saas",
-      "unc5537"
+      "unc5537",
+      "T1567.002"
     ],
     "techniques": [
       "T1567.002"
@@ -4330,7 +4540,8 @@ const HUNTS_DATA = [
     "tags": [
       "commandandcontrol",
       "t1568_002",
-      "dga"
+      "dga",
+      "T1568.002"
     ],
     "techniques": [
       "T1568.002"
@@ -4354,7 +4565,9 @@ const HUNTS_DATA = [
     "notes": "<ul><li>Data Collection and Preparation: Gather and encode data into numerical formats to support analysis (e.g., text vectorization or image hashing).</br><li>Similarity Analysis: Use similarity metrics (e.g., Levenshtein, cosine, or hash-based) to find related patterns or anomalies.</br><li>Clustering: Apply clustering (e.g., K-means) to group similar items, visualizing patterns and outliers.</br><li>Prioritization and Investigation: Flag clusters or anomalies for deeper analysis, focusing on items of interest or risk.",
     "tags": [
       "command_and_control",
-      "execution"
+      "execution",
+      "T1071.001",
+      "T1203"
     ],
     "techniques": [
       "T1071.001",
@@ -4383,7 +4596,9 @@ const HUNTS_DATA = [
       "model_assisted",
       "process_lineage",
       "clustering",
-      "anomaly_detection"
+      "anomaly_detection",
+      "T1059",
+      "T1218"
     ],
     "techniques": [
       "T1059",
@@ -4413,7 +4628,10 @@ const HUNTS_DATA = [
       "npm",
       "mcp",
       "supply_chain",
-      "ai_coding_assistant"
+      "ai_coding_assistant",
+      "T1195.002",
+      "T1119",
+      "T1555"
     ],
     "techniques": [
       "T1195.002",
@@ -4443,7 +4661,8 @@ const HUNTS_DATA = [
       "seo_poisoning",
       "malvertising",
       "domain_scoring",
-      "anomaly_detection"
+      "anomaly_detection",
+      "T1189"
     ],
     "techniques": [
       "T1189"

--- a/public/hunts-data.json
+++ b/public/hunts-data.json
@@ -8,7 +8,9 @@
     "tags": [
       "baseline",
       "networktraffic",
-      "anomalydetection"
+      "anomalydetection",
+      "T1071.001",
+      "T1041"
     ],
     "techniques": [
       "T1071.001",
@@ -34,7 +36,8 @@
     "tags": [
       "baseline",
       "persistence",
-      "anomalydetection"
+      "anomalydetection",
+      "T1219"
     ],
     "techniques": [
       "T1219"
@@ -59,7 +62,8 @@
     "tags": [
       "baseline",
       "persistence",
-      "anomalydetection"
+      "anomalydetection",
+      "T1547.001"
     ],
     "techniques": [
       "T1547.001"
@@ -85,7 +89,8 @@
       "baseline",
       "persistence",
       "anomalydetection",
-      "sus"
+      "sus",
+      "T1136"
     ],
     "techniques": [
       "T1136"
@@ -111,7 +116,8 @@
       "execution",
       "defenseevasion",
       "lolbin",
-      "rundll32"
+      "rundll32",
+      "T1218.011"
     ],
     "techniques": [
       "T1218.011"
@@ -136,7 +142,9 @@
     "tags": [
       "collection",
       "exfiltration",
-      "browserextensions"
+      "browserextensions",
+      "T1176",
+      "T1005"
     ],
     "techniques": [
       "T1176",
@@ -163,7 +171,9 @@
       "collection",
       "exfiltration",
       "email",
-      "mailforwarding"
+      "mailforwarding",
+      "T1114.003",
+      "T1020"
     ],
     "techniques": [
       "T1114.003",
@@ -189,7 +199,8 @@
     "tags": [
       "baseline",
       "privilege_escalation",
-      "anomalydetection"
+      "anomalydetection",
+      "T1098"
     ],
     "techniques": [
       "T1098"
@@ -215,7 +226,10 @@
       "defenseevasion",
       "masquerading",
       "trusteddeveloperutilities",
-      "proxyexecution"
+      "proxyexecution",
+      "T1036",
+      "T1127",
+      "T1211"
     ],
     "techniques": [
       "T1036",
@@ -240,7 +254,9 @@
     "tactic": "Lateral Movement",
     "notes": "Explore typical peering requests, initiators, unusual IPs, and connection events.",
     "tags": [
-      "lateralmovement"
+      "lateralmovement",
+      "T1599",
+      "T1021"
     ],
     "techniques": [
       "T1599",
@@ -265,7 +281,8 @@
     "notes": "Indicators of Xcode usage can be found in EDR telemetry and potential for detection if Xcode is not utilized/approved in the environment.",
     "tags": [
       "initialaccess",
-      "baseline"
+      "baseline",
+      "T1195.001"
     ],
     "techniques": [
       "T1195.001"
@@ -293,7 +310,8 @@
       "service_account",
       "ai_agent",
       "orphan_account",
-      "lifecycle"
+      "lifecycle",
+      "T1078.004"
     ],
     "techniques": [
       "T1078.004"
@@ -320,7 +338,8 @@
       "credential_access",
       "lsass",
       "sysmon",
-      "process_access"
+      "process_access",
+      "T1003.001"
     ],
     "techniques": [
       "T1003.001"
@@ -347,7 +366,8 @@
       "defense_evasion",
       "msiexec",
       "msi",
-      "software_installation"
+      "software_installation",
+      "T1218.007"
     ],
     "techniques": [
       "T1218.007"
@@ -376,7 +396,8 @@
       "wbadmin",
       "vssadmin",
       "domain_controller",
-      "active_directory"
+      "active_directory",
+      "T1003.003"
     ],
     "techniques": [
       "T1003.003"
@@ -426,7 +447,8 @@
     "tags": [
       "credentialaccess",
       "bruteforce",
-      "vpn"
+      "vpn",
+      "T1110"
     ],
     "techniques": [
       "T1110"
@@ -452,7 +474,8 @@
       "commandandcontrol",
       "remoteaccess",
       "edr",
-      "lolbin"
+      "lolbin",
+      "T1219"
     ],
     "techniques": [
       "T1219"
@@ -475,7 +498,9 @@
     "tactic": "Exfiltration",
     "notes": "Attackers often need to get data out, 1MB chunks sneak beneath big file anomaly detection. Consider different file sizes and types based on normal in your environment.",
     "tags": [
-      "exfiltration"
+      "exfiltration",
+      "T1030",
+      "T1560.001"
     ],
     "techniques": [
       "T1030",
@@ -501,7 +526,8 @@
     "tags": [
       "persistence",
       "lolbin",
-      "windows"
+      "windows",
+      "T1197"
     ],
     "techniques": [
       "T1197"
@@ -526,7 +552,8 @@
     "tags": [
       "persistence",
       "lolbas",
-      "linux"
+      "linux",
+      "T1546.004"
     ],
     "techniques": [
       "T1546.004"
@@ -550,7 +577,8 @@
     "notes": "Adversaries often abuse legitimate remote access features (such as RDP and SSH) already enabled in the environment.",
     "tags": [
       "lateralmovement",
-      "sus"
+      "sus",
+      "T1021"
     ],
     "techniques": [
       "T1021"
@@ -574,7 +602,8 @@
     "notes": "Adversaries often abuse legitimate command interpreters/applications, such as CMD, PowerShell, or bash/zsh.",
     "tags": [
       "execution",
-      "sus"
+      "sus",
+      "T1059"
     ],
     "techniques": [
       "T1059"
@@ -598,7 +627,8 @@
     "notes": "Domain Accounts can cover user, administrator, and service accounts.",
     "tags": [
       "persistence",
-      "activedirectory"
+      "activedirectory",
+      "T1136.002"
     ],
     "techniques": [
       "T1136.002"
@@ -622,7 +652,8 @@
     "notes": "Data requirements: Windows Sysmon, EDR telemetry, Proxy logs",
     "tags": [
       "defenseevasion",
-      "systembinaryproxyexecutionmshta"
+      "systembinaryproxyexecutionmshta",
+      "T1218.005"
     ],
     "techniques": [
       "T1218.005"
@@ -646,7 +677,8 @@
     "notes": "<ul><li>Data requirements: EDR telemetry, Windows event logs id 5140</li></br><li>Implementation examples in SIGMA:</li></br>Title: Suspicious Network Share Enumeration and Access</br>Id:xxxxx</br>Status: test</br>Description: Detects commands used for network share enumeration and correlates with Event ID 5140 for access to shared resources.</br>Author: Your Name</br>Date:2024/11/14</br>Tags:</br><ul><li>attack.discovery</br><li>attack.t1135</li></ul></br>logsource:</br>category: process_creation</br>product:windows</br>detection:</br>selection_cmd:</br>Image&#124;endswith:</br><ul><li>'\\cmd.exe'</br><li>'\\powershell.exe'</br>ComandLine&#124;contains&#124;all:</br><li>'net view'</br><li>'&bsol;'</br>selection_event:</br>EventID: 5140</br>condition: selection_cmd or selection_event</br>falsepositives:</br><li>Legitimate administrative tasks</br><li>Regular file-sharing activities</br>level: medium #T1039",
     "tags": [
       "collection",
-      "datafromnetworkshareddrive"
+      "datafromnetworkshareddrive",
+      "T1039"
     ],
     "techniques": [
       "T1039"
@@ -672,7 +704,8 @@
       "persistence",
       "privilege_escalation",
       "defense_evasion",
-      "dllsideloading"
+      "dllsideloading",
+      "T1574.002"
     ],
     "techniques": [
       "T1574.002"
@@ -697,7 +730,9 @@
     "tags": [
       "dns",
       "tunneling",
-      "exfiltration"
+      "exfiltration",
+      "T1048",
+      "T1071.004"
     ],
     "techniques": [
       "T1048",
@@ -724,7 +759,8 @@
       "powershell",
       "sysmon",
       "execution",
-      "ta0002"
+      "ta0002",
+      "T1059.001"
     ],
     "techniques": [
       "T1059.001"
@@ -751,7 +787,9 @@
       "namedpipes",
       "commandandcontrol",
       "sysmon",
-      "threathunting"
+      "threathunting",
+      "T1559",
+      "T1090"
     ],
     "techniques": [
       "T1559",
@@ -778,7 +816,9 @@
       "registry",
       "edr",
       "dns",
-      "defenseevasion"
+      "defenseevasion",
+      "T1562.001",
+      "T1112"
     ],
     "techniques": [
       "T1562.001",
@@ -803,7 +843,8 @@
     "notes": "Based on ATT&CK technique T1078, using compromised credentials.",
     "tags": [
       "initialaccess",
-      "sonicwall"
+      "sonicwall",
+      "T1078"
     ],
     "techniques": [
       "T1078"
@@ -828,7 +869,8 @@
     "tags": [
       "privilegeescalation",
       "exploit",
-      "apache"
+      "apache",
+      "T1068"
     ],
     "techniques": [
       "T1068"
@@ -853,7 +895,8 @@
     "tags": [
       "credentialaccess",
       "serverlessfunctions",
-      "cloud"
+      "cloud",
+      "T1098"
     ],
     "techniques": [
       "T1098"
@@ -879,7 +922,8 @@
       "persistence",
       "initialaccess",
       "userexecution",
-      "elf"
+      "elf",
+      "T1204"
     ],
     "techniques": [
       "T1204"
@@ -903,7 +947,8 @@
     "notes": "Based on ATT&CK technique T1047, using WMI for execution of PowerShell commands.",
     "tags": [
       "execution",
-      "wmi"
+      "wmi",
+      "T1047"
     ],
     "techniques": [
       "T1047"
@@ -927,7 +972,8 @@
     "notes": "Based on ATT&CK technique T1562.001, using the undocumented Windows Security Center (WSC) APIs",
     "tags": [
       "defenseevasion",
-      "wsc"
+      "wsc",
+      "T1562.001"
     ],
     "techniques": [
       "T1562.001"
@@ -951,7 +997,8 @@
     "notes": "Based on ATT&CK technique T1110. Generated by [hearth-auto-intel](https://github.com/THORCollective/HEARTH).",
     "tags": [
       "credentialaccess",
-      "socialengineering"
+      "socialengineering",
+      "T1110"
     ],
     "techniques": [
       "T1110"
@@ -975,7 +1022,8 @@
     "notes": "Based on ATT&CK technique T1564. Generated by [hearth-auto-intel](https://github.com/THORCollective/HEARTH).",
     "tags": [
       "defenseevasion",
-      "attribcommand"
+      "attribcommand",
+      "T1564"
     ],
     "techniques": [
       "T1564"
@@ -1000,7 +1048,9 @@
     "tags": [
       "initialaccess",
       "phishing",
-      "spearphishinglink"
+      "spearphishinglink",
+      "T1566.001",
+      "T1204.002"
     ],
     "techniques": [
       "T1566.001",
@@ -1027,7 +1077,9 @@
       "initialaccess",
       "execution",
       "userexecution",
-      "commandandscriptinginterpreter"
+      "commandandscriptinginterpreter",
+      "T1204.002",
+      "T1059.006"
     ],
     "techniques": [
       "T1204.002",
@@ -1052,7 +1104,8 @@
     "notes": "Based on ATT&CK technique T1070.004. Generated by [hearth-auto-intel](https://github.com/THORCollective/HEARTH).",
     "tags": [
       "defenseevasion",
-      "cipher_exe"
+      "cipher_exe",
+      "T1070.004"
     ],
     "techniques": [
       "T1070.004"
@@ -1077,7 +1130,8 @@
     "tags": [
       "initialaccess",
       "applescript",
-      "bluenoroff"
+      "bluenoroff",
+      "T1566.002"
     ],
     "techniques": [
       "T1566.002"
@@ -1102,7 +1156,8 @@
     "tags": [
       "defenseevasion",
       "evasion",
-      "macos"
+      "macos",
+      "T1497.003"
     ],
     "techniques": [
       "T1497.003"
@@ -1127,7 +1182,8 @@
     "tags": [
       "defenseevasion",
       "processinjection",
-      "macos"
+      "macos",
+      "T1055"
     ],
     "techniques": [
       "T1055"
@@ -1152,7 +1208,8 @@
     "tags": [
       "persistence",
       "launchdaemon",
-      "macos"
+      "macos",
+      "T1543.004"
     ],
     "techniques": [
       "T1543.004"
@@ -1177,7 +1234,8 @@
     "tags": [
       "collection",
       "cryptocurrency",
-      "bluenoroff"
+      "bluenoroff",
+      "T1005"
     ],
     "techniques": [
       "T1005"
@@ -1203,7 +1261,8 @@
       "defense_evasion",
       "command_and_scripting_interpreter",
       "applescript",
-      "malware"
+      "malware",
+      "T1059.002"
     ],
     "techniques": [
       "T1059.002"
@@ -1229,7 +1288,8 @@
       "execution",
       "command_and_scripting_interpreter",
       "powershell",
-      "ransomware"
+      "ransomware",
+      "T1059.001"
     ],
     "techniques": [
       "T1059.001"
@@ -1255,7 +1315,8 @@
       "persistence",
       "lateral_movement",
       "ide_plugin",
-      "event_triggered_execution"
+      "event_triggered_execution",
+      "T1546.016"
     ],
     "techniques": [
       "T1546.016"
@@ -1280,7 +1341,10 @@
     "tags": [
       "initial_access",
       "hardware_additions",
-      "air_gap"
+      "air_gap",
+      "T0847",
+      "T1091",
+      "T1200"
     ],
     "techniques": [
       "T0847",
@@ -1307,7 +1371,8 @@
     "tags": [
       "defense_evasion",
       "proxy",
-      "chisel"
+      "chisel",
+      "T1090.001"
     ],
     "techniques": [
       "T1090.001"
@@ -1333,7 +1398,8 @@
       "defense_evasion",
       "obfuscated_files_or_information",
       "javascript",
-      "malvertising"
+      "malvertising",
+      "T1027"
     ],
     "techniques": [
       "T1027"
@@ -1358,7 +1424,8 @@
     "tags": [
       "collection",
       "archive_collected_data",
-      "powershell"
+      "powershell",
+      "T1560"
     ],
     "techniques": [
       "T1560"
@@ -1383,7 +1450,8 @@
     "tags": [
       "reconnaissance",
       "active_scanning",
-      "network_service_scanning"
+      "network_service_scanning",
+      "T1595.001"
     ],
     "techniques": [
       "T1595.001"
@@ -1408,7 +1476,8 @@
     "tags": [
       "initial_access",
       "password_spraying",
-      "rdp"
+      "rdp",
+      "T1110.003"
     ],
     "techniques": [
       "T1110.003"
@@ -1433,7 +1502,8 @@
     "tags": [
       "privilege_escalation",
       "tinyshell",
-      "juniper"
+      "juniper",
+      "T1055"
     ],
     "techniques": [
       "T1055"
@@ -1458,7 +1528,8 @@
     "tags": [
       "defense_evasion",
       "deobfuscate_files",
-      "earth_estries"
+      "earth_estries",
+      "T1140"
     ],
     "techniques": [
       "T1140"
@@ -1483,7 +1554,8 @@
     "tags": [
       "defense_evasion",
       "registry_modification",
-      "persistence"
+      "persistence",
+      "T1112"
     ],
     "techniques": [
       "T1112"
@@ -1508,7 +1580,8 @@
     "tags": [
       "execution",
       "powershell",
-      "rat"
+      "rat",
+      "T1059.001"
     ],
     "techniques": [
       "T1059.001"
@@ -1533,7 +1606,8 @@
     "tags": [
       "execution",
       "mshta",
-      "living_off_the_land"
+      "living_off_the_land",
+      "T1218.005"
     ],
     "techniques": [
       "T1218.005"
@@ -1560,7 +1634,8 @@
       "networktraffic",
       "ssh",
       "linux",
-      "windows"
+      "windows",
+      "T1572"
     ],
     "techniques": [
       "T1572"
@@ -1585,7 +1660,8 @@
     "tags": [
       "command_and_control",
       "ingress_tool_transfer",
-      "powershell"
+      "powershell",
+      "T1105"
     ],
     "techniques": [
       "T1105"
@@ -1611,7 +1687,10 @@
       "defenseevasion",
       "execution",
       "masquerading",
-      "proxyexecution"
+      "proxyexecution",
+      "T1036",
+      "T1218",
+      "T1105"
     ],
     "techniques": [
       "T1036",
@@ -1638,7 +1717,9 @@
     "tags": [
       "defenseevasion",
       "phishing",
-      "collection"
+      "collection",
+      "T1564.008",
+      "T1114"
     ],
     "techniques": [
       "T1564.008",
@@ -1665,7 +1746,8 @@
       "credentialaccess",
       "activedirectory",
       "identity",
-      "secretsdump"
+      "secretsdump",
+      "T1003.006"
     ],
     "techniques": [
       "T1003.006"
@@ -1691,7 +1773,8 @@
       "commandandcontrol",
       "hvnc",
       "remoteaccess",
-      "glassworm"
+      "glassworm",
+      "T1219"
     ],
     "techniques": [
       "T1219"
@@ -1717,7 +1800,8 @@
       "command_and_control",
       "backconnect",
       "vnc",
-      "dllhost"
+      "dllhost",
+      "T1219"
     ],
     "techniques": [
       "T1219"
@@ -1742,7 +1826,8 @@
     "tags": [
       "discovery",
       "networkscan",
-      "ai_powered"
+      "ai_powered",
+      "T1046"
     ],
     "techniques": [
       "T1046"
@@ -1768,7 +1853,8 @@
       "defense_evasion",
       "macos",
       "gatekeeper",
-      "applescript"
+      "applescript",
+      "T1553.001"
     ],
     "techniques": [
       "T1553.001"
@@ -1794,7 +1880,8 @@
       "discovery",
       "gootloader",
       "powershell",
-      "systeminfo"
+      "systeminfo",
+      "T1082"
     ],
     "techniques": [
       "T1082"
@@ -1819,7 +1906,8 @@
     "tags": [
       "defense_evasion",
       "oauth",
-      "session_hijacking"
+      "session_hijacking",
+      "T1550.001"
     ],
     "techniques": [
       "T1550.001"
@@ -1844,7 +1932,8 @@
     "tags": [
       "discovery",
       "financial",
-      "powershell"
+      "powershell",
+      "T1135"
     ],
     "techniques": [
       "T1135"
@@ -1870,7 +1959,8 @@
       "privilege_escalation",
       "byovd",
       "edr_killer",
-      "ransomware"
+      "ransomware",
+      "T1068"
     ],
     "techniques": [
       "T1068"
@@ -1896,7 +1986,8 @@
       "exfiltration",
       "insider",
       "if001_006",
-      "if018_002"
+      "if018_002",
+      "T1567"
     ],
     "techniques": [
       "T1567"
@@ -1922,7 +2013,8 @@
       "netsh",
       "powershell",
       "ta0005",
-      "firewall"
+      "firewall",
+      "T1562.004"
     ],
     "techniques": [
       "T1562.004"
@@ -1948,7 +2040,8 @@
       "defense_evasion",
       "esxi",
       "hypervisor",
-      "ransomware"
+      "ransomware",
+      "T1562.001"
     ],
     "techniques": [
       "T1562.001"
@@ -1974,7 +2067,8 @@
       "c2",
       "tunnel",
       "ta0011",
-      "t1102"
+      "t1102",
+      "T1572"
     ],
     "techniques": [
       "T1572"
@@ -2000,7 +2094,8 @@
       "defense_evasion",
       "macos",
       "tcc",
-      "unc1069"
+      "unc1069",
+      "T1562.001"
     ],
     "techniques": [
       "T1562.001"
@@ -2026,7 +2121,8 @@
       "defense_evasion",
       "punycode",
       "idn",
-      "dns"
+      "dns",
+      "T1036.005"
     ],
     "techniques": [
       "T1036.005"
@@ -2053,7 +2149,8 @@
       "vmware",
       "vsphere",
       "rogue_vm",
-      "muddled_libra"
+      "muddled_libra",
+      "T1564.006"
     ],
     "techniques": [
       "T1564.006"
@@ -2080,7 +2177,9 @@
       "browser_extension",
       "ai_tokens",
       "chatgpt",
-      "session_hijack"
+      "session_hijack",
+      "T1528",
+      "T1185"
     ],
     "techniques": [
       "T1528",
@@ -2109,7 +2208,8 @@
       "supply_chain",
       "typosquatting",
       "tool_poisoning",
-      "ai_agent"
+      "ai_agent",
+      "T1195.002"
     ],
     "techniques": [
       "T1195.002"
@@ -2160,7 +2260,10 @@
       "command_and_control",
       "finger_exe",
       "lolbin",
-      "crashfix"
+      "crashfix",
+      "T1105",
+      "T1036.003",
+      "T1218"
     ],
     "techniques": [
       "T1105",
@@ -2263,7 +2366,10 @@
       "command_and_control",
       "cloud_c2",
       "apt28",
-      "filen"
+      "filen",
+      "T1102.002",
+      "T1203",
+      "T1055"
     ],
     "techniques": [
       "T1102.002",
@@ -2293,7 +2399,9 @@
       "esxi",
       "vmware",
       "ghost_nic",
-      "unc6201"
+      "unc6201",
+      "T1021",
+      "T1497"
     ],
     "techniques": [
       "T1021",
@@ -2322,7 +2430,9 @@
       "iptables",
       "port_knocking",
       "spa",
-      "unc6201"
+      "unc6201",
+      "T1205.001",
+      "T1562.004"
     ],
     "techniques": [
       "T1205.001",
@@ -2351,7 +2461,10 @@
       "outlook",
       "office_addin",
       "supply_chain",
-      "agreetosteal"
+      "agreetosteal",
+      "T1195.002",
+      "T1056.002",
+      "T1114"
     ],
     "techniques": [
       "T1195.002",
@@ -2381,7 +2494,10 @@
       "esxi",
       "vmware",
       "ghost_nic",
-      "unc6201"
+      "unc6201",
+      "T1021",
+      "T1599",
+      "T1049"
     ],
     "techniques": [
       "T1021",
@@ -2412,7 +2528,11 @@
       "command_and_control",
       "apt28",
       "notdoor",
-      "com_hijacking"
+      "com_hijacking",
+      "T1566.001",
+      "T1059.005",
+      "T1546.015",
+      "T1102"
     ],
     "techniques": [
       "T1566.001",
@@ -2443,7 +2563,10 @@
       "byovd",
       "gpo",
       "ransomware",
-      "crazyhunter"
+      "crazyhunter",
+      "T1484.001",
+      "T1562.001",
+      "T1106"
     ],
     "techniques": [
       "T1484.001",
@@ -2473,7 +2596,10 @@
       "command_and_control",
       "clickfix",
       "social_engineering",
-      "rat"
+      "rat",
+      "T1566.002",
+      "T1204.002",
+      "T1219"
     ],
     "techniques": [
       "T1566.002",
@@ -2504,7 +2630,10 @@
       "npm",
       "supply_chain",
       "mcp",
-      "ai_coding_assistant"
+      "ai_coding_assistant",
+      "T1195.002",
+      "T1555",
+      "T1119"
     ],
     "techniques": [
       "T1195.002",
@@ -2534,7 +2663,9 @@
       "supply_chain",
       "mcp",
       "ai_coding_tools",
-      "claude_code"
+      "claude_code",
+      "T1195.001",
+      "T1059.004"
     ],
     "techniques": [
       "T1195.001",
@@ -2563,7 +2694,9 @@
       "mshtml",
       "motw_bypass",
       "lnk",
-      "apt28"
+      "apt28",
+      "T1566.001",
+      "T1553.005"
     ],
     "techniques": [
       "T1566.001",
@@ -2593,7 +2726,10 @@
       "usb",
       "air_gap",
       "apt37",
-      "rubyjumper"
+      "rubyjumper",
+      "T1091",
+      "T1092",
+      "T1036.005"
     ],
     "techniques": [
       "T1091",
@@ -2622,7 +2758,8 @@
       "google_drive",
       "cloud_c2",
       "apt41",
-      "silver_dragon"
+      "silver_dragon",
+      "T1102.002"
     ],
     "techniques": [
       "T1102.002"
@@ -2650,7 +2787,9 @@
       "dll_sideloading",
       "supply_chain",
       "notepadpp",
-      "chrysalis"
+      "chrysalis",
+      "T1574.002",
+      "T1195.002"
     ],
     "techniques": [
       "T1574.002",
@@ -2679,7 +2818,9 @@
       "npm",
       "supply_chain",
       "worm",
-      "shai_hulud"
+      "shai_hulud",
+      "T1195.001",
+      "T1552.001"
     ],
     "techniques": [
       "T1195.001",
@@ -2709,7 +2850,10 @@
       "clickfix",
       "windows_terminal",
       "ransomware",
-      "velvet_tempest"
+      "velvet_tempest",
+      "T1204.002",
+      "T1059.001",
+      "T1027.004"
     ],
     "techniques": [
       "T1204.002",
@@ -2739,7 +2883,10 @@
       "clickfix",
       "windows_terminal",
       "lumma_stealer",
-      "infostealer"
+      "infostealer",
+      "T1204.002",
+      "T1059.001",
+      "T1555"
     ],
     "techniques": [
       "T1204.002",
@@ -2770,7 +2917,9 @@
       "lolbin",
       "finger_exe",
       "ransomware",
-      "velvet_tempest"
+      "velvet_tempest",
+      "T1204.002",
+      "T1218"
     ],
     "techniques": [
       "T1204.002",
@@ -2800,7 +2949,10 @@
       "vscode",
       "supply_chain",
       "glassworm",
-      "developer_tooling"
+      "developer_tooling",
+      "T1195.001",
+      "T1554",
+      "T1555"
     ],
     "techniques": [
       "T1195.001",
@@ -2830,7 +2982,8 @@
       "ai_agent_security",
       "api_key_exfil",
       "openclaw",
-      "clawdbot"
+      "clawdbot",
+      "T1552"
     ],
     "techniques": [
       "T1552"
@@ -2859,7 +3012,8 @@
       "crystal",
       "obscure_language_malware",
       "apt36",
-      "ai_generated_malware"
+      "ai_generated_malware",
+      "T1027"
     ],
     "techniques": [
       "T1027"
@@ -2888,7 +3042,8 @@
       "infostealer",
       "amos",
       "agentic_ai",
-      "openclaw"
+      "openclaw",
+      "T1195.001"
     ],
     "techniques": [
       "T1195.001"
@@ -2918,7 +3073,8 @@
       "cve_2025_68613",
       "workflow_automation",
       "lateral_movement",
-      "credential_access"
+      "credential_access",
+      "T1059"
     ],
     "techniques": [
       "T1059"
@@ -2950,7 +3106,8 @@
       "healthcare",
       "government",
       "cve_2024_47575",
-      "cve_2024_55591"
+      "cve_2024_55591",
+      "T1552.001"
     ],
     "techniques": [
       "T1552.001"
@@ -2980,7 +3137,8 @@
       "odyssey_stealer",
       "social_engineering",
       "credential_theft",
-      "session_hijacking"
+      "session_hijacking",
+      "T1204.002"
     ],
     "techniques": [
       "T1204.002"
@@ -3010,7 +3168,8 @@
       "hive0163",
       "slopoly",
       "backdoor",
-      "financial_crime"
+      "financial_crime",
+      "T1059.001"
     ],
     "techniques": [
       "T1059.001"
@@ -3040,7 +3199,8 @@
       "ai_agent",
       "zero_click",
       "document_delivery",
-      "patch_tuesday"
+      "patch_tuesday",
+      "T1048"
     ],
     "techniques": [
       "T1048"
@@ -3070,7 +3230,8 @@
       "auth_bypass",
       "cve_2026_27896",
       "ai_agent",
-      "tool_execution"
+      "tool_execution",
+      "T1078"
     ],
     "techniques": [
       "T1078"
@@ -3096,7 +3257,8 @@
       "impact",
       "intune",
       "mdm",
-      "wiper"
+      "wiper",
+      "T1485"
     ],
     "techniques": [
       "T1485"
@@ -3122,7 +3284,8 @@
       "defense_evasion",
       "iocontrol",
       "ot_iot",
-      "upx"
+      "upx",
+      "T1027.002"
     ],
     "techniques": [
       "T1027.002"
@@ -3148,7 +3311,8 @@
       "execution",
       "supply_chain",
       "npm",
-      "cicd"
+      "cicd",
+      "T1059.007"
     ],
     "techniques": [
       "T1059.007"
@@ -3173,7 +3337,8 @@
     "tags": [
       "defense_evasion",
       "forticlient",
-      "authentication_bypass"
+      "authentication_bypass",
+      "T1550.004"
     ],
     "techniques": [
       "T1550.004"
@@ -3200,7 +3365,8 @@
       "cve_2023_46604",
       "activemq",
       "exploit",
-      "rce"
+      "rce",
+      "T1190"
     ],
     "techniques": [
       "T1190"
@@ -3226,7 +3392,9 @@
       "privilege_escalation",
       "named_pipe",
       "getsystem",
-      "token_impersonation"
+      "token_impersonation",
+      "T1134.005",
+      "T1134"
     ],
     "techniques": [
       "T1134.005",
@@ -3252,7 +3420,8 @@
     "tags": [
       "defense_evasion",
       "event_log_clearing",
-      "anti_forensics"
+      "anti_forensics",
+      "T1070.001"
     ],
     "techniques": [
       "T1070.001"
@@ -3278,7 +3447,8 @@
       "credential_access",
       "lsass",
       "credential_dumping",
-      "mimikatz"
+      "mimikatz",
+      "T1003.001"
     ],
     "techniques": [
       "T1003.001"
@@ -3304,7 +3474,8 @@
       "discovery",
       "smb_scanning",
       "network_enumeration",
-      "reconnaissance"
+      "reconnaissance",
+      "T1018"
     ],
     "techniques": [
       "T1018"
@@ -3330,7 +3501,9 @@
       "discovery",
       "account_enumeration",
       "active_directory",
-      "net_commands"
+      "net_commands",
+      "T1087.002",
+      "T1087"
     ],
     "techniques": [
       "T1087.002",
@@ -3357,7 +3530,8 @@
       "discovery",
       "port_scanning",
       "network_scanning",
-      "advanced_ip_scanner"
+      "advanced_ip_scanner",
+      "T1046"
     ],
     "techniques": [
       "T1046"
@@ -3384,7 +3558,8 @@
       "ransomware",
       "encryption",
       "lockbit",
-      "data_encrypted_for_impact"
+      "data_encrypted_for_impact",
+      "T1486"
     ],
     "techniques": [
       "T1486"
@@ -3411,7 +3586,8 @@
       "defacement",
       "ransom_note",
       "wallpaper",
-      "extortion"
+      "extortion",
+      "T1491.001"
     ],
     "techniques": [
       "T1491.001"
@@ -3438,7 +3614,8 @@
       "seo_poisoning",
       "malvertising",
       "trojanized_installer",
-      "drive_by"
+      "drive_by",
+      "T1189"
     ],
     "techniques": [
       "T1189"
@@ -3465,7 +3642,8 @@
       "execution",
       "msiexec",
       "signed_binary_proxy",
-      "lolbin"
+      "lolbin",
+      "T1218.007"
     ],
     "techniques": [
       "T1218.007"
@@ -3494,7 +3672,8 @@
       "ntdsutil",
       "wbadmin",
       "vssadmin",
-      "credential_dumping"
+      "credential_dumping",
+      "T1003.003"
     ],
     "techniques": [
       "T1003.003"
@@ -3520,7 +3699,8 @@
       "collection",
       "data_staging",
       "exfiltration_prep",
-      "archive"
+      "archive",
+      "T1074.001"
     ],
     "techniques": [
       "T1074.001"
@@ -3546,7 +3726,8 @@
       "initial_access",
       "phishing_via_service",
       "teams",
-      "social_engineering"
+      "social_engineering",
+      "T1566.003"
     ],
     "techniques": [
       "T1566.003"
@@ -3572,7 +3753,8 @@
       "lateral_movement",
       "smb",
       "admin_shares",
-      "psexec"
+      "psexec",
+      "T1021.002"
     ],
     "techniques": [
       "T1021.002"
@@ -3598,7 +3780,8 @@
       "lateral_movement",
       "dcom",
       "wmi",
-      "wmiexec"
+      "wmiexec",
+      "T1021.003"
     ],
     "techniques": [
       "T1021.003"
@@ -3625,7 +3808,9 @@
       "persistence",
       "scheduled_task",
       "domain_controller",
-      "ntds"
+      "ntds",
+      "T1003.003",
+      "T1053.005"
     ],
     "techniques": [
       "T1003.003",
@@ -3653,7 +3838,8 @@
       "email_collection",
       "exchange",
       "mailbox_delegation",
-      "oauth"
+      "oauth",
+      "T1114.002"
     ],
     "techniques": [
       "T1114.002"
@@ -3679,7 +3865,8 @@
       "persistence",
       "web_shell",
       "godzilla",
-      "exchange"
+      "exchange",
+      "T1505.003"
     ],
     "techniques": [
       "T1505.003"
@@ -3705,7 +3892,8 @@
       "defense_evasion",
       "dll_search_order_hijacking",
       "sideloading",
-      "cryptbase"
+      "cryptbase",
+      "T1574.001"
     ],
     "techniques": [
       "T1574.001"
@@ -3731,7 +3919,8 @@
       "defense_evasion",
       "installutil",
       "lolbin",
-      "proxy_execution"
+      "proxy_execution",
+      "T1218.004"
     ],
     "techniques": [
       "T1218.004"
@@ -3757,7 +3946,8 @@
       "credential_access",
       "browser_credentials",
       "infostealer",
-      "chrome"
+      "chrome",
+      "T1555.003"
     ],
     "techniques": [
       "T1555.003"
@@ -3784,7 +3974,8 @@
       "rclone",
       "qemu",
       "data_exfiltration",
-      "vm_tunnel"
+      "vm_tunnel",
+      "T1048.001"
     ],
     "techniques": [
       "T1048.001"
@@ -3810,7 +4001,8 @@
       "credential_access",
       "api_hooking",
       "credential_interception",
-      "process_injection"
+      "process_injection",
+      "T1056.004"
     ],
     "techniques": [
       "T1056.004"
@@ -3837,7 +4029,8 @@
       "reflective_loading",
       "memory_only",
       "fileless",
-      "windows"
+      "windows",
+      "T1620"
     ],
     "techniques": [
       "T1620"
@@ -3863,7 +4056,8 @@
       "defense_evasion",
       "tcc_bypass",
       "macos",
-      "privacy_controls"
+      "privacy_controls",
+      "T1562.001"
     ],
     "techniques": [
       "T1562.001"
@@ -3889,7 +4083,8 @@
       "persistence",
       "launch_daemon",
       "macos",
-      "masquerading"
+      "masquerading",
+      "T1543.004"
     ],
     "techniques": [
       "T1543.004"
@@ -3916,7 +4111,8 @@
       "applescript",
       "curl_pipe",
       "macos",
-      "fileless"
+      "fileless",
+      "T1059.002"
     ],
     "techniques": [
       "T1059.002"
@@ -3942,7 +4138,8 @@
       "persistence",
       "launch_agent",
       "plist",
-      "macos"
+      "macos",
+      "T1543.001"
     ],
     "techniques": [
       "T1543.001"
@@ -3968,7 +4165,8 @@
       "defense_evasion",
       "sandbox_evasion",
       "environmental_keying",
-      "vm_detection"
+      "vm_detection",
+      "T1497.001"
     ],
     "techniques": [
       "T1497.001"
@@ -3995,7 +4193,8 @@
       "encrypted_channel",
       "aes",
       "custom_crypto",
-      "c2"
+      "c2",
+      "T1573.001"
     ],
     "techniques": [
       "T1573.001"
@@ -4022,7 +4221,8 @@
       "reflective_loading",
       "macos",
       "fileless",
-      "gatekeeper_bypass"
+      "gatekeeper_bypass",
+      "T1620"
     ],
     "techniques": [
       "T1620"
@@ -4037,6 +4237,184 @@
     "why": "- In the Sapphire Sleet macOS campaign, the icloudz backdoor was loaded via NSCreateObjectFileImageFromMemory — while these APIs were originally designed for pure in-memory loading, on modern macOS (dyld3+) they write a temp file to /private/var/folders/, creating a detectable artifact that many defenders don't know to look for\n- Sophisticated attackers (as demonstrated by Patrick Wardle at OBTS and OFTW) can reimplement Apple's older loader code to restore true in-memory loading, bypassing the temp file — this means both file-based and memory-based detection are needed for complete coverage\n- macOS reflective loading is fundamentally different from Windows reflective loading (H129) — it uses Mach-O dyld APIs rather than PE loading, requires different telemetry sources (ESF vs Sysmon/ETW), and bypasses different security controls (Gatekeeper/notarization vs AMSI)\n- Elastic Defend 8.11+ captures dylib load events with code signing metadata, providing the first scalable detection surface for unsigned in-memory module loads — prior to this, detection required raw ESF access or dtrace",
     "references": "- [MITRE ATT&CK T1620 - Reflective Code Loading](https://attack.mitre.org/techniques/T1620/)\n- [Microsoft Security Blog - Dissecting Sapphire Sleet's macOS Intrusion](https://www.microsoft.com/en-us/security/blog/2026/04/16/dissecting-sapphire-sleets-macos-intrusion-from-lure-to-compromise/)\n- [Objective-See - Restoring Reflective Code Loading on macOS (Part I)](https://objective-see.org/blog/blog_0x7C.html)\n- [Objective-See - Restoring Reflective Code Loading on macOS (Part II)](https://objective-see.org/blog/blog_0x82.html)\n- [Meta Red Team X - In-Memory Execution in macOS: the Old and the New](https://rtx.meta.security/post-exploitation/2022/12/19/In-Memory-Execution-in-macOS.html)\n- [slyd0g - Understanding and Defending Against Reflective Code Loading on macOS](https://slyd0g.medium.com/understanding-and-defending-against-reflective-code-loading-on-macos-e2e83211e48f)\n- [Elastic Security Labs - Sinking macOS Pirate Ships with Behavior Detections (dylib load events)](https://www.elastic.co/security-labs/sinking-macos-pirate-ships)\n- [XPN InfoSec - Restoring Dyld Memory Loading](https://blog.xpnsec.com/restoring-dyld-memory-loading/)\n- [Red Canary - Reflective Code Loading Threat Detection Report](https://redcanary.com/threat-detection-report/techniques/reflective-code-loading/)",
     "file_path": "Flames/H136.md"
+  },
+  {
+    "id": "H137",
+    "category": "Flames",
+    "title": "An adversary has chained a server-side request forgery (SSRF) vulnerability in a GCP-hosted web application with the GCP Instance Metadata Service (IMDS) to exfiltrate the underlying VM's service account access token, indicated by IMDS requests to /computeMetadata/v1/instance/service-accounts/default/token originating from a workload process (Node.js, Python, Java app server) rather than the GCE metadata SDK.",
+    "tactic": "Credential Access",
+    "notes": "Platform: GCP (IaaS). The Unit 42 \"Zealot\" autonomous agent reproduced this classic chain end-to-end against a vulnerable web app on port 3000 — the same chain used in the 2019 Capital One breach (AWS) and the December 2025 GCP misconfiguration campaigns. Detection data sources: VPC Flow Logs (look for traffic to 169.254.169.254 from non-system processes), GCP audit logs (data_access.googleapis.com is silent for IMDS calls — they happen entirely on the VM), and host-side endpoint telemetry on the GCE instance itself. Host-side hunt: process executing outbound HTTP GET to 169.254.169.254 with `Metadata-Flavor: Google` header, where the process is the application server (node, java, python, php-fpm) rather than the gcloud SDK or google-cloud-ops-agent. Use osquery or GCP Ops Agent to capture process_open_sockets joined with processes table. Cortex XDR / XSIAM has a managed BIOC alert: \"Cloud Unusual Instance Metadata Service (IMDS) access.\" Defender for Cloud equivalent: CloudAppEvents where ActionType == \"InstanceMetadataServiceAccessed\" and the calling service principal is a workload identity. Network-side hunt: any non-trivial volume of 169.254.169.254 traffic from web-tier subnets is suspicious — IMDS is normally called once per token refresh (~3600s). Focus on workload service accounts that have broader-than-necessary IAM bindings (storage.admin, bigquery.dataOwner) since those are the high-value SSRF targets. Cross-reference with T1190 (Exploit Public-Facing Application) for the SSRF root cause and T1078.004 (Valid Accounts: Cloud Accounts) for the post-token-theft activity that follows.",
+    "tags": [
+      "credential_access",
+      "gcp",
+      "imds",
+      "cloud",
+      "ssrf",
+      "service_account",
+      "T1552.005"
+    ],
+    "techniques": [
+      "T1552.005"
+    ],
+    "severity": null,
+    "status": "current",
+    "related_hunt_ids": [],
+    "submitter": {
+      "name": "Lauren Proehl",
+      "link": "https://x.com/jotunvillur"
+    },
+    "why": "- The Unit 42 Zealot multi-agent system demonstrated end-to-end automation of the SSRF→IMDS→service-account-token→cloud-data-exfil chain against GCP, and the same fundamental chain has produced multiple high-impact breaches (Capital One 2019 on AWS, multiple GCP incidents in 2025–2026) — the technique is now both reliably automatable and actively exploited\n- IMDS access is invisible in GCP audit logs because the call never touches a GCP API endpoint — it's intercepted by the hypervisor at the link-local address — meaning detection has to come from VPC Flow Logs, host-side telemetry, or workload identity audit on the *uses* of the stolen token after the fact\n- Legitimate IMDS access patterns are extremely narrow: the GCE metadata SDK, gcloud CLI, the Ops Agent, and a handful of Google-supplied workload SDKs — any other process making the call is highly anomalous, and modifying applications to call IMDS directly is rare in well-architected services that use Workload Identity Federation\n- A stolen service account token grants the same effective permissions as the workload itself for up to one hour — and the attacker's first action is almost always rapid IAM enumeration (T1069.003) followed by data discovery (T1619, T1526) to map what the token can reach, creating a detectable burst of cross-service API calls from a single token",
+    "references": "- [MITRE ATT&CK T1552.005 - Unsecured Credentials: Cloud Instance Metadata API](https://attack.mitre.org/techniques/T1552/005/)\n- [Unit 42 - Can AI Attack the Cloud? Lessons from the Zealot Autonomous Agent](https://unit42.paloaltonetworks.com/autonomous-ai-cloud-attacks/)\n- [Google Cloud - Best Practices for Securing the Metadata Server](https://cloud.google.com/compute/docs/metadata/overview#querying_metadata)\n- [Datadog Security Labs - The State of GCP Threats: SSRF and IMDS Exploitation](https://securitylabs.datadoghq.com/articles/the-state-of-gcp-threats/)\n- [Wiz - The Top Cloud Threats of 2025: IMDS Token Theft Patterns](https://www.wiz.io/blog/cloud-threats-2025)\n- [Sigma Rule - Suspicious Cloud Metadata Service Access](https://github.com/SigmaHQ/sigma/blob/master/rules/cloud/gcp/audit/gcp_metadata_service_access.yml)\n- [Red Canary Atomic Red Team - T1552.005 Cloud Instance Metadata API](https://github.com/redcanaryco/atomic-red-team/blob/master/atomics/T1552.005/T1552.005.md)",
+    "file_path": "Flames/H137.md"
+  },
+  {
+    "id": "H138",
+    "category": "Flames",
+    "title": "An adversary using a stolen or compromised GCP service account token is performing a rapid enumeration sequence — listing projects, services, IAM bindings, and compute resources within minutes — to map the blast radius of the compromised identity, indicated by a burst of resourcemanager.projects.list, serviceusage.services.list, iam.roles.list, and compute.instances.list calls from a single principal within a short time window.",
+    "tactic": "Discovery",
+    "notes": "Platform: GCP (IaaS). Covers three chained techniques: T1580 (Cloud Infrastructure Discovery — compute/network/image enumeration), T1526 (Cloud Service Discovery — what GCP services are enabled in the project), and T1069.003 (Permission Groups Discovery: Cloud Groups — IAM roles and bindings). The Zealot agent executed all three in sequence within minutes of stealing the IMDS token. Detection data sources: GCP Cloud Audit Logs, specifically the Admin Activity log stream (always on, free) and Data Access logs (must be explicitly enabled per service). Key methodNames to hunt as a sequence within ~10 minutes from a single principalEmail: google.cloud.resourcemanager.v3.Projects.ListProjects, google.iam.admin.v1.ListServiceAccounts, google.iam.admin.v1.ListRoles, google.iam.v1.IAMPolicy.GetIamPolicy, google.cloud.serviceusage.v1.ServiceUsage.ListServices, google.cloud.compute.v1.Instances.AggregatedList. KQL/CloudAppEvents (Defender for Cloud Apps GCP connector): CloudAppEvents | where Application == \"Google Cloud Platform\" | where ActionType in (\"ListProjects\", \"ListServiceAccounts\", \"ListRoles\", \"GetIamPolicy\", \"AggregatedListInstances\") | summarize distinct_actions = dcount(ActionType), action_list = make_set(ActionType) by AccountObjectId, bin(Timestamp, 10m) | where distinct_actions >= 4. Cortex XDR managed alert: \"Cloud infrastructure enumeration activity\" (T1580, T1526). Baseline expectation: human admins enumerate occasionally (e.g., when running terraform plan); workload service accounts almost never enumerate broadly — a service account that suddenly enumerates outside its normal API call set is the strongest signal. Cross-reference H137 (IMDS token theft) as the typical precursor and H139 (service account impersonation) as a typical follow-on if the attacker finds a higher-privileged target. AWS analog: same hunt works for ListBuckets + ListUsers + ListRoles + DescribeInstances burst from a single principal.",
+    "tags": [
+      "discovery",
+      "gcp",
+      "cloud",
+      "iam_enumeration",
+      "service_account",
+      "T1580",
+      "T1526",
+      "T1069.003"
+    ],
+    "techniques": [
+      "T1580",
+      "T1526",
+      "T1069.003"
+    ],
+    "severity": null,
+    "status": "current",
+    "related_hunt_ids": [],
+    "submitter": {
+      "name": "Lauren Proehl",
+      "link": "https://x.com/jotunvillur"
+    },
+    "why": "- The Zealot agent's \"Cloud Reconnaissance Agent\" and \"Cloud Security Agent\" in the Unit 42 study performed the full project/service/IAM/compute enumeration sequence in under 10 minutes — this rapid breadth-first survey is the canonical opening move for any cloud attacker (human or AI) because it determines what's worth attacking next\n- Service account enumeration patterns are radically different from human admin patterns: humans tend to focus on what they already know, while a token-stealing attacker hits multiple unrelated APIs (IAM + Compute + Storage + BigQuery) trying to find any open door — the breadth itself is the signal, not any single API call\n- GCP Admin Activity logs are enabled and retained by default for 400 days — the data is already there for free in every GCP environment, but most organizations don't have a hunt or alert that ties together the \"burst of distinct enumerations from one principal\" pattern\n- Combining T1580 + T1526 + T1069.003 into a single sequence-based hunt is more useful operationally than three separate technique hunts, because the techniques almost never appear in isolation in real cloud attacks — defenders want to catch the attacker mid-enumeration, not after they've moved on to data exfil",
+    "references": "- [MITRE ATT&CK T1580 - Cloud Infrastructure Discovery](https://attack.mitre.org/techniques/T1580/)\n- [MITRE ATT&CK T1526 - Cloud Service Discovery](https://attack.mitre.org/techniques/T1526/)\n- [MITRE ATT&CK T1069.003 - Permission Groups Discovery: Cloud Groups](https://attack.mitre.org/techniques/T1069/003/)\n- [Unit 42 - Can AI Attack the Cloud? Lessons from the Zealot Autonomous Agent](https://unit42.paloaltonetworks.com/autonomous-ai-cloud-attacks/)\n- [Google Cloud - Audit Logs Reference: Admin Activity vs Data Access](https://cloud.google.com/logging/docs/audit)\n- [Mitiga - Detection Engineering for GCP: Hunting Service Account Abuse](https://www.mitiga.io/blog/gcp-service-account-abuse-detection)\n- [Splunk - Detecting Cloud Reconnaissance Across AWS, Azure, and GCP](https://www.splunk.com/en_us/blog/security/cloud-reconnaissance-detection.html)\n- [SigmaHQ - GCP Service Account Enumeration Rule](https://github.com/SigmaHQ/sigma/blob/master/rules/cloud/gcp/audit/gcp_service_account_enumeration.yml)",
+    "file_path": "Flames/H138.md"
+  },
+  {
+    "id": "H139",
+    "category": "Flames",
+    "title": "An adversary holding a low-privilege GCP service account token is escalating privilege by impersonating a higher-privileged service account via the iam.serviceAccounts.generateAccessToken or iam.serviceAccounts.signJwt API, indicated by a service account calling generateAccessToken against a target principal it has not previously impersonated, especially when the source principal is a workload identity (compute-default, GKE node SA) and the target is a privileged role-bound SA (storage-admin, bq-admin, owner).",
+    "tactic": "Privilege Escalation, Defense Evasion",
+    "notes": "Platform: GCP (IaaS). Technique T1548.005 (Temporary Elevated Cloud Access) — adversary uses GCP's native service-account impersonation primitive, which is legitimate but commonly abused after a workload-identity compromise. Detection data source: GCP Cloud Audit Logs (Admin Activity stream), specifically methodName == \"google.iam.credentials.v1.IAMCredentials.GenerateAccessToken\" or \"google.iam.credentials.v1.IAMCredentials.SignJwt\". Key fields to extract: protoPayload.authenticationInfo.principalEmail (the source SA), protoPayload.request.name (the target SA being impersonated, format: projects/-/serviceAccounts/<email>), and protoPayload.response.expireTime (token lifetime). KQL hunt (Defender for Cloud Apps GCP connector): CloudAppEvents | where Application == \"Google Cloud Platform\" | where ActionType == \"GenerateAccessToken\" | extend Source = AccountObjectId, Target = tostring(RawEventData.request.name) | join kind=leftanti (CloudAppEvents | where ActionType == \"GenerateAccessToken\" | where Timestamp < ago(30d) | distinct Source, Target) on Source, Target | project Timestamp, Source, Target, IPAddress. Cortex XDR managed alert: \"GCP service account impersonation attempt.\" Baseline behavior: most workloads impersonate the same 1-3 SAs repeatedly (CI runners impersonating deploy SAs is common); adversary behavior is impersonating a never-before-seen, more-privileged SA. High-fidelity flag: source SA is a compute-default or GKE node SA AND target SA has an *Admin or owner role binding. Cross-reference H137 (IMDS token theft) as the typical precursor; once the attacker has a workload token, T1548.005 is how they reach the admin-tier permissions needed for T1537 (data exfil). Required IAM permission: roles/iam.serviceAccountTokenCreator on the target — flag any unexpected grants of this role.",
+    "tags": [
+      "privilege_escalation",
+      "defense_evasion",
+      "gcp",
+      "cloud",
+      "service_account_impersonation",
+      "T1548.005"
+    ],
+    "techniques": [
+      "T1548.005"
+    ],
+    "severity": null,
+    "status": "current",
+    "related_hunt_ids": [],
+    "submitter": {
+      "name": "Lauren Proehl",
+      "link": "https://x.com/jotunvillur"
+    },
+    "why": "- Service account impersonation is the canonical privilege-escalation path in GCP because workload identities are typically scoped to least privilege, and admin-tier capabilities are deliberately gated behind roles/iam.serviceAccountTokenCreator — but once an attacker compromises any workload that has been granted that role on an admin SA, escalation is a single API call\n- The Zealot agent demonstrated this exact pivot in the Unit 42 study, going from compute-default service account (via IMDS) to a project-owner-bound SA via generateAccessToken before attempting BigQuery exfiltration\n- generateAccessToken calls are logged in the always-on Admin Activity audit stream, which means the data is universally available — the gap is detection logic that catches *novel* impersonation pairs (Source SA → Target SA combinations not seen in the prior 30-day baseline), not just the API call itself\n- Misconfigured roles/iam.serviceAccountTokenCreator bindings are extremely common: a 2024 Wiz study found ~38% of GCP projects had at least one workload identity with token-creator on an admin SA, often granted \"temporarily\" during setup and never revoked — making this a high-prevalence, high-impact privilege path",
+    "references": "- [MITRE ATT&CK T1548.005 - Abuse Elevation Control Mechanism: Temporary Elevated Cloud Access](https://attack.mitre.org/techniques/T1548/005/)\n- [Unit 42 - Can AI Attack the Cloud? Lessons from the Zealot Autonomous Agent](https://unit42.paloaltonetworks.com/autonomous-ai-cloud-attacks/)\n- [Google Cloud - Service Account Impersonation: How It Works](https://cloud.google.com/iam/docs/service-account-impersonation)\n- [Wiz - The Top Cloud IAM Misconfigurations (2024 Cloud Security Report)](https://www.wiz.io/blog/cloud-iam-misconfigurations-2024)\n- [Mitiga - Privilege Escalation in GCP via Service Account Impersonation](https://www.mitiga.io/blog/privilege-escalation-gcp-service-account-impersonation)\n- [SigmaHQ - GCP Service Account Token Generation Rule](https://github.com/SigmaHQ/sigma/blob/master/rules/cloud/gcp/audit/gcp_iam_credentials_generateaccesstoken.yml)\n- [Datadog Security Labs - Hunting Privilege Escalation in GCP](https://securitylabs.datadoghq.com/articles/hunting-privilege-escalation-in-gcp/)\n- [Red Canary - Cloud IAM Privilege Escalation Detection Patterns](https://redcanary.com/blog/cloud-iam-privilege-escalation/)",
+    "file_path": "Flames/H139.md"
+  },
+  {
+    "id": "H140",
+    "category": "Flames",
+    "title": "An adversary with stolen GCP credentials is exfiltrating BigQuery data by exporting query results or table contents to a Cloud Storage bucket in a project outside the organization's known projects, indicated by jobservice.jobcompleted or BigQuery extract jobs whose destinationUris reference gs:// buckets in foreign projects, or by storage.objects.create activity from a BigQuery service principal targeting a previously-unseen bucket.",
+    "tactic": "Exfiltration, Discovery",
+    "notes": "Platform: GCP (IaaS, BigQuery, Cloud Storage). Covers T1537 (Transfer Data to Cloud Account) and T1619 (Cloud Storage Object Discovery — the enumeration step that precedes the exfil). The Zealot agent executed an end-to-end BigQuery extract → cross-project gs:// bucket pattern in the Unit 42 study. Detection data sources: BigQuery audit logs (resourceName starts with \"projects/<proj>/jobs/\") and Cloud Storage Data Access logs (must be explicitly enabled — many environments do not have this on, which is the first gap to close). Key methodNames: jobservice.jobcompleted with metadataJson.jobChange.job.jobConfig.type == \"EXPORT\", and google.cloud.bigquery.v2.JobService.InsertJob for jobs.insert with type EXPORT or COPY. KQL hunt (Defender for Cloud Apps): CloudAppEvents | where Application == \"Google Cloud Platform\" | where ActionType == \"BigQueryExportJob\" | extend dest_uri = tostring(RawEventData.destinationUris[0]) | extend dest_project = extract(\"gs://([^/]+)/\", 1, dest_uri) | where dest_project !in (known_org_buckets) | project Timestamp, AccountObjectId, dest_uri. Cortex XDR managed alert: \"BigQuery table or query results exfiltrated to a foreign project.\" Cross-project exfil signal: resource.labels.project_id (where job runs) != extracted project from destinationUris[0] (where data lands). For T1619, hunt for storage.buckets.list and storage.objects.list calls across many buckets within minutes from a single principal — the discovery step before the export. High-fidelity flags: (1) any BigQuery export to a gs:// URI whose bucket name doesn't match the org's naming convention, (2) any storage.objects.create to a bucket in a project outside the GCP organization, (3) any BigQuery query with result size >100 MB followed within 5 minutes by an export job. Baseline expectation: legitimate exports go to a small set of well-known analytics buckets with predictable naming — anything outside that pattern from a service account is suspicious. Cross-reference H137 (IMDS), H138 (enumeration), and H139 (impersonation) as typical precursors.",
+    "tags": [
+      "exfiltration",
+      "discovery",
+      "gcp",
+      "cloud",
+      "bigquery",
+      "cloud_storage",
+      "T1537",
+      "T1619"
+    ],
+    "techniques": [
+      "T1537",
+      "T1619"
+    ],
+    "severity": null,
+    "status": "current",
+    "related_hunt_ids": [],
+    "submitter": {
+      "name": "Lauren Proehl",
+      "link": "https://x.com/jotunvillur"
+    },
+    "why": "- BigQuery is the highest-value data target in GCP environments — it routinely contains years of customer, financial, and PII data that competitors and ransomware groups will pay for — and the EXPORT job type is a single API call that can move terabytes to an attacker-controlled bucket in seconds\n- The destination of a BigQuery EXPORT can be any gs:// URI the calling principal has write access to — including buckets in *other GCP projects outside the victim organization* — and this cross-project signal is the single most reliable detection for this technique because legitimate exports almost always stay within the org's project set\n- The Zealot agent in the Unit 42 study completed the BigQuery → cross-project bucket exfil in under 60 seconds end-to-end after privilege escalation, which means alerting on \"completed\" exfil is too late — the value is in detecting the bucket-creation/enumeration burst (T1619) that precedes the export, giving defenders a chance to revoke the token before data moves\n- Cloud Storage Data Access logs are off by default on most projects, creating a major blind spot — turning them on for production projects is a low-cost configuration change that materially improves detection of all storage-tier exfiltration, not just BigQuery EXPORT",
+    "references": "- [MITRE ATT&CK T1537 - Transfer Data to Cloud Account](https://attack.mitre.org/techniques/T1537/)\n- [MITRE ATT&CK T1619 - Cloud Storage Object Discovery](https://attack.mitre.org/techniques/T1619/)\n- [Unit 42 - Can AI Attack the Cloud? Lessons from the Zealot Autonomous Agent](https://unit42.paloaltonetworks.com/autonomous-ai-cloud-attacks/)\n- [Google Cloud - BigQuery Data Exfiltration: Detection and Prevention](https://cloud.google.com/bigquery/docs/exporting-data)\n- [Mandiant - Cloud Data Exfiltration Patterns Across AWS, Azure, and GCP](https://cloud.google.com/blog/topics/threat-intelligence/cloud-data-exfiltration-patterns)\n- [Wiz - Hunting BigQuery Exfiltration in Production GCP Environments](https://www.wiz.io/blog/bigquery-exfiltration-detection)\n- [SigmaHQ - GCP BigQuery Job Export to Foreign Project](https://github.com/SigmaHQ/sigma/blob/master/rules/cloud/gcp/audit/gcp_bigquery_export_foreign_project.yml)\n- [Splunk - Detecting Data Exfiltration via Cloud Storage Buckets](https://www.splunk.com/en_us/blog/security/detecting-cloud-storage-exfiltration.html)",
+    "file_path": "Flames/H140.md"
+  },
+  {
+    "id": "H141",
+    "category": "Flames",
+    "title": "A malicious npm package executed during `npm install` on a developer workstation or CI runner is harvesting environment variables, dotfiles (~/.npmrc, ~/.aws/credentials, ~/.ssh/id_*), and cloud-credential files via a preinstall or postinstall lifecycle hook, then exfiltrating them over HTTPS POST to an endpoint themed as legitimate analytics or telemetry, indicated by a Node child process reading credential files and making outbound HTTPS to a non-allowlisted domain within seconds of an `npm install` invocation.",
+    "tactic": "Initial Access, Credential Access",
+    "notes": "Platform: developer workstations and CI/CD runners across Windows, macOS, and Linux (this hunt is platform-agnostic by design — the npm install attack surface is the same across all three). Primary techniques: T1195.002 (Compromise Software Supply Chain) for the install-time vector and T1555 (Credentials from Password Stores — extended interpretation covering the dotfile pattern). The Unit 42 npm threat landscape paper (Apr 2026) documented the Bun-runtime variant beaconing to audit.checkmarx[.]cx (94.154.172.43) using AES-256-GCM-encrypted POST bodies and a fallback C2 lookup via GitHub Search API. Detection data sources: Sysmon (Windows) Event ID 1 (process create) + Event ID 3 (network connect) joined by ProcessGuid; ESF on macOS (ES_EVENT_TYPE_NOTIFY_EXEC, ES_EVENT_TYPE_NOTIFY_OPEN on credential file paths); auditd on Linux (execve + connect syscalls); for CI: GitHub Actions / GitLab Runner workflow logs and self-hosted runner host telemetry. KQL (DeviceProcessEvents): DeviceProcessEvents | where InitiatingProcessFileName in (\"npm.cmd\", \"npm.ps1\", \"node.exe\") | where FileName in~ (\"node.exe\", \"bun.exe\", \"node\") | join kind=inner (DeviceNetworkEvents | where ActionType == \"ConnectionSuccess\") on DeviceId, $left.ProcessId == $right.InitiatingProcessId | where RemoteUrl !in (allowlisted_npm_endpoints) | project Timestamp, DeviceName, ProcessCommandLine, RemoteUrl, RemoteIP. High-fidelity host signals: (1) any process spawned by `npm install` (parent npm, grandparent shell) that reads ~/.npmrc, ~/.aws/credentials, ~/.ssh/id_rsa, or enumerates process.env entirely (auditd execve with `printenv` or equivalent JS env dump), (2) Bun runtime download from github.com/oven-sh/bun/releases followed by execution from a non-system path, (3) outbound HTTPS POST with high-entropy body (>0.8 bits/byte) from a node child within 60s of npm install start, (4) creation of `.github/workflows/format-check.yml` or similar transient workflow file in a CI checkout. Baseline allowlist for outbound domains: registry.npmjs.org, *.npmjs.com, github.com (clone/fetch), raw.githubusercontent.com (limited), and the org's own artifact registry — any other destination from a node child process during install is suspicious. Skip-detection bypass to watch for: Signal handlers catching SIGINT/SIGTERM with no-ops (the Bun loader does this) — an `npm install` that takes longer than expected or appears to ignore Ctrl+C is a manual-investigation signal. Cross-reference: this is the developer-endpoint side of the same supply-chain attack surface that appears in cloud telemetry as anomalous CloudAppEvents from CI runners reading AWS_*, AZURE_*, GCP_* env vars.",
+    "tags": [
+      "initial_access",
+      "credential_access",
+      "supply_chain",
+      "npm",
+      "developer_endpoint",
+      "ci_cd",
+      "T1195.002",
+      "T1555"
+    ],
+    "techniques": [
+      "T1195.002",
+      "T1555"
+    ],
+    "severity": null,
+    "status": "current",
+    "related_hunt_ids": [],
+    "submitter": {
+      "name": "Lauren Proehl",
+      "link": "https://x.com/jotunvillur"
+    },
+    "why": "- The npm ecosystem averaged a new credential-stealing package campaign every ~9 days through 2025–2026 per the Unit 42 landscape paper, and the Bun-runtime variant (audit.checkmarx[.]cx) demonstrated that attackers are now bundling full secondary runtimes inside packages to evade Node-based EDR signatures — making generic detection that doesn't depend on a specific package name essential\n- Developer workstations are the most under-monitored asset class in most enterprises: they're not in the same scope as production servers, they have legitimate reason to read credential files locally (gcloud auth, aws configure, ssh-agent), and they generate enormous noise — making the *install-time* window (the seconds immediately after `npm install`) the highest-fidelity hunt window\n- The \"npm install → child process reads ~/.aws/credentials → outbound HTTPS POST\" chain is detectable using only stock Sysmon/ESF/auditd telemetry that most orgs already collect, but the join across process and network events keyed on the npm parent process is rarely written as a hunt rule — this hunt closes that specific gap\n- CI runners amplify the impact because they hold higher-value secrets (cloud admin credentials, signing keys, deploy tokens) and run untrusted package code on every PR — the same hunt logic applies but the data sources shift to GitHub Actions audit logs and self-hosted runner host telemetry, which often aren't piped to the SIEM at all",
+    "references": "- [MITRE ATT&CK T1195.002 - Supply Chain Compromise: Compromise Software Supply Chain](https://attack.mitre.org/techniques/T1195/002/)\n- [MITRE ATT&CK T1555 - Credentials from Password Stores](https://attack.mitre.org/techniques/T1555/)\n- [Unit 42 - The npm Threat Landscape: Attack Surface and Mitigations](https://unit42.paloaltonetworks.com/monitoring-npm-supply-chain-attacks/)\n- [Checkmarx - Anatomy of an npm Supply Chain Attack: The Bun Loader Pattern](https://checkmarx.com/blog/npm-supply-chain-bun-loader/)\n- [Snyk - Malicious npm Packages: Detection Strategies for Developer Endpoints](https://snyk.io/blog/malicious-npm-packages-detection/)\n- [GitHub Security Lab - Detecting Workflow Injection from Untrusted Dependencies](https://securitylab.github.com/research/github-actions-untrusted-input/)\n- [Sigma Rule - Suspicious Process Spawned by Node/NPM During Install](https://github.com/SigmaHQ/sigma/blob/master/rules/category/process_creation/proc_creation_node_install_suspicious.yml)\n- [Red Canary Atomic Red Team - T1195.002 Software Supply Chain Compromise](https://github.com/redcanaryco/atomic-red-team/blob/master/atomics/T1195.002/T1195.002.md)\n- [Datadog Security Labs - Hunting npm Package Compromise on Developer Workstations](https://securitylabs.datadoghq.com/articles/hunting-npm-package-compromise/)",
+    "file_path": "Flames/H141.md"
+  },
+  {
+    "id": "H142",
+    "category": "Flames",
+    "title": "Threat actors are using the Snowflake GET command to exfiltrate compressed GZIP files from temporary internal stages to locally specified directories on attacker-controlled systems after staging stolen database records.",
+    "tactic": "Exfiltration",
+    "notes": "Based on ATT&CK technique T1567.002. Generated by [hearth-auto-intel](https://github.com/THORCollective/HEARTH).",
+    "tags": [
+      "exfiltration",
+      "snowflake",
+      "saas",
+      "unc5537",
+      "T1567.002"
+    ],
+    "techniques": [
+      "T1567.002"
+    ],
+    "severity": null,
+    "status": "current",
+    "related_hunt_ids": [],
+    "submitter": {
+      "name": "Omer M",
+      "link": ""
+    },
+    "why": "- UNC5537 systematically used this specific exfiltration technique across hundreds of Snowflake customer instances to steal significant volumes of sensitive data for extortion and sale on cybercrime forums\n- The GET command combined with GZIP compression represents the final stage of a multi-step data theft operation, making it a critical detection point before data leaves the environment\n- This technique is highly observable in Snowflake query history logs and represents a distinctive behavior pattern that differs from legitimate data export activities, especially when combined with temporary stage usage\n- Detection of this activity can prevent large-scale data breaches affecting cloud data warehousing platforms, which are increasingly targeted by financially motivated threat actors\n- The campaign demonstrates how SaaS platforms are becoming prime targets for credential-based attacks, with this exfiltration method likely to be replicated against other similar platforms",
+    "references": "- [MITRE ATT&CK T1567.002 - Exfiltration Over Web Service: Exfiltration to Cloud Storage](https://attack.mitre.org/techniques/T1567/002/)\n- [Source CTI Report](https://cloud.google.com/blog/topics/threat-intelligence/unc5537-snowflake-data-theft-extortion)",
+    "file_path": "Flames/H142.md"
   },
   {
     "id": "M001",
@@ -4161,7 +4539,8 @@
     "tags": [
       "commandandcontrol",
       "t1568_002",
-      "dga"
+      "dga",
+      "T1568.002"
     ],
     "techniques": [
       "T1568.002"
@@ -4185,7 +4564,9 @@
     "notes": "<ul><li>Data Collection and Preparation: Gather and encode data into numerical formats to support analysis (e.g., text vectorization or image hashing).</br><li>Similarity Analysis: Use similarity metrics (e.g., Levenshtein, cosine, or hash-based) to find related patterns or anomalies.</br><li>Clustering: Apply clustering (e.g., K-means) to group similar items, visualizing patterns and outliers.</br><li>Prioritization and Investigation: Flag clusters or anomalies for deeper analysis, focusing on items of interest or risk.",
     "tags": [
       "command_and_control",
-      "execution"
+      "execution",
+      "T1071.001",
+      "T1203"
     ],
     "techniques": [
       "T1071.001",
@@ -4214,7 +4595,9 @@
       "model_assisted",
       "process_lineage",
       "clustering",
-      "anomaly_detection"
+      "anomaly_detection",
+      "T1059",
+      "T1218"
     ],
     "techniques": [
       "T1059",
@@ -4244,7 +4627,10 @@
       "npm",
       "mcp",
       "supply_chain",
-      "ai_coding_assistant"
+      "ai_coding_assistant",
+      "T1195.002",
+      "T1119",
+      "T1555"
     ],
     "techniques": [
       "T1195.002",
@@ -4274,7 +4660,8 @@
       "seo_poisoning",
       "malvertising",
       "domain_scoring",
-      "anomaly_detection"
+      "anomaly_detection",
+      "T1189"
     ],
     "techniques": [
       "T1189"

--- a/scripts/rebuild_hunts_data.py
+++ b/scripts/rebuild_hunts_data.py
@@ -50,7 +50,12 @@ def parse_hunt_file(path, category):
         "title": parsed.get("title") or parsed["hypothesis"],
         "tactic": ", ".join(parsed.get("tactics", [])),
         "notes": parsed.get("notes", ""),
-        "tags": parsed.get("tags", []),
+        # Merge techniques into tags so HuntFinder's /^T\d{4}/ filter finds them.
+        # Techniques live in a separate frontmatter field but the frontend only
+        # checks hunt.tags, so we combine both here without duplicates.
+        "tags": list(dict.fromkeys(
+            parsed.get("tags", []) + parsed.get("techniques", [])
+        )),
         "techniques": parsed.get("techniques", []),
         "severity": parsed.get("severity"),
         "status": parsed.get("status", "current"),


### PR DESCRIPTION
## Summary

- **Root cause:** The frontmatter migration moved MITRE technique IDs out of hunt tags and into a separate `techniques:` YAML field. `rebuild_hunts_data.py` emitted them as separate JSON fields, but `HuntFinder.getMatchingHunts()` only inspects `hunt.tags` with a `/^T\d{4}/` filter — so every data-source selection returned 0 matches.
- **Fix 1:** Merge `techniques` into `tags` in the rebuild script output so technique IDs like `T1071.001` appear where the frontend expects them.
- **Fix 2:** Update `update-hunts.yml` to also commit `public/hunts-data.json` (previously only `hunts-data.js` was committed, leaving the live-site data stale after every auto-update).
- **Regenerated data:** 168 hunts total, 158 with technique tags — Endpoint Logs now matches 54 hunts (34% coverage).

## Test plan

- [ ] Select "Endpoint Logs" in What Can I Hunt? — should show ~54 hunts with coverage %
- [ ] Select multiple data sources — counts should increase
- [ ] "Select All" should show full coverage across all hunts
- [ ] Confirm `public/hunts-data.json` has technique IDs in `.tags` arrays
- [ ] Merge to main → verify GitHub Pages deploy succeeds and live site reflects fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)