### PR TITLE
chore(deps): replace deprecated PyPDF2 with pypdf; bump pytest

### DIFF
--- a/.github/scripts/process_issue.py
+++ b/.github/scripts/process_issue.py
@@ -2,7 +2,7 @@ import os
 import re
 import requests
 from bs4 import BeautifulSoup
-import PyPDF2
+import pypdf
 import docx
 import io
 from pathlib import Path
@@ -152,7 +152,7 @@ def get_cti_content(url):
 
         if 'pdf' in content_type:
             with io.BytesIO(response.content) as f:
-                reader = PyPDF2.PdfReader(f)
+                reader = pypdf.PdfReader(f)
                 text = "".join(page.extract_text() for page in reader.pages)
             return text
         elif 'vnd.openxmlformats-officedocument.wordprocessingml.document' in content_type:

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,7 +14,7 @@ readability-lxml>=0.8.0
 lxml>=5.0.0
 
 # Document Processing
-PyPDF2>=3.0.0
+pypdf>=4.0.0
 python-docx>=1.0.0
 
 # Utilities
@@ -24,4 +24,4 @@ jsonschema==4.23.0
 
 # Optional: For local GitHub Actions testing
 # act (install via brew or binary, not pip)
-pytest==8.3.3
+pytest>=9.0.3

--- a/scripts/generate_from_cti.py
+++ b/scripts/generate_from_cti.py
@@ -1,7 +1,7 @@
 import os
 from pathlib import Path
 from dotenv import load_dotenv
-from PyPDF2 import PdfReader
+from pypdf import PdfReader
 
 # Add Anthropic (Claude) support
 try:


### PR DESCRIPTION
## What

- **Replace `PyPDF2` → `pypdf`.** PyPDF2 is deprecated and frozen at 3.0.1, which carries **CVE-2023-36464** (infinite loop on a crafted PDF). `pypdf` is the maintained successor with a compatible `PdfReader` API, so this is a drop-in import rename.
- **Bump `pytest` `==8.3.3` → `>=9.0.3`** (resolves GHSA-6w46-j5rx-g56g / CVE-2025-71176; dev-only).

## Changes

- `requirements.txt`: `PyPDF2>=3.0.0` → `pypdf>=4.0.0`; `pytest==8.3.3` → `>=9.0.3`
- `scripts/generate_from_cti.py`: `from PyPDF2 import PdfReader` → `from pypdf import PdfReader`
- `.github/scripts/process_issue.py`: `import PyPDF2` → `import pypdf` (2 lines)

## Verification

- `PdfReader` import + instantiation works under `pypdf` 6.x
- `pytest` collection unchanged between 8.3.3 and 9.1.1 (no regression)
- Edits are surgical — no unrelated reformatting

🤖 Generated with [Claude Code](https://claude.com/claude-code)