### PR TITLE
feat: mobile responsive design — hamburger nav + 480px breakpoint

### DIFF
--- a/home.html
+++ b/home.html
@@ -372,6 +372,46 @@
     .sec-head{grid-template-columns:1fr;gap:18px}
     .foot-grid{grid-template-columns:1fr 1fr}
   }
+  @media (max-width:480px){
+    .wrap{padding:0 16px}
+    .topbar-inner{padding:12px 16px;gap:12px}
+    .mark .sub{display:none}
+    .hero{padding:40px 0 32px}
+    .hero-grid{gap:24px}
+    .lede{font-size:16px}
+    .sec{padding:48px 0}
+    .sec-title{font-size:clamp(32px,8vw,80px)}
+    .sec-head{gap:12px}
+    .stats{grid-template-columns:1fr 1fr}
+    .stat{padding:16px}
+    .stat .n{font-size:36px}
+    .ticker{display:none}
+    .cat{min-height:auto}
+    .cat-art{min-height:180px}
+    .sidecar{padding:16px}
+    .feed-item{grid-template-columns:48px 1fr auto;gap:10px}
+    .demo{gap:24px}
+    .hypothesis{padding:16px}
+    .h-title{font-size:20px}
+    .h-attck{grid-template-columns:1fr 1fr}
+    .feature .left,.feature .right{padding:20px 18px}
+    .feature h3{font-size:32px}
+    pre{overflow-x:auto;-webkit-overflow-scrolling:touch;font-size:11.5px}
+    .search{flex-wrap:wrap;gap:10px}
+    .search .chips{flex-wrap:wrap;width:100%}
+    .lib-head,.lib-row{grid-template-columns:1fr 60px}
+    .lib-head>div:nth-child(2),.lib-row .badge{display:none}
+    .lib-foot{font-size:11px}
+    .leader-row{grid-template-columns:24px 1fr 60px;gap:10px}
+    .leader-row .bar{display:none}
+    .keeper{padding:16px}
+    .keeper .name{font-size:20px}
+    .cta{padding:32px 20px}
+    .cta-row{flex-direction:column;gap:16px;align-items:flex-start}
+    .cta h3{font-size:clamp(28px,7vw,60px)}
+    .foot-grid{grid-template-columns:1fr}
+    .foot-end{flex-direction:column;gap:8px;font-size:11px}
+  }
 </style>
 </head>
 <body>

--- a/home.html
+++ b/home.html
@@ -311,6 +311,49 @@
   .foot-end{margin-top:48px;padding-top:24px;border-top:1px solid var(--line-soft);display:flex;justify-content:space-between;font-family:var(--mono);font-size:11.5px;color:var(--fg-dim);letter-spacing:.05em}
   .foot-end em{font-style:italic;color:var(--ember-2)}
 
+  /* Hamburger nav toggle */
+  .nav-toggle {
+    display: none;
+    background: transparent;
+    border: 1px solid var(--line-soft);
+    color: var(--fg);
+    width: 36px;
+    height: 36px;
+    border-radius: 8px;
+    cursor: pointer;
+    font-size: 18px;
+    align-items: center;
+    justify-content: center;
+    flex-shrink: 0;
+    transition: .15s;
+    padding: 0;
+  }
+  .nav-toggle:hover { background: var(--surface); border-color: var(--line); }
+
+  /* Mobile nav drawer */
+  .nav-drawer {
+    display: none;
+    flex-direction: column;
+    background: oklch(0.17 0.020 300 / 0.98);
+    border-top: 1px solid var(--line-soft);
+    padding: 8px 20px 16px;
+  }
+  .nav-drawer a {
+    display: flex;
+    align-items: center;
+    min-height: 44px;
+    font-size: 15px;
+    color: var(--fg-mute);
+    border-bottom: 1px solid var(--line-soft);
+    padding: 0 4px;
+    text-decoration: none;
+    transition: .15s;
+  }
+  .nav-drawer a:last-child { border-bottom: 0; }
+  .nav-drawer a.on, .nav-drawer a:hover { color: var(--fg); }
+
+  .topbar.nav-open .nav-drawer { display: flex; }
+
   /* responsive */
   @media (max-width:1020px){
     .hero-grid{grid-template-columns:1fr;gap:36px}
@@ -324,6 +367,8 @@
     .lib-head,.lib-row{grid-template-columns:1.5fr .9fr 60px}
     .lib-head .h3,.lib-head .h4,.lib-head .h5,.lib-row .c3,.lib-row .c4,.lib-row .c5{display:none}
     .nav{display:none}
+    .nav-toggle{display:flex}
+    .pill-mono,.top-cta .btn:not(.primary){display:none}
     .sec-head{grid-template-columns:1fr;gap:18px}
     .foot-grid{grid-template-columns:1fr 1fr}
   }
