### PR TITLE
Remove internal review section from H209

### DIFF
--- a/Flames/H209.md
+++ b/Flames/H209.md
@@ -46,6 +46,8 @@ notes: |
   Endpoint network and DNS telemetry - Core filter: child process from SimpleHelp lineage opening outbound connections that are not normal SimpleHelp service traffic. Triage values: `source IP address`, `remote URL`, `remote IP`, `destination port`, `user agent`. Correlation: join `node.exe` loader execution to DNS for `trycloudflare.com` or other temporary tunnel infrastructure, then outbound encrypted C2 from the same host. Strong red flags: `jquery.js` fetched from a temporary tunnel, followed by credential-store reads.
   Cloud audit logs - Core filter: after endpoint secret reads, look for new credential use or long-lived credential creation by the same user or developer principal. Triage values: `user`, `source IP address`, `user agent`, `session ID`, `request ID`. Pivot: `CreateAccessKey`, `GetSecretValue`, `ListSecrets`, `AssumeRole`, service-account key creation, storage listing, or source repository token use. Strong red flags: cloud control-plane activity from infrastructure not tied to the endpoint shortly after TaskWeaver execution.
 ---
+# H209
+
 SOCRadar reported active exploitation of CVE-2026-48558, a SimpleHelp OIDC authentication bypass that can give an attacker a fully authenticated technician session in vulnerable deployments. Blackpoint reported the follow-on intrusion chain: the attacker used the trusted remote support path to deploy TaskWeaver, a heavily obfuscated Node.js loader delivered as jquery.js, then delivered Djinn Stealer. The useful hunting point is not whether SimpleHelp is present. It is the remote support lineage launching a Node.js loader, touching credential stores, and opening C2 from the managed endpoint.
 
 ## Why
@@ -54,21 +56,6 @@ SOCRadar reported active exploitation of CVE-2026-48558, a SimpleHelp OIDC authe
 - The detection survives infrastructure rotation because it keys on remote support process lineage, Node.js loader staging, and credential-store access, not a domain list alone.
 - The required telemetry is common in MDR work: endpoint process, file, and network events can show the loader chain, and cloud audit logs can show follow-on credential use.
 - False positives are controllable because legitimate SimpleHelp support activity should not load a jQuery-named Node payload and immediately read browser, SSH, package registry, and cloud credential stores.
-
-## Implementation Notes
-
-Endpoint EDR process telemetry - Core filter: SimpleHelp service or technician process spawning `node.exe`, `powershell.exe`, `wscript.exe`, `cscript.exe`, `mshta.exe`, or a user-writable executable. Triage values: `process command line`, `parent process command line`, `file path`, `user`, `host`. Pivot: require `jquery.js` or `jsquery.js` staging under `AppData`, `ProgramData`, `Temp`, or a remote support working directory. Strong red flags: `SimpleService.exe`, `Manage Remote Access Service.exe`, or another SimpleHelp lineage launching `node.exe <path>\jquery.js`.
-Endpoint EDR file telemetry - Core filter: the same process lineage reading credential stores after loader execution. Triage values: `file path`, `process command line`, `parent process command line`, `user`, `host`. Pivot: reads or copies of `Cookies`, `Login Data`, `%USERPROFILE%\.ssh`, `.aws\credentials`, `.npmrc`, `.pypirc`, `Docker config.json`, `.git-credentials`, or source-control token files. Strong red flags: several secret families touched within minutes by the same remote support child process.
-Endpoint network and DNS telemetry - Core filter: child process from SimpleHelp lineage opening outbound connections that are not normal SimpleHelp service traffic. Triage values: `source IP address`, `remote URL`, `remote IP`, `destination port`, `user agent`. Correlation: join `node.exe` loader execution to DNS for `trycloudflare.com` or other temporary tunnel infrastructure, then outbound encrypted C2 from the same host. Strong red flags: `jquery.js` fetched from a temporary tunnel, followed by credential-store reads.
-Cloud audit logs - Core filter: after endpoint secret reads, look for new credential use or long-lived credential creation by the same user or developer principal. Triage values: `user`, `source IP address`, `user agent`, `session ID`, `request ID`. Pivot: `CreateAccessKey`, `GetSecretValue`, `ListSecrets`, `AssumeRole`, service-account key creation, storage listing, or source repository token use. Strong red flags: cloud control-plane activity from infrastructure not tied to the endpoint shortly after TaskWeaver execution.
-
-## False Positive Notes
-
-SimpleHelp is a legitimate remote support product, and technicians can run scripts through it during support work. Developers also run Node.js constantly. Do not alert on either condition by itself. The discriminator is the ordered chain: SimpleHelp service lineage, `jquery.js` or `jsquery.js` execution through `node.exe`, reads of several credential-store paths, and outbound C2 or cloud credential use from the same host or principal.
-
-## Duplicate Review
-
-I did not find an existing HEARTH hunt for CVE-2026-48558, SimpleHelp technician-session abuse, TaskWeaver, or Djinn Stealer. Nearby remote support hunts should not be treated as duplicates because this one requires Node loader staging and credential-store access from the remote support lineage.
 
 ## References
 


### PR DESCRIPTION
## Summary

Removes the internal Duplicate Review section from H209 and adds the standard H209 body heading. The duplicate check remains represented only by the submitted hunt's normal content and metadata, not as a public markdown section.

## Validation

- .venv/bin/python -m pytest scripts/tests -q
- Parsed Flames/H209.md with scripts.hunt_parser.parse_hunt_file
