### PR TITLE
ci: add PR build/test guard

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,44 @@
+name: CI
+
+# Build/test guard for pull requests. Runs the same install + build the Pages
+# deploy runs, so a broken build, failing tests, type errors, or a
+# platform-incomplete package-lock.json fail HERE (before merge) instead of on
+# the production deploy after merge.
+
+on:
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build-and-test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: "npm"
+
+      # Strict install — fails fast if package-lock.json is out of sync or is
+      # missing the linux-x64 native binaries the runner needs (npm/cli#4828).
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Type-check
+        run: npm run type-check
+
+      - name: Test
+        run: npm test
+
+      - name: Build
+        run: npm run build


### PR DESCRIPTION
## Why

The `#290 → #291 → #292` saga happened because **nothing validated the build before merge** — a platform-incomplete `package-lock.json` only blew up on the *production* Pages deploy, after merge. This adds a pre-merge gate so that class of failure is caught on the PR.

## What it does

A `CI` workflow on every PR to `main` that runs the same steps as the deploy, on `ubuntu-latest` / node 20:

- `npm ci` — strict install; **fails fast if the lockfile is out of sync or missing the linux-x64 native binaries** ([npm/cli#4828](https://github.com/npm/cli/issues/4828)), exactly the bug that broke the deploy twice
- `npm run type-check`
- `npm test`
- `npm run build`

## Effect

Future PRs that touch dependencies or source can't reach a green-to-merge state with a broken build/tests/lockfile — the failure surfaces on the PR instead of taking down the post-merge deploy. The live site is never the place we discover a bad lockfile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)