### PR TITLE
fix(cti): restore missing `import re` in hunt draft generator

### DIFF
--- a/scripts/generate_from_cti.py
+++ b/scripts/generate_from_cti.py
@@ -1,4 +1,5 @@
 import os
+import re
 from pathlib import Path
 from dotenv import load_dotenv
 from pypdf import PdfReader


### PR DESCRIPTION
## What
Adds back `import re` to `scripts/generate_from_cti.py`.

## Why
A prior lint cleanup (`e350a13` "comprehensive linting fixes") removed `import re` as unused, but it **is** used:
- `generate_from_cti.py:73` → `re.findall(...)` (technique extraction)
- `generate_from_cti.py:151` → `re.compile(r"^H(\d+)$")` (next hunt ID)

As a result, **every CTI submission's draft run has crashed at startup** with:
```
NameError: name 're' is not defined
```
The script dies long before it generates a draft, so the issue never gets a **"View Hunt Draft" preview** comment, no hunt file/PR branch is created, and the **duplicate/similarity detection step never runs**. Example: #297 (ClickFix) and the 06-28 submissions all failed this way.

This is a pure regression fix — similarity/duplicate detection was never removed, it just never executed.

## Verification
- File compiles cleanly; `re` now resolvable at both call sites.
- Confirmed the same lint pass's other removals (`time`, `requests`, `io`) are genuinely unused — `re` was the only false positive.

## Follow-up (after merge)
Re-trigger #297 by toggling the `intel-submission` label so it drafts a preview and runs similarity. Submitter credit (`th3CyF0x` / x.com/th3cyf0x) is parsed from the issue body and is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)