### PR TITLE
Add H209: SimpleHelp technician session launches TaskWeaver and reads developer secrets

### DIFF
--- a/Flames/H209.md
+++ b/Flames/H209.md
@@ -1,0 +1,77 @@
+---
+id: H209
+category: Flames
+title: SimpleHelp technician session launches TaskWeaver and reads developer secrets
+hypothesis: >-
+  An adversary abuses a SimpleHelp technician session to launch jquery.js through Node.js, then reads developer and cloud credential stores before outbound C2.
+tactics:
+  - Initial Access
+  - Execution
+  - Command and Control
+  - Credential Access
+  - Collection
+  - Exfiltration
+techniques:
+  - T1190
+  - T1219
+  - T1059.007
+  - T1105
+  - T1552.001
+  - T1555
+  - T1005
+  - T1041
+tags:
+  - simplehelp
+  - cve_2026_48558
+  - taskweaver
+  - djinn_stealer
+  - rmm_abuse
+  - credential_access
+  - nodejs
+submitter:
+  name: Joshua Strickland
+  link: ""
+required_data_sources:
+  - Endpoint EDR process telemetry
+  - Endpoint EDR file telemetry
+  - Endpoint EDR network connection telemetry
+  - DNS logs
+  - Windows Security process creation events where available
+  - Cloud audit logs for credential and secrets access
+false_positive_notes: |
+  SimpleHelp is a legitimate remote support product, and technicians can run scripts through it during support work. Developers also run Node.js constantly. Do not alert on either condition by itself. The discriminator is the ordered chain: SimpleHelp service lineage, `jquery.js` or `jsquery.js` execution through `node.exe`, reads of several credential-store paths, and outbound C2 or cloud credential use from the same host or principal.
+notes: |
+  Endpoint EDR process telemetry - Core filter: SimpleHelp service or technician process spawning `node.exe`, `powershell.exe`, `wscript.exe`, `cscript.exe`, `mshta.exe`, or a user-writable executable. Triage values: `process command line`, `parent process command line`, `file path`, `user`, `host`. Pivot: require `jquery.js` or `jsquery.js` staging under `AppData`, `ProgramData`, `Temp`, or a remote support working directory. Strong red flags: `SimpleService.exe`, `Manage Remote Access Service.exe`, or another SimpleHelp lineage launching `node.exe <path>\jquery.js`.
+  Endpoint EDR file telemetry - Core filter: the same process lineage reading credential stores after loader execution. Triage values: `file path`, `process command line`, `parent process command line`, `user`, `host`. Pivot: reads or copies of `Cookies`, `Login Data`, `%USERPROFILE%\.ssh`, `.aws\credentials`, `.npmrc`, `.pypirc`, `Docker config.json`, `.git-credentials`, or source-control token files. Strong red flags: several secret families touched within minutes by the same remote support child process.
+  Endpoint network and DNS telemetry - Core filter: child process from SimpleHelp lineage opening outbound connections that are not normal SimpleHelp service traffic. Triage values: `source IP address`, `remote URL`, `remote IP`, `destination port`, `user agent`. Correlation: join `node.exe` loader execution to DNS for `trycloudflare.com` or other temporary tunnel infrastructure, then outbound encrypted C2 from the same host. Strong red flags: `jquery.js` fetched from a temporary tunnel, followed by credential-store reads.
+  Cloud audit logs - Core filter: after endpoint secret reads, look for new credential use or long-lived credential creation by the same user or developer principal. Triage values: `user`, `source IP address`, `user agent`, `session ID`, `request ID`. Pivot: `CreateAccessKey`, `GetSecretValue`, `ListSecrets`, `AssumeRole`, service-account key creation, storage listing, or source repository token use. Strong red flags: cloud control-plane activity from infrastructure not tied to the endpoint shortly after TaskWeaver execution.
+---
+SOCRadar reported active exploitation of CVE-2026-48558, a SimpleHelp OIDC authentication bypass that can give an attacker a fully authenticated technician session in vulnerable deployments. Blackpoint reported the follow-on intrusion chain: the attacker used the trusted remote support path to deploy TaskWeaver, a heavily obfuscated Node.js loader delivered as jquery.js, then delivered Djinn Stealer. The useful hunting point is not whether SimpleHelp is present. It is the remote support lineage launching a Node.js loader, touching credential stores, and opening C2 from the managed endpoint.
+
+## Why
+
+- The source reporting is current and tied to active CVE-2026-48558 exploitation, so the hunt starts from observed post-exploitation behavior instead of patch state or internet exposure.
+- The detection survives infrastructure rotation because it keys on remote support process lineage, Node.js loader staging, and credential-store access, not a domain list alone.
+- The required telemetry is common in MDR work: endpoint process, file, and network events can show the loader chain, and cloud audit logs can show follow-on credential use.
+- False positives are controllable because legitimate SimpleHelp support activity should not load a jQuery-named Node payload and immediately read browser, SSH, package registry, and cloud credential stores.
+
+## Implementation Notes
+
+Endpoint EDR process telemetry - Core filter: SimpleHelp service or technician process spawning `node.exe`, `powershell.exe`, `wscript.exe`, `cscript.exe`, `mshta.exe`, or a user-writable executable. Triage values: `process command line`, `parent process command line`, `file path`, `user`, `host`. Pivot: require `jquery.js` or `jsquery.js` staging under `AppData`, `ProgramData`, `Temp`, or a remote support working directory. Strong red flags: `SimpleService.exe`, `Manage Remote Access Service.exe`, or another SimpleHelp lineage launching `node.exe <path>\jquery.js`.
+Endpoint EDR file telemetry - Core filter: the same process lineage reading credential stores after loader execution. Triage values: `file path`, `process command line`, `parent process command line`, `user`, `host`. Pivot: reads or copies of `Cookies`, `Login Data`, `%USERPROFILE%\.ssh`, `.aws\credentials`, `.npmrc`, `.pypirc`, `Docker config.json`, `.git-credentials`, or source-control token files. Strong red flags: several secret families touched within minutes by the same remote support child process.
+Endpoint network and DNS telemetry - Core filter: child process from SimpleHelp lineage opening outbound connections that are not normal SimpleHelp service traffic. Triage values: `source IP address`, `remote URL`, `remote IP`, `destination port`, `user agent`. Correlation: join `node.exe` loader execution to DNS for `trycloudflare.com` or other temporary tunnel infrastructure, then outbound encrypted C2 from the same host. Strong red flags: `jquery.js` fetched from a temporary tunnel, followed by credential-store reads.
+Cloud audit logs - Core filter: after endpoint secret reads, look for new credential use or long-lived credential creation by the same user or developer principal. Triage values: `user`, `source IP address`, `user agent`, `session ID`, `request ID`. Pivot: `CreateAccessKey`, `GetSecretValue`, `ListSecrets`, `AssumeRole`, service-account key creation, storage listing, or source repository token use. Strong red flags: cloud control-plane activity from infrastructure not tied to the endpoint shortly after TaskWeaver execution.
+
+## False Positive Notes
+
+SimpleHelp is a legitimate remote support product, and technicians can run scripts through it during support work. Developers also run Node.js constantly. Do not alert on either condition by itself. The discriminator is the ordered chain: SimpleHelp service lineage, `jquery.js` or `jsquery.js` execution through `node.exe`, reads of several credential-store paths, and outbound C2 or cloud credential use from the same host or principal.
+
+## Duplicate Review
+
+I did not find an existing HEARTH hunt for CVE-2026-48558, SimpleHelp technician-session abuse, TaskWeaver, or Djinn Stealer. Nearby remote support hunts should not be treated as duplicates because this one requires Node loader staging and credential-store access from the remote support lineage.
+
+## References
+
+- [CVE-2026-48558: SimpleHelp OIDC Auth Bypass Used to Deploy Infostealer Payloads](https://socradar.io/blog/cve-2026-48558-simplehelp-oidc-infostealer/)
+- [A Djinn in the Machine: TaskWeaver's Node.js Intrusion Chain](https://blackpointcyber.com/blog/a-djinn-in-the-machine-taskweavers-node-js-intrusion-chain/)
+- [Critical SimpleHelp flaw exploited to deploy new stealer malware](https://www.bleepingcomputer.com/news/security/hackers-exploit-critical-simplehelp-flaw-deploy-new-djinn-infostealer-taskweaver-malware/)


### PR DESCRIPTION
## Summary

Adds `H209`: SimpleHelp technician session launches TaskWeaver and reads developer secrets.

## Sources

- https://socradar.io/blog/cve-2026-48558-simplehelp-oidc-infostealer/

## Validation

- Draft reviewed locally before submission.
- Source links are preserved in the hunt writeup.