@@ -350,8 +395,16 @@
       <span class="pill-mono" id="topbar-pill">— hunts</span>
       <a class="btn" href="index.html">Search <span class="kbd">⌘K</span></a>
       <a class="btn primary" href="submit.html">Submit a hunt →</a>
+      <button class="nav-toggle" aria-label="Toggle navigation" aria-expanded="false">&#9776;</button>
     </div>
-  </div>
+  </div><!-- end topbar-inner -->
+  <nav class="nav-drawer" id="nav-drawer" aria-hidden="true">
+    <a class="on" href="home.html">Home</a>
+    <a href="index.html">Library</a>
+    <a href="graph.html">Coverage</a>
+    <a href="context-graph.html">Context</a>
+    <a href="submit.html">Submit</a>
+  </nav>
 </header>
 
 <!-- ====== HERO ====== -->
@@ -715,6 +768,25 @@ SigninLogs
   </div>
 </footer>
 
+<script>
+  (function(){
+    var toggle = document.querySelector('.nav-toggle');
+    var header = document.querySelector('.topbar');
+    if (!toggle || !header) return;
+    toggle.addEventListener('click', function() {
+      var open = header.classList.toggle('nav-open');
+      toggle.setAttribute('aria-expanded', open ? 'true' : 'false');
+      document.getElementById('nav-drawer').setAttribute('aria-hidden', open ? 'false' : 'true');
+    });
+    document.querySelectorAll('.nav-drawer a').forEach(function(a) {
+      a.addEventListener('click', function() {
+        header.classList.remove('nav-open');
+        toggle.setAttribute('aria-expanded', 'false');
+        document.getElementById('nav-drawer').setAttribute('aria-hidden', 'true');
+      });
+    });
+  })();
+</script>
 <script type="module" src="/src/home.ts"></script>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -311,6 +311,34 @@ html,body{margin:0;padding:0;background:var(--bg);min-height:100%}
 }
 @keyframes hl-pulse{0%,100%{opacity:.3}50%{opacity:1}}
 
+/* Mobile nav toggle */
+.hl-nav-toggle{
+  display:none;
+  background:transparent;
+  border:1px solid var(--line-soft);
+  color:var(--fg);
+  width:36px;height:36px;
+  border-radius:8px;cursor:pointer;font-size:18px;
+  align-items:center;justify-content:center;
+  flex-shrink:0;transition:.15s;padding:0;
+}
+.hl-nav-toggle:hover{background:var(--surface);border-color:var(--line)}
+
+.hl-nav-drawer{
+  display:flex;flex-direction:column;
+  background:oklch(0.17 0.020 300 / 0.98);
+  border-top:1px solid var(--line-soft);
+  padding:8px 20px 16px;
+}
+.hl-nav-drawer a{
+  display:flex;align-items:center;min-height:44px;
+  font-size:15px;color:var(--fg-mute);
+  border-bottom:1px solid var(--line-soft);
+  padding:0 4px;text-decoration:none;transition:.15s;
+}
+.hl-nav-drawer a:last-child{border-bottom:0}
+.hl-nav-drawer a.on,.hl-nav-drawer a:hover{color:var(--fg)}
+
 /* ── Responsive ──────────────────────────────────────────────────────────── */
 @media (max-width:1100px){
   .hl-workspace .two-col{grid-template-columns:1fr}
@@ -321,6 +349,7 @@ html,body{margin:0;padding:0;background:var(--bg);min-height:100%}
   .hl-lib-head > *:nth-child(n+4):not(:last-child),
   .hl-lib-row  > *:nth-child(n+4):not(:last-child){display:none}
   .hl-nav{display:none}
+  .hl-nav-toggle{display:flex}
   .hl-statrow{grid-template-columns:1fr 1fr}
   .hl-statcell:last-child{display:none}
 }
