### PR TITLE
fix(ci): prevent and catch hunt-ID collisions in draft PRs

### DIFF
--- a/.github/workflows/pr-from-approval.yml
+++ b/.github/workflows/pr-from-approval.yml
@@ -16,8 +16,30 @@ jobs:
       - name: "Checkout draft branch"
         uses: actions/checkout@v4
         with:
-          ref: ${{ steps.get_branch.outputs.branch_name }}
+          ref: draft/issue-${{ github.event.issue.number }}
           fetch-depth: 0
+
+      - name: "Set up Python"
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.x"
+
+      - name: "Fetch main"
+        run: git fetch origin main
+
+      - name: "Reassign hunt ID if it collides with main"
+        id: reassign
+        run: python scripts/reassign_hunt_id.py
+
+      - name: "Commit and push reassigned hunt ID"
+        if: steps.reassign.outputs.changed == 'true'
+        run: |
+          git config --global user.name 'hearthbot'
+          git config --global user.email 'hearthbot@users.noreply.github.com'
+          git add -A
+          git commit -m "fix(draft): reassign hunt id to ${{ steps.reassign.outputs.hunt_id }} (issue #${{ github.event.issue.number }})"
+          git remote set-url origin https://x-access-token:${{ secrets.HEARTH_TOKEN }}@github.com/${{ github.repository }}
+          git push origin HEAD:draft/issue-${{ github.event.issue.number }}
 
       - name: "Remove 'needs-triage' label"
         if: success()
@@ -48,7 +70,7 @@ jobs:
           script: |
             const issueNumber = context.issue.number;
             const branchName = `draft/issue-${issueNumber}`;
