### PR TITLE
Add Alchemy M023: authentication lateral-movement via per-user host fan-out

### DIFF
--- a/Alchemy/M023.md
+++ b/Alchemy/M023.md
@@ -1,0 +1,109 @@
+---
+category: Alchemy
+id: M023
+hypothesis: A per-identity baseline over Windows authentication events (NTLM and
+  Kerberos network logons) can distinguish a compromised credential moving
+  laterally from legitimate accounts, by modeling each source account's normal
+  set of distinct destination hosts and flagging windows where authentication
+  breadth — distinct destination-host fan-out — spikes far above that account's
+  own rolling baseline. Because service and automation accounts legitimately
+  authenticate to hundreds of hosts, a global fan-out threshold is unworkable in
+  both directions; a per-user robust baseline (median + k*MAD of distinct-host
+  count) surfaces credential spread while tuning the always-busy service account
+  out.
+notes: 'ALCHEMY ANALYTIC — per-identity baseline, not a static rule. Platform:
+  Windows / Active Directory (on-prem authentication). **Attacker pattern**: once
+  an adversary captures a credential or hash, lateral movement fans the same
+  account across many destination hosts it never normally touches — pass-the-hash
+  (NTLM network logons) and Kerberos service-ticket use across the estate. In the
+  LANL Unified Host & Network red-team data this is unmistakable: 104 compromised
+  accounts touch a median of 20 distinct destination hosts (max 198) during the
+  operation, versus a median of 1 for benign users in the same window — but a
+  handful of benign service accounts legitimately reach thousands of hosts, which
+  is exactly why a static org-wide cutoff fails. **Data sources**: Windows
+  Security Event Log 4624 (logon; focus LogonType 3 = network), 4625 (failed
+  logon), 4768/4769 (Kerberos TGT/TGS), or domain-controller authentication; the
+  LANL `auth.txt` schema (time, source user@domain, destination user@domain,
+  source computer, destination computer, auth type, logon type, auth orientation,
+  success/failure) is a faithful research stand-in. Required fields: timestamp,
+  source account, source host, destination host, auth type (NTLM/Kerberos), logon
+  type, success. **Feature engineering** (per source account, sliding
+  daily/hourly window): (1) `distinct_dst_hosts` = dcount(destination host) — the
+  primary breadth signal; (2) `auth_volume` = total logon count (the foil
+  dimension — volume alone cannot separate a chatty service account from a
+  spreading credential); (3) `new_host_fraction` = share of destination hosts not
+  seen for this account in its prior 30-day history (novelty); (4)
+  `ntlm_network_fraction` = share of NTLM LogonType-3 events (pass-the-hash tell,
+  T1550.002); (5) `failure_ratio` = 4625/(4624+4625) (spray/guessing
+  corroborator). **Model approach**: fit a per-account robust baseline of
+  `distinct_dst_hosts` over a rolling 30-day window using median + k*MAD (robust
+  to a single busy day poisoning the baseline; mean+stddev inflates and goes
+  blind), and flag windows where breadth exceeds the account''s own envelope. A
+  global threshold is the explicit foil: any cutoff low enough to catch a
+  compromised user''s 20-host fan-out also fires on every legitimate
+  vulnerability-scanner, SCCM, or backup service account. **Fire conditions**:
+  alert when `distinct_dst_hosts` exceeds the account''s baseline envelope AND
+  (`new_host_fraction` high OR `ntlm_network_fraction` high). **Tuning**: maintain
+  a per-environment allowlist of known wide-reach service principals (scanners,
+  patch management, monitoring, backup) and seed their baselines; apply a
+  cold-start guard so a newly-onboarded account is not flagged until it has
+  accrued baseline history. Cross-reference **T1550.002** (Use Alternate
+  Authentication Material: Pass the Hash — the NTLM network-logon spread) and
+  **T1078** (Valid Accounts — the captured credential is the precondition).'
+submitter:
+  name: Lauren Proehl
+  link: https://x.com/jotunvillur
+tactics:
+- Lateral Movement
+tags:
+- lateral_movement
+- authentication
+- ntlm
+- kerberos
+- pass_the_hash
+- credential_access
+- anomaly_detection
+- model_assisted
+- per_identity_baseline
+- active_directory
+- lanl
+- t1021
+- t1550_002
+- t1078
+techniques:
+- T1021
+---
+
+## Why
+
+- Lateral movement is a *breadth* signal, not a *volume* one: a compromised
+  credential's tell is the set of **distinct destination hosts** it suddenly
+  reaches, not how many times it authenticates. Volume-based alerting chases the
+  noisiest service account and misses a credential that spreads quietly to twenty
+  machines.
+- A static, org-wide fan-out threshold fails in both directions — it drowns in the
+  legitimate scanners, patch-management, and backup accounts that reach hundreds
+  of hosts by design, and it misses a normal user account whose baseline is one or
+  two hosts the moment it jumps to ten. A per-identity baseline is the only thing
+  that separates "normal for a service account" from "abnormal for this user."
+- The discriminator is empirically validated on real ground truth: in the LANL
+  Unified Host & Network red-team dataset, the 104 compromised accounts fan out to
+  a median of 20 distinct destination hosts (p95 76, max 198) during the
+  operation, while benign accounts in the same window sit at a median of 1 — yet
+  benign service accounts reach as many as ~9,400 hosts, confirming that only a
+  per-account baseline, not a global cutoff, makes the separation clean.
+- A robust per-account baseline (median + MAD, not mean + stddev) matters
+  operationally: red-team operations are bursty, and a single legitimately-busy
+  day in the baseline window inflates a mean/stddev threshold enough to mask the
+  later spread. The median ignores the lone spike, so the baseline stays tight.
+  NTLM-network-logon fraction and new-host novelty sharpen the signal toward
+  pass-the-hash specifically.
+
+## References
+
+- [MITRE ATT&CK T1021 — Remote Services](https://attack.mitre.org/techniques/T1021/)
+- [MITRE ATT&CK T1550.002 — Use Alternate Authentication Material: Pass the Hash](https://attack.mitre.org/techniques/T1550/002/)
+- [MITRE ATT&CK T1078 — Valid Accounts](https://attack.mitre.org/techniques/T1078/)
+- [LANL Unified Host and Network Data Set — Turcotte, Kent & Hash (comprehensive cyber-security data with red-team labels)](https://csr.lanl.gov/data/2017/)
+- [Hopper: Modeling and Detecting Lateral Movement — Ho et al., USENIX Security 2021](https://www.usenix.org/conference/usenixsecurity21/presentation/ho)
+- [A.D. Kent — Comprehensive, Multi-Source Cyber-Security Events (LANL authentication data)](https://csr.lanl.gov/data/cyber1/)


### PR DESCRIPTION
## New Alchemy hypothesis — M023

**Authentication lateral-movement via per-user destination-host fan-out.**

A compromised credential moving laterally fans the same account across many destination hosts it never normally touches (pass-the-hash / Kerberos spread). The discriminator is **breadth, not volume**, and it must be **per-identity** — service/automation accounts legitimately reach hundreds of hosts, so a global fan-out threshold fails in both directions. A robust per-account baseline (median + k·MAD of distinct destination hosts) surfaces the spread while tuning the always-busy service account out.

### Why this one
- **Empirically validated on real ground truth.** In the LANL Unified Host & Network red-team dataset, the 104 compromised accounts fan out to a median of **20** distinct destination hosts (p95 76, max 198) during the operation, vs a median of **1** for benign users in the same window — yet benign service accounts reach as many as **~9,400** hosts. Only a per-account baseline makes that separation clean.
- Pairs with the existing per-identity Alchemy analytics (M016 Key Vault, M022 Graph enumeration) — same robust-baseline philosophy, new tactic (Lateral Movement).
- Robust median + MAD (not mean + stddev) so a single busy baseline day can't inflate the threshold and mask the later spread.

### Frontmatter
- `category: Alchemy` · `id: M023` · `tactics: [Lateral Movement]` · `techniques: [T1021]` (cross-refs T1550.002, T1078)
- Submitter: Lauren Proehl

Indexes (`hunts-data.js`, DB, coverage) regenerate via the existing Actions workflow on merge. Opening for review of the public wording before merge.