### PR TITLE
feat(cti): headless-browser fallback for JS bot-challenged sources

### DIFF
--- a/.github/scripts/process_issue.py
+++ b/.github/scripts/process_issue.py
@@ -214,6 +214,13 @@ def get_cti_content(url):
                     print(f"✅ JS rendering succeeded ({len(js_content.split())} words)")
                     return js_content
 
+                # Heaviest fallback: a real headless browser, which can solve
+                # JS bot-challenges (e.g. AWS WAF) the paths above cannot.
+                browser_content = fetch_with_browser(url)
+                if browser_content and len(browser_content.split()) > word_count:
+                    print(f"✅ Browser rendering succeeded ({len(browser_content.split())} words)")
+                    return browser_content
+
             return final_text
 
     except requests.exceptions.HTTPError as e:
@@ -266,6 +273,57 @@ def try_js_rendering(url):
     except Exception as e:
         print(f"⚠️  JS rendering failed: {e}")
         return None
+
+def fetch_with_browser(url):
+    """
+    Render the page in a headless Chromium browser to defeat JavaScript bot
+    challenges (e.g. AWS WAF, Cloudflare) that serve no extractable content to
+    a plain HTTP client. Returns extracted article text, or None on failure.
+
+    This is the heaviest fallback and only runs after the lightweight paths
+    return too little content, so the common case never pays the browser cost.
+    """
+    try:
+        from playwright.sync_api import sync_playwright
+    except ImportError:
+        print("⚠️  playwright not available, skipping browser fallback")
+        return None
+
+    try:
+        with sync_playwright() as pw:
+            browser = pw.chromium.launch(headless=True)
+            try:
+                page = browser.new_page(user_agent=get_user_agent())
+                page.goto(url, wait_until='domcontentloaded', timeout=45000)
+                # Give the challenge script time to solve and reload the page.
+                try:
+                    page.wait_for_load_state('networkidle', timeout=20000)
+                except Exception:
+                    pass
+                page.wait_for_timeout(3000)
+                html = page.content()
+            finally:
+                browser.close()
+    except Exception as e:
+        print(f"⚠️  Browser fallback failed: {e}")
+        return None
+
+    # Prefer readability to strip nav/footer chrome; fall back to raw parsing.
+    try:
+        from readability import Document
+        html = Document(html).summary()
+    except Exception:
+        pass
+
+    soup = BeautifulSoup(html, 'html.parser')
+    for junk in soup(["script", "style", "meta", "noscript"]):
+        junk.decompose()
+    paragraphs = [
+        el.get_text(strip=True)
+        for el in soup.find_all(['p', 'h1', 'h2', 'h3', 'h4', 'li', 'blockquote'])
+        if len(el.get_text(strip=True)) > 20
+    ]
+    return '\n\n'.join(paragraphs) or None
 
 def save_cti_content_to_file(content, issue_number):
     """
@@ -345,6 +403,17 @@ def main():
     # Download the full content
     print("Downloading CTI content from URL...")
     content = get_cti_content(cti_url)
+
+    # An empty / near-empty result is a failure, not a 0-char "success": a JS
+    # bot-challenge (e.g. AWS WAF) can return no extractable text without raising
+    # an HTTP error. Route it to the failure path so the submitter is asked to
+    # paste the content instead of seeing a misleading download confirmation.
+    if content and not content.startswith("Error") and len(content.strip()) < 50:
+        content = (
+            "Error: The page returned no extractable text. This usually means the "
+            "site is behind a JavaScript bot-challenge (e.g. AWS WAF or Cloudflare) "
+            "that automated fetching could not pass."
+        )
 
     # Check if content starts with "Error:" (our error messages, not content containing the word "error")
     if content.startswith("Error"):

--- a/.github/workflows/issue-generate-hunts.yml
+++ b/.github/workflows/issue-generate-hunts.yml
@@ -83,6 +83,9 @@ jobs:
           python -m pip install --upgrade pip
           pip install -r requirements.txt
 
+      - name: "Install Playwright browser"
+        run: python -m playwright install --with-deps chromium
+
       - name: "Download MITRE ATT&CK data"
         run: |
           mkdir -p data

--- a/.github/workflows/process-cti-issue.yml
+++ b/.github/workflows/process-cti-issue.yml
@@ -25,6 +25,9 @@ jobs:
           python -m pip install --upgrade pip
           pip install -r requirements.txt
 
+      - name: "Install Playwright browser"
+        run: python -m playwright install --with-deps chromium
+
       - name: Process CTI link
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,6 +12,8 @@ brotli>=1.1.0
 zstandard>=0.22.0
 readability-lxml>=0.8.0
 lxml>=5.0.0
+# Headless-browser fallback for JS bot-challenged sources (needs: playwright install chromium)
+playwright>=1.40.0
 
 # Document Processing
 pypdf>=4.0.0


### PR DESCRIPTION
## Problem
Some CTI sources sit behind a **JavaScript bot-challenge** (e.g. Wordfence → AWS WAF). A plain `requests` client gets an **HTTP 202** + a 2.3 KB *"enable JavaScript"* interstitial instead of the article — **0 extractable characters**. Worse, `raise_for_status()` doesn't treat 202 as an error, so the submission was stamped *"✅ Content successfully downloaded — 0 characters"* (e.g. #299).

## Change
1. **`fetch_with_browser()`** in `process_issue.py` — a headless **Chromium (Playwright)** fetch that runs the challenge JS, gets the `aws-waf-token`, and returns the rendered article (readability-cleaned, raw-parse fallback).
2. It's invoked **only as the last resort** inside `get_cti_content()`'s existing `word_count < 100` branch — *after* `requests` and the lightweight readability path. **The common case never launches a browser.**
3. **Empty ≠ success:** a near-empty result is now routed to the failure path (asks the submitter to paste content) instead of a misleading 0-char "download".
4. Wires `playwright` into `requirements.txt` and adds `playwright install --with-deps chromium` to both CTI workflows.

## Verification (local, real Wordfence URL)
The URL that gave #299 **0 chars** now escalates correctly:
```
requests → 2275-byte challenge (0 words)
  → JS rendering failed
  → ✅ Browser rendering succeeded (1398 words)
get_cti_content() → 10,641 chars, starts_with_Error: False
```
Clean article recovered: *"On March 30th, 2026, we publicly disclosed a Sensitive Information Exposure vulnerability in Gravity SMTP…"*

Also passes the new `python-checks` guard (`E9,F63,F7,F82`).

## Cost / tradeoffs
- Chromium install adds ~1 min to a CTI workflow run, but the browser **only launches when a fetch is actually challenged** — normal sources (e.g. Elastic/#300) never trigger it.
- Follow-up (out of scope): there's a pre-existing `readability-lxml`/`lxml` incompatibility (`cannot use a string pattern on a bytes-like object`) that also breaks the existing `try_js_rendering`. This PR's fallback tolerates it (raw-parse), but it's worth fixing separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)