### PR TITLE
Polish: instant data refresh + aligned coverage boards

### DIFF
--- a/actors.html
+++ b/actors.html
@@ -1085,6 +1085,11 @@
           oklch(0.18 0.022 300 / 0.55)
         );
         position: relative;
+        /* Column layout so the list fills the (equal-height) board and rows
+           distribute evenly — keeps both boards' 5 rows aligned even when one
+           side's subtitles wrap to two lines. */
+        display: flex;
+        flex-direction: column;
       }
       .board::before {
         content: "";
@@ -1130,6 +1135,9 @@
         padding: 0;
         counter-reset: rk;
         position: relative;
+        flex: 1;
+        display: flex;
+        flex-direction: column;
       }
       .board-list li {
         counter-increment: rk;
@@ -1143,6 +1151,8 @@
         align-items: center;
         transition: background 0.18s ease;
         position: relative;
+        /* Rows share the board height equally so both boards line up row-for-row. */
+        flex: 1;
       }
       .board-list li:last-child {
         border-bottom: 0;

--- a/src/coverage-heatmap.ts
+++ b/src/coverage-heatmap.ts
@@ -1,5 +1,5 @@
-import type { Hunt } from './types/Hunt';
-import type { MitreMatrix } from './types/Mitre';
+import type { Hunt } from "./types/Hunt";
+import type { MitreMatrix } from "./types/Mitre";
 import {
   buildCoverageMap,
   buildTacticCoverage,
@@ -7,19 +7,19 @@ import {
   type CoverageMap,
   type PeakCategory,
   type TacticCoverage,
-} from './lib/coverage';
-import { renderMatrix } from './components/Matrix';
-import { renderTacticGrid } from './components/TacticGrid';
-import { renderTechniquePanel } from './components/TechniquePanel';
-import { renderTacticPanel } from './components/TacticPanel';
-import { Drawer } from './components/Drawer';
+} from "./lib/coverage";
+import { renderMatrix } from "./components/Matrix";
+import { renderTacticGrid } from "./components/TacticGrid";
+import { renderTechniquePanel } from "./components/TechniquePanel";
+import { renderTacticPanel } from "./components/TacticPanel";
+import { Drawer } from "./components/Drawer";
 
-import './styles/components/matrix.css';
-import './styles/components/drawer.css';
-import './styles/components/techniquepanel.css';
-import './styles/components/tactic-grid.css';
+import "./styles/components/matrix.css";
+import "./styles/components/drawer.css";
+import "./styles/components/techniquepanel.css";
+import "./styles/components/tactic-grid.css";
 
-type View = 'tactic' | 'technique';
+type View = "tactic" | "technique";
 
 interface State {
   hunts: Hunt[];
@@ -36,12 +36,12 @@ async function init(): Promise<void> {
   let matrix: MitreMatrix;
   try {
     [hunts, matrix] = await Promise.all([
-      fetchJson<Hunt[]>('/hunts-data.json'),
-      fetchJson<MitreMatrix>('/mitre-matrix.json'),
+      fetchJson<Hunt[]>("/hunts-data.json"),
+      fetchJson<MitreMatrix>("/mitre-matrix.json"),
     ]);
   } catch (err) {
-    console.error('[coverage] load failed', err);
-    showError('Could not load coverage data — try refreshing.');
+    console.error("[coverage] load failed", err);
+    showError("Could not load coverage data — try refreshing.");
     return;
   }
 
@@ -50,28 +50,36 @@ async function init(): Promise<void> {
   const drawer = new Drawer({ onClose: () => clearDrawerFromUrl() });
   const coverage = buildCoverageMap(hunts, matrix, peakFilter ?? undefined);
   const tacticCoverage = buildTacticCoverage(matrix, coverage);
-  const state: State = { hunts, matrix, peakFilter, view, coverage, tacticCoverage, drawer };
+  const state: State = {
+    hunts,
+    matrix,
+    peakFilter,
+    view,
+    coverage,
+    tacticCoverage,
+    drawer,
+  };
 
   paintFilterChips(state);
   paintViewToggle(state);
   paintStats(state);
   paintGrid(state);
 
-  document.getElementById('peak-filter')?.addEventListener('click', (e) => {
+  document.getElementById("peak-filter")?.addEventListener("click", (e) => {
     const target = e.target as HTMLElement;
     const peak = target.dataset.peak;
     if (!peak) return;
-    setPeak(state, peak === 'all' ? null : (peak as PeakCategory));
+    setPeak(state, peak === "all" ? null : (peak as PeakCategory));
   });
 
-  document.getElementById('view-toggle')?.addEventListener('click', (e) => {
+  document.getElementById("view-toggle")?.addEventListener("click", (e) => {
     const target = e.target as HTMLElement;
     const v = target.dataset.view;
-    if (v !== 'tactic' && v !== 'technique') return;
+    if (v !== "tactic" && v !== "technique") return;
     setView(state, v);
   });
 
-  window.addEventListener('popstate', () => {
+  window.addEventListener("popstate", () => {
     const nextPeak = readPeakFromUrl();
     if (nextPeak !== state.peakFilter) applyPeak(state, nextPeak);
     const nextView = readViewFromUrl();
@@ -86,7 +94,8 @@ async function init(): Promise<void> {
   const initialTech = readTechniqueFromUrl();
   const initialTactic = readTacticFromUrl();
   if (initialTech) openTechnique(state, initialTech, { updateUrl: false });
-  else if (initialTactic) openTactic(state, initialTactic, { updateUrl: false });
+  else if (initialTactic)
+    openTactic(state, initialTactic, { updateUrl: false });
 }
 
 function setPeak(state: State, peak: PeakCategory | null): void {
@@ -97,7 +106,11 @@ function setPeak(state: State, peak: PeakCategory | null): void {
 
 function applyPeak(state: State, peak: PeakCategory | null): void {
   state.peakFilter = peak;
-  state.coverage = buildCoverageMap(state.hunts, state.matrix, peak ?? undefined);
+  state.coverage = buildCoverageMap(
+    state.hunts,
+    state.matrix,
+    peak ?? undefined,
+  );
   state.tacticCoverage = buildTacticCoverage(state.matrix, state.coverage);
   paintFilterChips(state);
   paintStats(state);
@@ -116,7 +129,11 @@ function applyView(state: State, view: View): void {
   paintGrid(state);
 }
 
-function openTechnique(state: State, techId: string, opts: { updateUrl?: boolean } = {}): void {
+function openTechnique(
+  state: State,
+  techId: string,
+  opts: { updateUrl?: boolean } = {},
+): void {
   const technique = state.matrix.techniques.find((t) => t.id === techId);
   const cell = state.coverage.get(techId);
   if (!technique || !cell) {
@@ -124,64 +141,81 @@ function openTechnique(state: State, techId: string, opts: { updateUrl?: boolean
     clearDrawerFromUrl();
     return;
   }
-  const tactic = state.matrix.tactics.find((t) => t.shortname === technique.tactic_shortnames[0]);
-  state.drawer.setContent(renderTechniquePanel({
-    technique,
-    cell,
-    tacticName: tactic?.name ?? technique.tactic_shortnames[0] ?? '',
-  }));
+  const tactic = state.matrix.tactics.find(
+    (t) => t.shortname === technique.tactic_shortnames[0],
+  );
+  state.drawer.setContent(
+    renderTechniquePanel({
+      technique,
+      cell,
+      tacticName: tactic?.name ?? technique.tactic_shortnames[0] ?? "",
+    }),
+  );
   state.drawer.open();
   if (opts.updateUrl !== false) writeTechniqueToUrl(techId);
 }
 
-function openTactic(state: State, shortname: string, opts: { updateUrl?: boolean } = {}): void {
+function openTactic(
+  state: State,
+  shortname: string,
+  opts: { updateUrl?: boolean } = {},
+): void {
   const tactic = state.tacticCoverage.get(shortname);
   if (!tactic) {
     console.warn(`[coverage] No tactic found for ?tactic=${shortname}`);
     clearDrawerFromUrl();
     return;
   }
-  state.drawer.setContent(renderTacticPanel({
-    tactic,
-    onTechniqueClick: (techId) => openTechnique(state, techId),
-  }));
+  state.drawer.setContent(
+    renderTacticPanel({
+      tactic,
+      onTechniqueClick: (techId) => openTechnique(state, techId),
+    }),
+  );
   state.drawer.open();
   if (opts.updateUrl !== false) writeTacticToUrl(shortname);
 }
 
 function paintFilterChips(state: State): void {
-  const chips = document.querySelectorAll<HTMLElement>('#peak-filter [data-peak]');
+  const chips = document.querySelectorAll<HTMLElement>(
+    "#peak-filter [data-peak]",
+  );
   chips.forEach((chip) => {
-    const isActive = (chip.dataset.peak === 'all' && state.peakFilter === null)
-      || chip.dataset.peak === state.peakFilter;
-    chip.classList.toggle('filter-chip--active', isActive);
-    chip.setAttribute('aria-selected', String(isActive));
+    const isActive =
+      (chip.dataset.peak === "all" && state.peakFilter === null) ||
+      chip.dataset.peak === state.peakFilter;
+    chip.classList.toggle("filter-chip--active", isActive);
+    chip.setAttribute("aria-selected", String(isActive));
   });
 }
 
 function paintViewToggle(state: State): void {
-  const buttons = document.querySelectorAll<HTMLElement>('#view-toggle [data-view]');
+  const buttons = document.querySelectorAll<HTMLElement>(
+    "#view-toggle [data-view]",
+  );
   buttons.forEach((btn) => {
     const isActive = btn.dataset.view === state.view;
-    btn.classList.toggle('view-toggle__btn--active', isActive);
-    btn.setAttribute('aria-pressed', String(isActive));
+    btn.classList.toggle("view-toggle__btn--active", isActive);
+    btn.setAttribute("aria-pressed", String(isActive));
   });
 }
 
 function paintStats(state: State): void {
-  const el = document.getElementById('stats-strip');
+  const el = document.getElementById("stats-strip");
   if (!el) return;
   const s = summarize(state.coverage);
-  const scope = state.peakFilter ?? 'All';
+  const scope = state.peakFilter ?? "All";
   while (el.firstChild) el.removeChild(el.firstChild);
   el.appendChild(statSpan(String(s.huntsCount), ` hunts in ${scope}`));
-  el.appendChild(statSpan(`${s.coveredCount} / ${s.totalCount}`, ' techniques covered'));
-  el.appendChild(statSpan(String(s.gapCount), ' gaps'));
+  el.appendChild(
+    statSpan(`${s.coveredCount} / ${s.totalCount}`, " techniques covered"),
+  );
+  el.appendChild(statSpan(String(s.gapCount), " gaps"));
 }
 
 function statSpan(strongText: string, suffix: string): HTMLSpanElement {
-  const span = document.createElement('span');
-  const strong = document.createElement('strong');
+  const span = document.createElement("span");
+  const strong = document.createElement("strong");
   strong.textContent = strongText;
   span.appendChild(strong);
   span.appendChild(document.createTextNode(suffix));
@@ -189,11 +223,13 @@ function statSpan(strongText: string, suffix: string): HTMLSpanElement {
 }
 
 function paintGrid(state: State): void {
-  const container = document.getElementById('matrix-container');
+  const container = document.getElementById("matrix-container");
   if (!container) return;
-  container.setAttribute('aria-busy', 'false');
-  if (state.view === 'tactic') {
-    const tactics = state.matrix.tactics.map((t) => state.tacticCoverage.get(t.shortname)!).filter(Boolean);
+  container.setAttribute("aria-busy", "false");
+  if (state.view === "tactic") {
+    const tactics = state.matrix.tactics
+      .map((t) => state.tacticCoverage.get(t.shortname)!)
+      .filter(Boolean);
     renderTacticGrid({
       container,
       tactics,
@@ -210,72 +246,73 @@ function paintGrid(state: State): void {
 }
 
 function readPeakFromUrl(): PeakCategory | null {
-  const p = new URLSearchParams(window.location.search).get('peak');
-  if (p === 'Flames' || p === 'Embers' || p === 'Alchemy') return p;
+  const p = new URLSearchParams(window.location.search).get("peak");
+  if (p === "Flames" || p === "Embers" || p === "Alchemy") return p;
   return null;
 }
 
 function readViewFromUrl(): View {
-  const v = new URLSearchParams(window.location.search).get('view');
-  return v === 'technique' ? 'technique' : 'tactic';
+  const v = new URLSearchParams(window.location.search).get("view");
+  return v === "technique" ? "technique" : "tactic";
 }
 
 function readTechniqueFromUrl(): string | null {
-  return new URLSearchParams(window.location.search).get('t');
+  return new URLSearchParams(window.location.search).get("t");
 }
 
 function readTacticFromUrl(): string | null {
-  return new URLSearchParams(window.location.search).get('tactic');
+  return new URLSearchParams(window.location.search).get("tactic");
 }
 
 function writePeakToUrl(peak: PeakCategory | null): void {
   const url = new URL(window.location.href);
-  if (peak) url.searchParams.set('peak', peak);
-  else url.searchParams.delete('peak');
-  history.pushState({}, '', url.toString());
+  if (peak) url.searchParams.set("peak", peak);
+  else url.searchParams.delete("peak");
+  history.pushState({}, "", url.toString());
 }
 
 function writeViewToUrl(view: View): void {
   const url = new URL(window.location.href);
-  if (view === 'technique') url.searchParams.set('view', 'technique');
-  else url.searchParams.delete('view');
-  history.pushState({}, '', url.toString());
+  if (view === "technique") url.searchParams.set("view", "technique");
+  else url.searchParams.delete("view");
+  history.pushState({}, "", url.toString());
 }
 
 function writeTechniqueToUrl(techId: string): void {
   const url = new URL(window.location.href);
-  url.searchParams.set('t', techId);
-  url.searchParams.delete('tactic');
-  history.pushState({}, '', url.toString());
+  url.searchParams.set("t", techId);
+  url.searchParams.delete("tactic");
+  history.pushState({}, "", url.toString());
 }
 
 function writeTacticToUrl(shortname: string): void {
   const url = new URL(window.location.href);
-  url.searchParams.set('tactic', shortname);
-  url.searchParams.delete('t');
-  history.pushState({}, '', url.toString());
+  url.searchParams.set("tactic", shortname);
+  url.searchParams.delete("t");
+  history.pushState({}, "", url.toString());
 }
 
 function clearDrawerFromUrl(): void {
   const url = new URL(window.location.href);
-  url.searchParams.delete('t');
-  url.searchParams.delete('tactic');
-  history.pushState({}, '', url.toString());
+  url.searchParams.delete("t");
+  url.searchParams.delete("tactic");
+  history.pushState({}, "", url.toString());
 }
 
 async function fetchJson<T>(url: string): Promise<T> {
-  const res = await fetch(url);
+  // no-cache: data files live at fixed paths, so revalidate to avoid stale data after a deploy.
+  const res = await fetch(url, { cache: "no-cache" });
   if (!res.ok) throw new Error(`HTTP ${res.status} for ${url}`);
   return res.json() as Promise<T>;
 }
 
 function showError(msg: string): void {
-  const container = document.getElementById('matrix-container');
+  const container = document.getElementById("matrix-container");
   if (!container) return;
-  container.setAttribute('aria-busy', 'false');
+  container.setAttribute("aria-busy", "false");
   while (container.firstChild) container.removeChild(container.firstChild);
-  const err = document.createElement('div');
-  err.className = 'matrix-error';
+  const err = document.createElement("div");
+  err.className = "matrix-error";
   err.textContent = msg;
   container.appendChild(err);
 }

--- a/src/home.ts
+++ b/src/home.ts
@@ -116,7 +116,7 @@ async function init() {
   setupChips();
 
   try {
-    const res = await fetch("/hunts-data.json");
+    const res = await fetch("/hunts-data.json", { cache: "no-cache" });
     if (!res.ok) throw new Error(`HTTP ${res.status}`);
     allHunts = await res.json();
   } catch (err) {

--- a/src/lib/actor-matching.ts
+++ b/src/lib/actor-matching.ts
@@ -549,9 +549,15 @@ export function analyzeActor(
    Data loading (shared by actors.ts and home.ts)
    ───────────────────────────────────────────── */
 
-/** Fetch + parse JSON, throwing on a non-OK response so 404s don't parse as data. */
+/**
+ * Fetch + parse JSON, throwing on a non-OK response so 404s don't parse as data.
+ * Uses cache: "no-cache" to force revalidation — these data files live at fixed,
+ * un-hashed paths (e.g. /context-graph-data.json), so without it a browser can
+ * serve a stale copy after a deploy until a hard refresh. Revalidation is a cheap
+ * 304 when unchanged and always picks up a fresh file after the monthly refresh.
+ */
 export async function fetchJson<T>(url: string): Promise<T> {
-  const res = await fetch(url);
+  const res = await fetch(url, { cache: "no-cache" });
   if (!res.ok) throw new Error(`HTTP ${res.status} for ${url}`);
   return res.json() as Promise<T>;
 }

--- a/src/lib/hunt-ranker.ts
+++ b/src/lib/hunt-ranker.ts
@@ -1,4 +1,4 @@
-import type { Hunt } from '../types/Hunt';
+import type { Hunt } from "../types/Hunt";
 
 /* ────────────────────────────────────────────────────────
    Context Graph types (mirrors public/context-graph-data.json)
@@ -6,7 +6,14 @@ import type { Hunt } from '../types/Hunt';
 
 interface GraphNode {
   id: string;
-  type: 'hypothesis' | 'technique' | 'tactic' | 'datasource' | 'contributor' | 'threat_actor' | 'campaign';
+  type:
+    | "hypothesis"
+    | "technique"
+    | "tactic"
+    | "datasource"
+    | "contributor"
+    | "threat_actor"
+    | "campaign";
   label: string;
   // technique-specific
   prevalence_score?: number;
@@ -20,7 +27,13 @@ interface GraphNode {
 interface GraphEdge {
   source: string;
   target: string;
-  type: 'TARGETS' | 'EMPLOYS' | 'OBSERVES' | 'BELONGS_TO' | 'SUBMITTED_BY' | 'INSPIRED_BY';
+  type:
+    | "TARGETS"
+    | "EMPLOYS"
+    | "OBSERVES"
+    | "BELONGS_TO"
+    | "SUBMITTED_BY"
+    | "INSPIRED_BY";
 }
 
 interface ContextGraphData {
@@ -35,8 +48,8 @@ interface ContextGraphData {
 
 export interface RankedHunt {
   hunt: Hunt;
-  score: number;               // 0-1 composite
-  scoreDisplay: number;        // 0-100 rounded
+  score: number; // 0-1 composite
+  scoreDisplay: number; // 0-100 rounded
   subscores: {
     prevalence: number;
     actorCoverage: number;
@@ -45,23 +58,23 @@ export interface RankedHunt {
     coverageUniqueness: number;
   };
   // Reasoning fields for top-N display
-  topActors: string[];         // up to 3 actor labels
+  topActors: string[]; // up to 3 actor labels
   actorCount: number;
-  activeCampaigns: string[];   // campaign labels with last_seen within 2 years
-  techniques: string[];        // technique IDs this hunt targets
-  prevalenceLevel: 'hot' | 'warm' | 'cold';
+  activeCampaigns: string[]; // campaign labels with last_seen within 2 years
+  techniques: string[]; // technique IDs this hunt targets
+  prevalenceLevel: "hot" | "warm" | "cold";
 }
 
 export interface CoverageGap {
   categoryName: string;
   categoryIcon: string;
-  techniques: string[];        // techniques covered by category but with 0 hunts
+  techniques: string[]; // techniques covered by category but with 0 hunts
 }
 
 export interface RankingResult {
   ranked: RankedHunt[];
   gaps: CoverageGap[];
-  topThreat: string | null;         // technique label with highest prevalence
+  topThreat: string | null; // technique label with highest prevalence
   topThreatScore: number;
   averageScore: number;
 }
@@ -115,12 +128,17 @@ export class HuntRanker {
 
   private async _fetch(): Promise<void> {
     try {
-      const resp = await fetch('/context-graph-data.json');
+      const resp = await fetch("/context-graph-data.json", {
+        cache: "no-cache",
+      });
       if (!resp.ok) throw new Error(`HTTP ${resp.status}`);
-      this.graphData = await resp.json() as ContextGraphData;
+      this.graphData = (await resp.json()) as ContextGraphData;
       this.buildLookups();
     } catch (err) {
-      console.warn('[HuntRanker] Failed to load context graph — falling back to unranked', err);
+      console.warn(
+        "[HuntRanker] Failed to load context graph — falling back to unranked",
+        err,
+      );
       this.graphData = null;
     }
   }
@@ -130,30 +148,30 @@ export class HuntRanker {
 
     for (const node of this.graphData.nodes) {
       switch (node.type) {
-        case 'technique':
+        case "technique":
           this.techniqueNodes.set(node.id, node);
           break;
-        case 'threat_actor':
+        case "threat_actor":
           this.actorNodes.set(node.id, node);
           break;
-        case 'campaign':
+        case "campaign":
           this.campaignNodes.set(node.id, node);
           break;
       }
     }
 
     for (const edge of this.graphData.edges) {
-      if (edge.type === 'TARGETS') {
+      if (edge.type === "TARGETS") {
         // hypothesis → technique
         const arr = this.techniqueHunts.get(edge.target) || [];
         arr.push(edge.source);
         this.techniqueHunts.set(edge.target, arr);
-      } else if (edge.type === 'EMPLOYS') {
-        if (edge.source.startsWith('actor:')) {
+      } else if (edge.type === "EMPLOYS") {
+        if (edge.source.startsWith("actor:")) {
           const arr = this.techniqueActors.get(edge.target) || [];
           arr.push(edge.source);
           this.techniqueActors.set(edge.target, arr);
-        } else if (edge.source.startsWith('campaign:')) {
+        } else if (edge.source.startsWith("campaign:")) {
           const arr = this.techniqueCampaigns.get(edge.target) || [];
           arr.push(edge.source);
           this.techniqueCampaigns.set(edge.target, arr);
@@ -188,12 +206,15 @@ export class HuntRanker {
     allHunts: Hunt[],
     coveredTechs: Set<string>,
     selectedCategories: Set<string>,
-    categoryMap: Map<string, { name: string; icon: string; techniques: string[] }>,
+    categoryMap: Map<
+      string,
+      { name: string; icon: string; techniques: string[] }
+    >,
   ): RankingResult {
     if (!this.graphData) {
       // Graceful degradation: return unranked with neutral scores
       return {
-        ranked: hunts.map(h => this.neutralScore(h)),
+        ranked: hunts.map((h) => this.neutralScore(h)),
         gaps: [],
         topThreat: null,
         topThreatScore: 0,
@@ -209,23 +230,29 @@ export class HuntRanker {
     for (const h of allHunts) {
       for (const tag of h.tags) {
         if (/^T\d{4}/.test(tag)) {
-          huntCountPerTechnique.set(tag, (huntCountPerTechnique.get(tag) || 0) + 1);
+          huntCountPerTechnique.set(
+            tag,
+            (huntCountPerTechnique.get(tag) || 0) + 1,
+          );
         }
       }
     }
     const maxHuntsPerTech = Math.max(1, ...huntCountPerTechnique.values());
 
-    const ranked: RankedHunt[] = hunts.map(hunt => {
-      const techTags = hunt.tags.filter(t => /^T\d{4}/.test(t));
+    const ranked: RankedHunt[] = hunts.map((hunt) => {
+      const techTags = hunt.tags.filter((t) => /^T\d{4}/.test(t));
 
       // Normalize technique IDs: hunt tags use T1059_001, graph uses T1059.001
-      const normalizedTechs = techTags.map(t => this.normalizeTechId(t));
+      const normalizedTechs = techTags.map((t) => this.normalizeTechId(t));
 
       // ── Prevalence (0.4) ──
       let maxPrevalence = 0;
       for (const tid of normalizedTechs) {
         const node = this.techniqueNodes.get(tid);
-        if (node?.prevalence_score != null && node.prevalence_score > maxPrevalence) {
+        if (
+          node?.prevalence_score != null &&
+          node.prevalence_score > maxPrevalence
+        ) {
           maxPrevalence = node.prevalence_score;
         }
       }
@@ -233,7 +260,7 @@ export class HuntRanker {
       // ── Actor coverage (0.2) ──
       const actorSet = new Set<string>();
       for (const tid of normalizedTechs) {
-        for (const a of (this.techniqueActors.get(tid) || [])) {
+        for (const a of this.techniqueActors.get(tid) || []) {
           actorSet.add(a);
         }
       }
@@ -251,12 +278,14 @@ export class HuntRanker {
       const campaignSet = new Set<string>();
       const activeCampaigns: string[] = [];
       for (const tid of normalizedTechs) {
-        for (const cId of (this.techniqueCampaigns.get(tid) || [])) {
+        for (const cId of this.techniqueCampaigns.get(tid) || []) {
           if (campaignSet.has(cId)) continue;
           campaignSet.add(cId);
           const cNode = this.campaignNodes.get(cId);
           if (cNode) {
-            const lastSeen = cNode.last_seen ? new Date(cNode.last_seen).getTime() : 0;
+            const lastSeen = cNode.last_seen
+              ? new Date(cNode.last_seen).getTime()
+              : 0;
             if (now - lastSeen < twoYearsMs) {
               activeCampaigns.push(cNode.label);
             }
@@ -279,16 +308,18 @@ export class HuntRanker {
         // Also try normalized form
         else if (coveredTechs.has(this.normalizeTechId(tag))) matchedCount++;
       }
-      const dataSourceMatch = techTags.length > 0 ? matchedCount / techTags.length : 0;
+      const dataSourceMatch =
+        techTags.length > 0 ? matchedCount / techTags.length : 0;
 
       // ── Coverage uniqueness (0.1) ──
       // Rare coverage = more valuable. Inverse of how many hunts cover the same technique.
       let uniquenessSum = 0;
       for (const tag of techTags) {
         const count = huntCountPerTechnique.get(tag) || 1;
-        uniquenessSum += 1 - (count / maxHuntsPerTech);
+        uniquenessSum += 1 - count / maxHuntsPerTech;
       }
-      const coverageUniqueness = techTags.length > 0 ? uniquenessSum / techTags.length : 0;
+      const coverageUniqueness =
+        techTags.length > 0 ? uniquenessSum / techTags.length : 0;
 
       // ── Composite score ──
       const score =
@@ -298,9 +329,8 @@ export class HuntRanker {
         WEIGHTS.dataSourceMatch * dataSourceMatch +
         WEIGHTS.coverageUniqueness * coverageUniqueness;
 
-      const prevalenceLevel: 'hot' | 'warm' | 'cold' =
-        maxPrevalence >= 0.6 ? 'hot' :
-        maxPrevalence >= 0.2 ? 'warm' : 'cold';
+      const prevalenceLevel: "hot" | "warm" | "cold" =
+        maxPrevalence >= 0.6 ? "hot" : maxPrevalence >= 0.2 ? "warm" : "cold";
 
       return {
         hunt,
@@ -331,8 +361,9 @@ export class HuntRanker {
       const uncoveredTechs: string[] = [];
       for (const tid of cat.techniques) {
         const normalized = this.normalizeTechId(tid);
-        const huntCount = (this.techniqueHunts.get(tid)?.length || 0) +
-                          (this.techniqueHunts.get(normalized)?.length || 0);
+        const huntCount =
+          (this.techniqueHunts.get(tid)?.length || 0) +
+          (this.techniqueHunts.get(normalized)?.length || 0);
         if (huntCount === 0) {
           uncoveredTechs.push(normalized);
         }
@@ -351,16 +382,21 @@ export class HuntRanker {
     let topThreatScore = 0;
     for (const tid of coveredTechs) {
       const norm = this.normalizeTechId(tid);
-      const node = this.techniqueNodes.get(tid) || this.techniqueNodes.get(norm);
-      if (node?.prevalence_score != null && node.prevalence_score > topThreatScore) {
+      const node =
+        this.techniqueNodes.get(tid) || this.techniqueNodes.get(norm);
+      if (
+        node?.prevalence_score != null &&
+        node.prevalence_score > topThreatScore
+      ) {
         topThreatScore = node.prevalence_score;
         topThreat = node.label;
       }
     }
 
-    const averageScore = ranked.length > 0
-      ? ranked.reduce((sum, r) => sum + r.score, 0) / ranked.length
-      : 0;
+    const averageScore =
+      ranked.length > 0
+        ? ranked.reduce((sum, r) => sum + r.score, 0) / ranked.length
+        : 0;
 
     return { ranked, gaps, topThreat, topThreatScore, averageScore };
   }
@@ -372,33 +408,40 @@ export class HuntRanker {
     const parts: string[] = [];
 
     if (rh.actorCount > 0) {
-      const actorStr = rh.topActors.length > 0
-        ? rh.topActors.join(', ')
-        : `${rh.actorCount} actors`;
-      const techStr = rh.techniques.join(', ');
-      parts.push(`${rh.actorCount} threat actor${rh.actorCount > 1 ? 's' : ''} use ${techStr} including ${actorStr}`);
+      const actorStr =
+        rh.topActors.length > 0
+          ? rh.topActors.join(", ")
+          : `${rh.actorCount} actors`;
+      const techStr = rh.techniques.join(", ");
+      parts.push(
+        `${rh.actorCount} threat actor${rh.actorCount > 1 ? "s" : ""} use ${techStr} including ${actorStr}`,
+      );
     }
 
     if (rh.activeCampaigns.length > 0) {
-      parts.push(`Active campaign${rh.activeCampaigns.length > 1 ? 's' : ''}: ${rh.activeCampaigns.join(', ')}`);
+      parts.push(
+        `Active campaign${rh.activeCampaigns.length > 1 ? "s" : ""}: ${rh.activeCampaigns.join(", ")}`,
+      );
     }
 
     if (rh.subscores.dataSourceMatch >= 1) {
-      parts.push('Your data sources fully cover this hunt');
+      parts.push("Your data sources fully cover this hunt");
     } else if (rh.subscores.dataSourceMatch > 0) {
-      parts.push(`${Math.round(rh.subscores.dataSourceMatch * 100)}% data source match`);
+      parts.push(
+        `${Math.round(rh.subscores.dataSourceMatch * 100)}% data source match`,
+      );
     }
 
     if (rh.subscores.coverageUniqueness > 0.5) {
-      parts.push('Rare coverage — few other hunts target this technique');
+      parts.push("Rare coverage — few other hunts target this technique");
     }
 
-    return parts.join('. ') + (parts.length > 0 ? '.' : '');
+    return parts.join(". ") + (parts.length > 0 ? "." : "");
   }
 
   /** Normalize technique ID: T1059_001 → T1059.001 */
   private normalizeTechId(id: string): string {
-    return id.replace(/_/g, '.');
+    return id.replace(/_/g, ".");
   }
 
   /** Return a neutral / unranked score for graceful degradation */
@@ -417,8 +460,8 @@ export class HuntRanker {
       topActors: [],
       actorCount: 0,
       activeCampaigns: [],
-      techniques: hunt.tags.filter(t => /^T\d{4}/.test(t)),
-      prevalenceLevel: 'cold',
+      techniques: hunt.tags.filter((t) => /^T\d{4}/.test(t)),
+      prevalenceLevel: "cold",
     };
   }
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,21 +1,23 @@
-import { AppState } from './state/AppState';
-import { SearchBar } from './components/SearchBar';
-import { FilterPanel } from './components/FilterPanel';
-import { HuntGrid } from './components/HuntGrid';
-import { Pagination } from './components/Pagination';
-import { Modal } from './components/Modal';
-import { HuntFinder } from './components/HuntFinder';
-import type { Hunt } from './types/Hunt';
-import './styles/main.css';
+import { AppState } from "./state/AppState";
+import { SearchBar } from "./components/SearchBar";
+import { FilterPanel } from "./components/FilterPanel";
+import { HuntGrid } from "./components/HuntGrid";
+import { Pagination } from "./components/Pagination";
+import { Modal } from "./components/Modal";
+import { HuntFinder } from "./components/HuntFinder";
+import type { Hunt } from "./types/Hunt";
+import "./styles/main.css";
 
 /**
  * Load hunt data from JSON file
  */
 async function loadHunts(): Promise<Hunt[]> {
-  const response = await fetch('/hunts-data.json');
+  const response = await fetch("/hunts-data.json", { cache: "no-cache" });
 
   if (!response.ok) {
-    throw new Error(`Failed to load hunt data: HTTP ${response.status} ${response.statusText}`);
+    throw new Error(
+      `Failed to load hunt data: HTTP ${response.status} ${response.statusText}`,
+    );
   }
 
   const data: Hunt[] = await response.json();
@@ -26,9 +28,9 @@ async function loadHunts(): Promise<Hunt[]> {
  * Hide loading indicator
  */
 function hideLoading(): void {
-  const loading = document.getElementById('loading');
+  const loading = document.getElementById("loading");
   if (loading) {
-    loading.style.display = 'none';
+    loading.style.display = "none";
   }
 }
 
@@ -36,7 +38,7 @@ function hideLoading(): void {
  * Show error message to user
  */
 function showError(message: string): void {
-  const container = document.getElementById('huntsGrid');
+  const container = document.getElementById("huntsGrid");
   if (container) {
     container.innerHTML = `
       <div class="error-message">
@@ -54,14 +56,14 @@ function showError(message: string): void {
  */
 async function initApp(): Promise<void> {
   try {
-    console.log('HEARTH initializing...');
+    console.log("HEARTH initializing...");
 
     // Load hunt data
     const hunts = await loadHunts();
     console.log(`Loaded ${hunts.length} hunts`);
 
     if (hunts.length === 0) {
-      showError('No hunts found in database');
+      showError("No hunts found in database");
       return;
     }
 
@@ -85,22 +87,24 @@ async function initApp(): Promise<void> {
 
     // Initialize Hunt Finder (lazy - created on first tab switch)
     let huntFinderInit = false;
-    const finderView = document.getElementById('huntFinderView');
+    const finderView = document.getElementById("huntFinderView");
     const libraryElements = [
-      document.querySelector('.intro') as HTMLElement,
-      document.querySelector('.controls') as HTMLElement,
-      document.getElementById('huntsGrid') as HTMLElement,
+      document.querySelector(".intro") as HTMLElement,
+      document.querySelector(".controls") as HTMLElement,
+      document.getElementById("huntsGrid") as HTMLElement,
     ].filter(Boolean);
 
-    const navLibrary = document.getElementById('navLibrary');
-    const navFinder = document.getElementById('navFinder');
+    const navLibrary = document.getElementById("navLibrary");
+    const navFinder = document.getElementById("navFinder");
 
     function switchView(view: string) {
-      const isLibrary = view === 'library';
-      libraryElements.forEach(el => { if (el) el.style.display = isLibrary ? '' : 'none'; });
-      if (finderView) finderView.style.display = isLibrary ? 'none' : '';
-      navLibrary?.classList.toggle('nav-tab--active', isLibrary);
-      navFinder?.classList.toggle('nav-tab--active', !isLibrary);
+      const isLibrary = view === "library";
+      libraryElements.forEach((el) => {
+        if (el) el.style.display = isLibrary ? "" : "none";
+      });
+      if (finderView) finderView.style.display = isLibrary ? "none" : "";
+      navLibrary?.classList.toggle("nav-tab--active", isLibrary);
+      navFinder?.classList.toggle("nav-tab--active", !isLibrary);
 
       if (!isLibrary && !huntFinderInit && finderView) {
         huntFinderInit = true;
@@ -108,41 +112,42 @@ async function initApp(): Promise<void> {
       }
     }
 
-    navLibrary?.addEventListener('click', () => switchView('library'));
-    navFinder?.addEventListener('click', () => switchView('finder'));
+    navLibrary?.addEventListener("click", () => switchView("library"));
+    navFinder?.addEventListener("click", () => switchView("finder"));
 
     // Handle hash navigation
-    if (window.location.hash === '#finder') {
-      switchView('finder');
+    if (window.location.hash === "#finder") {
+      switchView("finder");
     }
 
-    console.log('HEARTH initialized successfully');
+    console.log("HEARTH initialized successfully");
     console.log(`- Total hunts: ${state.getTotalHuntCount()}`);
     console.log(`- Unique tactics: ${state.getUniqueTactics().size}`);
     console.log(`- Contributors: ${state.getUniqueContributors().size}`);
-
   } catch (error) {
-    console.error('Failed to initialize HEARTH:', error);
+    console.error("Failed to initialize HEARTH:", error);
 
-    if (error instanceof TypeError && error.message.includes('fetch')) {
-      showError('Failed to load hunt data. Please check your network connection.');
-    } else if (error instanceof Error && error.message.includes('404')) {
-      showError('Hunt data file not found. Please contact support.');
+    if (error instanceof TypeError && error.message.includes("fetch")) {
+      showError(
+        "Failed to load hunt data. Please check your network connection.",
+      );
+    } else if (error instanceof Error && error.message.includes("404")) {
+      showError("Hunt data file not found. Please contact support.");
     } else if (error instanceof Error) {
       showError(`Failed to load hunt data: ${error.message}`);
     } else {
-      showError('An unexpected error occurred. Please refresh the page.');
+      showError("An unexpected error occurred. Please refresh the page.");
     }
   }
 }
 
 // Global error handlers
-window.addEventListener('error', (event) => {
-  console.error('Unhandled error:', event.error);
+window.addEventListener("error", (event) => {
+  console.error("Unhandled error:", event.error);
 });
 
-window.addEventListener('unhandledrejection', (event) => {
-  console.error('Unhandled promise rejection:', event.reason);
+window.addEventListener("unhandledrejection", (event) => {
+  console.error("Unhandled promise rejection:", event.reason);
 });
 
 // Start the application


### PR DESCRIPTION
Two small fixes from reviewing the live actor-coverage page.

## 1. Stale data after deploy (cache-busting)
The coverage page briefly showed the **old** HEARTH-scoped numbers after the rework deployed — a hard refresh fixed it. Cause: the data files (`context-graph-data.json`, `hunts-data.json`, `mitre-matrix.json`) are served at fixed, un-hashed paths, so the browser served a cached copy until forced to refetch.

Added `cache: "no-cache"` to every data-file fetch — the shared `fetchJson` plus the raw fetches in `main.ts`, `home.ts`, `hunt-ranker.ts`, and `coverage-heatmap.ts`. This forces a cheap revalidation (a `304` when unchanged), so the monthly actor refresh and hunt-database updates show up without a hard reload.

## 2. Misaligned boards
"Most covered" and "Least covered" both show 5 actors, but the gap board's two-line subtitles ("27 techniques to hunt · 27 hunts") made its rows taller — so the boards' rows didn't line up and the left board had dead space at the bottom.

Made each board a flex column whose rows `flex: 1`, so 5 equal rows fill each (equal-height) board and align 1:1. **Verified in-browser** (Playwright):

| Before | After |
|---|---|
| left rows compact + bottom gap; rows offset from right board | rows equal height, line up row-for-row across both boards |

## Verification
- ✅ `npm run type-check`, `npm test` (11/11), `npm run build`
- ✅ Rendered locally and confirmed both boards align and data loads through the new fetch

🤖 Generated with [Claude Code](https://claude.com/claude-code)