### PR TITLE
fix(ci): install CTI deps from requirements.txt, not a hand-kept list

### DIFF
--- a/.github/workflows/issue-generate-hunts.yml
+++ b/.github/workflows/issue-generate-hunts.yml
@@ -81,7 +81,7 @@ jobs:
       - name: "Install Python dependencies"
         run: |
           python -m pip install --upgrade pip
-          pip install requests beautifulsoup4 PyPDF2 python-docx openai python-dotenv anthropic readability-lxml brotli zstandard
+          pip install -r requirements.txt
 
       - name: "Download MITRE ATT&CK data"
         run: |

--- a/.github/workflows/process-cti-issue.yml
+++ b/.github/workflows/process-cti-issue.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install requests beautifulsoup4 PyPDF2 python-docx anthropic brotli zstandard readability-lxml
+          pip install -r requirements.txt
 
       - name: Process CTI link
         env:


### PR DESCRIPTION
## What
Both CTI workflows now run `pip install -r requirements.txt` instead of a hand-maintained inline package list.

## Why
The deps bump (PyPDF2 → pypdf) updated the code (`from pypdf import PdfReader`) and `requirements.txt`, but **not** the inline `pip install` lists in:
- `.github/workflows/issue-generate-hunts.yml`
- `.github/workflows/process-cti-issue.yml`

Those still installed `PyPDF2`, so the draft generator crashed at startup on every submission:
```
ModuleNotFoundError: No module named 'pypdf'
```
(This was the failure left over *after* the `import re` fix in #306 — re-triggering #297 surfaced it.)

`requirements.txt` is already a strict superset of both inline lists, so pointing at it is a behavior-preserving fix **and** removes the duplicated dependency list that drifted in the first place — future deps changes flow to the pipeline automatically.

## Verification
- Confirmed both inline lists ⊆ `requirements.txt` (only addition: `pypdf` replaces `PyPDF2`, plus harmless extras already used elsewhere: lxml, frontmatter, jsonschema, pytest).
- Diff is exactly two lines (one per workflow).

🤖 Generated with [Claude Code](https://claude.com/claude-code)