### PR TITLE
ci: add errors-only flake8 guard for Python pipeline scripts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,3 +42,24 @@ jobs:
 
       - name: Build
         run: npm run build
+
+  # Errors-only lint of the Python pipeline scripts. Catches syntax errors and
+  # undefined names — e.g. a used import removed by an over-eager cleanup, which
+  # is exactly what broke hunt drafting (a missing `import re` crashed every CTI
+  # submission at runtime, past where py_compile or the build job would notice).
+  python-checks:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.x"
+
+      - name: Install flake8
+        run: pip install flake8
+
+      - name: Lint pipeline scripts (errors only)
+        run: flake8 scripts/ .github/scripts/ --count --select=E9,F63,F7,F82 --show-source --statistics


### PR DESCRIPTION
## What
Adds a `python-checks` job to CI that runs `flake8` over `scripts/` and `.github/scripts/` with an **errors-only** selection (`E9,F63,F7,F82` — syntax errors, undefined names, logic bugs). No style/format rules.

## Why
CI's existing job only builds the **frontend** (vitest/npm) and never imports or analyzes the Python CTI pipeline. That's how two regressions reached production and silently broke hunt drafting for every submission:
1. A used `import re` was stripped by an over-eager lint pass → runtime `NameError` (fixed in #306).
2. `PyPDF2`→`pypdf` install drift in the workflows (fixed in #307).

`#82` (undefined names) catches class 1 statically — *before* merge.

## Why this selection (not py_compile, not full flake8)
- `py_compile` would **not** have caught the `re` bug — it's a runtime `NameError` inside a function; the file compiles fine.
- Full flake8 would fail on pre-existing style/F401 noise and re-introduce the over-aggressive unused-import enforcement that caused the original removal.
- `E9,F63,F7,F82` is the canonical "real errors only" preset: passes clean on the current tree, fires only on genuine bugs.

## Verification
- Stripped `import re` from a throwaway copy → `F821 undefined name 're'`, job exits 1. ✅
- Current tree under this selection: **clean, exit 0**. ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)