@@ -584,8 +613,10 @@ function useFilteredHunts({ q, cat, tactic, sort }) {
 
 function TopBar() {
   const stats = window.HUNT_STATS || {};
+  const [navOpen, setNavOpen] = React.useState(false);
+  const close = () => setNavOpen(false);
   return (
-    <header className="hl-topbar">
+    <header className={`hl-topbar${navOpen ? ' nav-open' : ''}`}>
       <div className="hl-topbar-inner">
         <a className="hl-mark" href="/">
           <Glyph />
@@ -603,8 +634,19 @@ function TopBar() {
           <span className="hl-pill">{stats.hypotheses || 0} hunts indexed</span>
           <a className="hl-btn" href="https://github.com/THORCollective/HEARTH" target="_blank" rel="noopener">View on GitHub ↗</a>
           <a className="hl-btn primary" href="/submit.html">Submit a hunt &rarr;</a>
+          <button className="hl-nav-toggle" aria-label="Toggle navigation"
+                  aria-expanded={navOpen} onClick={() => setNavOpen(o => !o)}>&#9776;</button>
         </div>
       </div>
+      {navOpen && (
+        <nav className="hl-nav-drawer">
+          <a href="home.html" onClick={close}>Home</a>
+          <a className="on" href="index.html" onClick={close}>Library</a>
+          <a href="graph.html" onClick={close}>Coverage</a>
+          <a href="context-graph.html" onClick={close}>Context</a>
+          <a href="submit.html" onClick={close}>Submit</a>
+        </nav>
+      )}
     </header>
   );
 }

--- a/index.html
+++ b/index.html
@@ -360,6 +360,19 @@ html,body{margin:0;padding:0;background:var(--bg);min-height:100%}
   .hl-workbar{top:49px}
   .hl-statrow{grid-template-columns:1fr 1fr;border-left:0}
   .hl-selects{display:none}
+  .hl-mark .hl-sub{display:none}
+  .hl-search{min-width:0}
+  .hl-statstrip{display:none}
+}
+@media (max-width:480px){
+  .hl-workbar .wrap,.hl-workspace .wrap{padding:0 12px}
+  .hl-search input{font-size:13px}
+  .hl-segments .seg{padding:8px 10px;font-size:12px}
+  .hl-lib-head,.hl-lib-row{grid-template-columns:1fr 36px}
+  .hl-lib-head>*:nth-child(n+2):not(:last-child),
+  .hl-lib-row>*:nth-child(n+2):not(:last-child){display:none}
+  .hl-lib-row .name{font-size:15px;padding-right:8px}
+  .hl-pv-grid{grid-template-columns:1fr}
 }
 </style>
 </head>

--- a/submit.html
+++ b/submit.html
@@ -192,10 +192,30 @@
   .step-desc{font-size:12.5px;line-height:1.5;color:var(--fg-mute)}
 
   /* ───────── Responsive ───────── */
+  /* Hamburger */
+  .nav-toggle{
+    display:none;background:transparent;border:1px solid var(--line-soft);color:var(--fg);
+    width:36px;height:36px;border-radius:8px;cursor:pointer;font-size:18px;
+    align-items:center;justify-content:center;flex-shrink:0;transition:.15s;padding:0;
+  }
+  .nav-toggle:hover{background:var(--surface);border-color:var(--line)}
+  .nav-drawer{
+    display:none;flex-direction:column;
+    background:oklch(0.17 0.020 300 / 0.98);
+    border-top:1px solid var(--line-soft);padding:8px 20px 16px;
+  }
+  .nav-drawer a{
+    display:flex;align-items:center;min-height:44px;font-size:15px;color:var(--fg-mute);
+    border-bottom:1px solid var(--line-soft);padding:0 4px;text-decoration:none;transition:.15s;
+  }
+  .nav-drawer a:last-child{border-bottom:0}
+  .nav-drawer a.on,.nav-drawer a:hover{color:var(--fg)}
+  .topbar.nav-open .nav-drawer{display:flex}
   @media (max-width:1020px){
     .band-grid{grid-template-columns:1fr;gap:14px}
     .submit-grid{grid-template-columns:1fr}
     .nav{display:none}
+    .nav-toggle{display:flex}
     .how-steps{grid-template-columns:repeat(2,1fr);gap:16px}
     .how-step{border-right:0;border-bottom:1px solid var(--line-soft);padding:0 0 16px}
     .how-step:nth-child(2n){border-bottom:1px solid var(--line-soft)}
@@ -205,6 +225,22 @@
     .pill-mono,.top-cta .btn:not(.primary){display:none}
     .how-steps{grid-template-columns:1fr}
     .card{padding:20px}
+  }
+  @media (max-width:480px){
+    .wrap{padding:0 16px}
+    .topbar-inner{padding:12px 16px;gap:12px}
+    .mark .sub{display:none}
+    .header-band{padding:16px 0 0}
+    .band-grid{gap:10px}
+    h1.page-title{font-size:clamp(24px,7vw,48px)}
+    .main{padding:24px 0 48px}
+    .card{padding:16px 16px 20px}
+    .card-title{font-size:20px}
+    .how-strip{padding:18px}
+    .how-steps{grid-template-columns:1fr}
+    .how-step{border-bottom:1px solid var(--line-soft);padding-bottom:14px;border-right:0}
+    .how-step:last-child{border-bottom:0}
+    pre{overflow-x:auto;-webkit-overflow-scrolling:touch}
   }
 </style>
 </head>
@@ -229,8 +265,16 @@
       <span class="pill-mono">130 hunts · 691 techniques</span>
       <a class="btn" href="index.html">← Browse library</a>
       <a class="btn primary" href="#ctiForm">Submit a hunt →</a>
+      <button class="nav-toggle" aria-label="Toggle navigation" aria-expanded="false">&#9776;</button>
     </div>
   </div>
+  <nav class="nav-drawer" id="nav-drawer" aria-hidden="true">
+    <a href="home.html">Home</a>
+    <a href="index.html">Library</a>
+    <a href="graph.html">Coverage</a>
+    <a href="context-graph.html">Context</a>
+    <a class="on" href="submit.html">Submit</a>
+  </nav>
 </header>
 
 <!-- ───────── HEADER BAND ───────── -->
@@ -355,6 +399,25 @@
   </div>
 </main>
 
+<script>
+  (function(){
+    var toggle = document.querySelector('.nav-toggle');
+    var header = document.querySelector('.topbar');
+    if (!toggle || !header) return;
+    toggle.addEventListener('click', function() {
+      var open = header.classList.toggle('nav-open');
+      toggle.setAttribute('aria-expanded', open ? 'true' : 'false');
+      document.getElementById('nav-drawer').setAttribute('aria-hidden', open ? 'false' : 'true');
+    });
+    document.querySelectorAll('.nav-drawer a').forEach(function(a) {
+      a.addEventListener('click', function() {
+        header.classList.remove('nav-open');
+        toggle.setAttribute('aria-expanded', 'false');
+        document.getElementById('nav-drawer').setAttribute('aria-hidden', 'true');
+      });
+    });
+  })();
+</script>
 <script type="module" src="/src/submit.ts"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary

- Added hamburger nav drawer to all three pages (`home.html`, `index.html`, `submit.html`) — appears at the existing breakpoint where the desktop nav hides (1020px / 1100px)
- `index.html` uses React `useState` for the toggle; `home.html` and `submit.html` use vanilla JS IIFE
- Added `@media (max-width:480px)` block to all three pages with spacing overhaul: 16px wrap padding, single-column footer/how-steps, readable table columns, horizontally-scrollable `pre` blocks

## Test Plan

- [ ] Dev tools → iPhone 14 Pro (390px): hamburger appears, desktop nav hidden, primary CTA still visible
- [ ] Tap ☰ → drawer opens with all 5 nav links (44px min-height each)
- [ ] Tap any drawer link → drawer closes
- [ ] Scroll home.html at 390px: footer single column, stats 2×2, pre scrolls horizontally
- [ ] index.html at 390px: library table shows name + arrow only, search input fits
- [ ] submit.html at 390px: form fields full-width, "How it works" single column
- [ ] `npm run build` exits 0 ✅
- [ ] `npm run type-check` exits 0 ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)