-            
+
             try {
               // Get the full issue details to ensure we have the user object
               const { data: issue } = await github.rest.issues.get({
@@ -112,4 +134,4 @@ jobs:
           issue-number: ${{ github.event.issue.number }}
           body: |
             🚀 Your submission has been approved and a pull request has been created. Thank you!
-            🔗 **View PR**: #${{ steps.create_pr.outputs.pull-request-number }} 
+            🔗 **View PR**: #${{ steps.create_pr.outputs.pull-request-number }}

--- a/.github/workflows/validate-hunt-schema.yml
+++ b/.github/workflows/validate-hunt-schema.yml
@@ -24,11 +24,19 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
-      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5.6.0
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          fetch-depth: 0
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: "3.11"
       - run: pip install -r requirements.txt
+      - name: Check for hunt ID collisions
+        if: github.event_name == 'pull_request'
+        run: |
+          git fetch origin main
+          python scripts/check_hunt_id_collisions.py
       - name: Validate every hunt file
         run: |
           python - <<'PY'

--- a/scripts/check_hunt_id_collisions.py
+++ b/scripts/check_hunt_id_collisions.py
@@ -1,0 +1,65 @@
+#!/usr/bin/env python3
+"""Fail a PR if it introduces a hunt ID that collides with an existing one.
+
+Run on a PR with the head checked out and ``origin/main`` fetched. Detects:
+  1. a hunt file ADDED by the PR whose ID already exists on main,
+  2. an added file whose ``# <id>`` heading disagrees with its filename,
+  3. two files in the working tree sharing an ID.
+
+Exits 1 (printing each problem) on any collision, else 0.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+_REPO_ROOT = str(Path(__file__).resolve().parent.parent)
+if _REPO_ROOT not in sys.path:
+    sys.path.insert(0, _REPO_ROOT)
+
+from scripts.hunt_ids import find_id_problems
+
+DIRS = ("Flames", "Embers", "Alchemy")
+
+
+def _git(*args: str) -> str:
+    return subprocess.run(
+        ["git", *args], check=True, capture_output=True, text=True
+    ).stdout
+
+
+def _heading_id(path: Path) -> str | None:
+    try:
+        first = path.read_text(encoding="utf-8").split("\n", 1)[0].strip()
+    except OSError:
+        return None
+    return first[2:].strip() if first.startswith("# ") else None
+
+
+def main() -> int:
+    added_out = _git(
+        "diff", "--diff-filter=A", "--name-only", "origin/main...HEAD", "--", *DIRS
+    )
+    added_paths = [Path(p) for p in added_out.splitlines() if p.endswith(".md")]
+    added = [(p.stem, _heading_id(p)) for p in added_paths]
+
+    main_out = _git("ls-tree", "-r", "--name-only", "origin/main", "--", *DIRS)
+    main_ids = {Path(p).stem for p in main_out.splitlines() if p.endswith(".md")}
+
+    all_stems = [p.stem for d in DIRS for p in Path(d).glob("*.md")]
+
+    problems = find_id_problems(added, main_ids, all_stems)
+    if problems:
+        print("Hunt ID collision check FAILED:")
+        for problem in problems:
+            print(f"  - {problem}")
+        return 1
+
+    print("Hunt ID collision check passed.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/hunt_ids.py
+++ b/scripts/hunt_ids.py
@@ -1,0 +1,103 @@
+"""Shared helpers for HEARTH hunt-ID parsing, allocation, and rewriting.
+
+Hunt IDs use the format ``H-YYYY-NNN`` (files under ``Flames/``). Older hunts
+use ``HNNN`` (and ``B``/``A`` prefixes for Embers/Alchemy); those are a separate
+namespace and are intentionally ignored by the ``H-YYYY-NNN`` allocator here.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+from typing import Iterable
+
+HUNT_STEM_RE = re.compile(r"^H-(\d{4})-(\d{3,})$")
+
+
+def parse_hunt_number(stem: str) -> int | None:
+    """Return the numeric part of an ``H-YYYY-NNN`` stem, or None if it isn't one."""
+    match = HUNT_STEM_RE.match(stem)
+    return int(match.group(2)) if match else None
+
+
+def existing_numbers(names: Iterable[str]) -> set[int]:
+    """Collect the numeric IDs from an iterable of ``H-YYYY-NNN(.md)`` names/paths."""
+    nums: set[int] = set()
+    for name in names:
+        num = parse_hunt_number(Path(name).stem)
+        if num is not None:
+            nums.add(num)
+    return nums
+
+
+def next_free_number(existing: set[int]) -> int:
+    """Next free hunt number: ``max(existing) + 1`` (1 when empty).
+
+    Matches the generator's historical ``max+1`` semantics rather than filling
+    gaps left by deletions, so IDs stay monotonic and predictable.
+    """
+    return max(existing) + 1 if existing else 1
+
+
+def format_hunt_id(year: int, num: int) -> str:
+    return f"H-{year}-{num:03d}"
+
+
+def rewrite_hunt_id(path: Path, new_id: str) -> Path:
+    """Rename a hunt file to ``new_id`` and rewrite the ID embedded inside it.
+
+    Rewrites the line-1 ``# <old_id>`` heading and any populated ``| <old_id> |``
+    Hunt# table cell. The ID does not appear elsewhere in the body. Removes the
+    old file and returns the new path.
+    """
+    path = Path(path)
+    old_id = path.stem
+    text = path.read_text(encoding="utf-8")
+
+    lines = text.split("\n")
+    if lines and lines[0].strip() == f"# {old_id}":
+        lines[0] = f"# {new_id}"
+    text = "\n".join(lines)
+
+    # Replace a populated Hunt# cell (e.g. "| H-2026-001 |"); a no-op for the
+    # common case where generated files leave that cell empty.
+    text = re.sub(rf"\|\s*{re.escape(old_id)}\s*\|", f"| {new_id} |", text, count=1)
+
+    new_path = path.with_name(f"{new_id}.md")
+    new_path.write_text(text, encoding="utf-8")
+    if new_path != path:
+        path.unlink()
+    return new_path
+
+
+def find_id_problems(
+    added: list[tuple[str, str | None]],
+    main_ids: set[str],
+    all_stems: list[str],
+) -> list[str]:
+    """Return human-readable collision problems for a PR (empty list = clean).
+
+    ``added`` is ``[(stem, heading_id), ...]`` for hunt files the PR adds.
+    ``main_ids`` is the set of hunt stems already on ``main``.
+    ``all_stems`` is every hunt stem in the working tree (for duplicate detection).
+    """
+    problems: list[str] = []
+
+    for stem, heading_id in added:
+        if stem in main_ids:
+            problems.append(f"{stem}.md: hunt ID '{stem}' already exists on main")
+        if heading_id is not None and heading_id != stem:
+            problems.append(
+                f"{stem}.md: heading ID '{heading_id}' does not match filename '{stem}'"
+            )
+
+    seen: set[str] = set()
+    dups: set[str] = set()
+    for stem in all_stems:
+        if stem in seen:
+            dups.add(stem)
+        seen.add(stem)
+    for dup in sorted(dups):
+        problems.append(f"duplicate hunt ID '{dup}' appears on more than one file")
+
+    return problems

--- a/scripts/reassign_hunt_id.py
+++ b/scripts/reassign_hunt_id.py
@@ -1,0 +1,99 @@
+#!/usr/bin/env python3
+"""Reassign a draft hunt's ID if it collides with an ID already on ``main``.
+
+Run on a checked-out draft branch with ``origin/main`` fetched. For each hunt
+file the branch ADDS under ``Flames/`` whose ``H-YYYY-NNN`` number already
+exists on main, rename it to the next free number (rewriting the heading and
+any populated Hunt# cell), and stage the rename.
+
+Emits ``changed`` and ``hunt_id`` to ``$GITHUB_OUTPUT``. Always exits 0 — no
+collision is a no-op.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+_REPO_ROOT = str(Path(__file__).resolve().parent.parent)
+if _REPO_ROOT not in sys.path:
+    sys.path.insert(0, _REPO_ROOT)
+
+from scripts.hunt_ids import (
+    existing_numbers,
+    format_hunt_id,
+    next_free_number,
+    parse_hunt_number,
+    rewrite_hunt_id,
+)
+
+FLAMES = "Flames"
+
+
+def _git(*args: str) -> str:
+    return subprocess.run(
+        ["git", *args], check=True, capture_output=True, text=True
+    ).stdout
+
+
+def _main_numbers() -> set[int]:
+    out = _git("ls-tree", "-r", "--name-only", "origin/main", "--", f"{FLAMES}/")
+    return existing_numbers(out.splitlines())
+
+
+def _added_files() -> list[Path]:
+    out = _git(
+        "diff",
+        "--diff-filter=A",
+        "--name-only",
+        "origin/main...HEAD",
+        "--",
+        f"{FLAMES}/",
+    )
+    return [Path(p) for p in out.splitlines() if p.endswith(".md")]
+
+
+def _set_output(changed: bool, hunt_id: str) -> None:
+    github_output = os.environ.get("GITHUB_OUTPUT")
+    if not github_output:
+        return
+    with open(github_output, "a", encoding="utf-8") as fh:
+        print(f"changed={'true' if changed else 'false'}", file=fh)
+        print(f"hunt_id={hunt_id}", file=fh)
+
+
+def main() -> int:
+    main_nums = _main_numbers()
+    claimed = set(main_nums)
+    changed = False
+    final_id = ""
+
+    for path in _added_files():
+        num = parse_hunt_number(path.stem)
+        if num is None:
+            continue
+        final_id = path.stem
+        if num in main_nums:
+            year = int(path.stem.split("-")[1])
+            new_num = next_free_number(claimed)
+            new_id = format_hunt_id(year, new_num)
+            new_path = rewrite_hunt_id(path, new_id)
+            _git("add", "-A", "--", FLAMES)
+            claimed.add(new_num)
+            final_id = new_id
+            changed = True
+            print(f"Reassigned {path.name} -> {new_path.name} (collided with main)")
+        else:
+            claimed.add(num)
+            print(f"{path.name}: ID free, no change")
+
+    if not changed:
+        print("No hunt-ID collisions to fix.")
+    _set_output(changed, final_id)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/tests/test_hunt_ids.py
+++ b/scripts/tests/test_hunt_ids.py
@@ -1,0 +1,93 @@
+from pathlib import Path
+
+from scripts.hunt_ids import (
+    find_id_problems,
+    format_hunt_id,
+    next_free_number,
+    parse_hunt_number,
+    rewrite_hunt_id,
+)
+
+
+def test_parse_hunt_number():
+    assert parse_hunt_number("H-2026-007") == 7
+    assert parse_hunt_number("H-2026-012") == 12
+    assert parse_hunt_number("H001") is None  # old namespace ignored
+    assert parse_hunt_number("B-2026-001") is None  # Embers prefix, not H
+    assert parse_hunt_number("not-an-id") is None
+
+
+def test_next_free_number():
+    assert next_free_number(set()) == 1
+    assert next_free_number({1, 2}) == 3
+    assert next_free_number({1, 3}) == 4  # max+1, not gap-fill
+    assert next_free_number({5}) == 6
+
+
+def test_format_hunt_id():
+    assert format_hunt_id(2026, 3) == "H-2026-003"
+    assert format_hunt_id(2026, 42) == "H-2026-042"
+
+
+def _write_hunt(path: Path, hunt_id: str, hunt_cell: str = "") -> None:
+    path.write_text(
+        f"# {hunt_id}\n\n"
+        "Threat actors are doing a specific bad thing to a specific target.\n\n"
+        "| Hunt # | Idea / Hypothesis | Tactic | Notes | Tags | Submitter |\n"
+        "|---|---|---|---|---|---|\n"
+        f"| {hunt_cell} | A hypothesis | Collection | n | #collection | T3chn3 |\n\n"
+        "## Why\n- reason\n\n## References\n- link\n",
+        encoding="utf-8",
+    )
+
+
+def test_rewrite_hunt_id_renames_and_updates_heading(tmp_path):
+    src = tmp_path / "H-2026-001.md"
+    _write_hunt(src, "H-2026-001")  # empty Hunt# cell — the real generated format
+    new_path = rewrite_hunt_id(src, "H-2026-003")
+    assert new_path.name == "H-2026-003.md"
+    assert not src.exists()
+    text = new_path.read_text()
+    assert text.splitlines()[0] == "# H-2026-003"
+    assert "# H-2026-001" not in text
+    assert "## Why" in text and "## References" in text  # body preserved
+
+
+def test_rewrite_hunt_id_updates_populated_table_cell(tmp_path):
+    src = tmp_path / "H-2026-002.md"
+    _write_hunt(src, "H-2026-002", hunt_cell="H-2026-002")
+    new_path = rewrite_hunt_id(src, "H-2026-004")
+    text = new_path.read_text()
+    assert "| H-2026-004 |" in text
+    assert "H-2026-002" not in text
+
+
+def test_find_id_problems_flags_main_collision():
+    added = [("H-2026-002", "H-2026-002")]
+    problems = find_id_problems(
+        added, main_ids={"H-2026-001", "H-2026-002"}, all_stems=["H-2026-002"]
+    )
+    assert any("already exists on main" in p for p in problems)
+
+
+def test_find_id_problems_clean_add():
+    added = [("H-2026-003", "H-2026-003")]
+    problems = find_id_problems(
+        added,
+        main_ids={"H-2026-001", "H-2026-002"},
+        all_stems=["H-2026-001", "H-2026-002", "H-2026-003"],
+    )
+    assert problems == []
+
+
+def test_find_id_problems_heading_mismatch():
+    added = [("H-2026-003", "H-2026-002")]
+    problems = find_id_problems(added, main_ids=set(), all_stems=["H-2026-003"])
+    assert any("does not match filename" in p for p in problems)
+
+
+def test_find_id_problems_duplicate_in_tree():
+    problems = find_id_problems(
+        [], main_ids=set(), all_stems=["H-2026-001", "H-2026-001"]
+    )
+    assert any("duplicate" in p.lower() for p in problems)


### PR DESCRIPTION
## Problem

Hunt IDs (`H-YYYY-NNN`, files in `Flames/`) are assigned by scanning **only `main`** for `max(N)+1` at draft-generation time. The generator is blind to other open draft branches, so any submissions drafted before one of them merges all grab the same number. One merges; the rest collide as **dirty** PRs — and the collision *never fails a check*, so it stays invisible until a human hits it. This already happened with issues #280 / #281 / #285 (we fixed #284, #287, #288 by hand).

## Fix (two layers)

**B — auto-reassign at PR-creation time** (`pr-from-approval.yml` + `scripts/reassign_hunt_id.py`)
On the `approved` label, before opening the PR: re-scan `main`, and if the draft's hunt ID is taken, rename the file + heading to the next free ID, commit, and push to the draft branch. The PR is then collision-free. Automates the exact manual rename used on #284/#287/#288, run against fresh `main` at the last moment so bursts can't collide.

**C — fail loudly if a collision slips through** (`validate-hunt-schema.yml` + `scripts/check_hunt_id_collisions.py`)
On every PR, fail the `validate` check if an added hunt ID already exists on `main`, a file's `# heading` disagrees with its filename, or a duplicate ID appears in-tree. Universal backstop covering any submission path, not just the approval flow.

Shared logic lives in `scripts/hunt_ids.py` (pure, stdlib-only, unit-tested in `scripts/tests/test_hunt_ids.py`). Also fixes a latent broken checkout (`ref: ${{ steps.get_branch... }}` referenced a nonexistent step) in `pr-from-approval.yml`.

## Not changed
Generation-time ID assignment is left alone (it would need to enumerate every open draft and still races); B corrects the ID at PR time instead. No existing hunts or generated artifacts (`hunts-data.js`, `hunts.db`) are touched — they regenerate from filenames on push to `main`.

## Verification
- `pytest scripts/tests/` — 9 new tests + full suite (57) green.
- Reproduced a real collision in a throwaway worktree (draft branched pre-`H-2026-001`, adding the same ID): **C** failed with a clear message; **B** reassigned `H-2026-001 → H-2026-003` (correctly skipping the also-taken `002`), rewrote the heading, staged the rename; **C** then passed; **B** was idempotent on re-run.
- Both workflow YAMLs parse; collision check confirmed clean against current `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)