### PR TITLE
fix(cti): don't treat the auto-download stub as manually-pasted content

### DIFF
--- a/.github/workflows/issue-generate-hunts.yml
+++ b/.github/workflows/issue-generate-hunts.yml
@@ -137,7 +137,8 @@ jobs:
           if grep -q "### CTI Content" /tmp/issue_body.txt; then
             # Check if it's not the placeholder or error message
             if ! grep -q "This will be processed automatically by our system" /tmp/issue_body.txt && \
-               ! grep -q "Failed to retrieve or process content" /tmp/issue_body.txt; then
+               ! grep -q "Failed to retrieve or process content" /tmp/issue_body.txt && \
+               ! grep -q "Content successfully downloaded" /tmp/issue_body.txt; then
               has_manual_content="true"
             fi
           fi


### PR DESCRIPTION
## Problem
Re-triggering #299 still drafted an empty hunt **even with the browser fallback merged** — because the fetcher was never called. CI showed `has_manual_content="true"`, so the workflow used the issue body as "pasted content" and skipped the source re-fetch entirely.

Root cause: the manual-content check treats *any* `### CTI Content` section that isn't the placeholder/explicit-failure text as real pasted content. But a previously-failed auto-download leaves a **`✅ Content successfully downloaded … 0 characters`** stub in the body — which got mistaken for content. Every outage victim hits this on resubmission.

## Fix
Add the bot's own stub marker to the exclusion list:
```bash
&& ! grep -q "Content successfully downloaded" /tmp/issue_body.txt
```
Now a stale/empty auto-download stub → `has_manual_content=false` → the workflow falls through to a fresh **source-URL fetch**, where the new headless-browser fallback (#309) can defeat the JS challenge.

## Bonus
This also fixes a quieter quality issue: the body's CTI Content section is only a **truncated 500-char preview**, so submissions that *did* auto-download were drafting from 500 chars, not the full article. Falling through to a real re-fetch means the generator now sees the **full** text.

## Preserved
Genuine human-pasted submissions (no bot stub in the body) still set `has_manual_content=true` and use the pasted text — that path is unchanged.

## Validation plan
Merge → re-trigger #299 → expect `has_manual_content=false` → fetcher runs → `✅ Browser rendering succeeded` → real Gravity-SMTP draft credited to `kkroth0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)