### PR TITLE
fix(hunts): dedupe hunt IDs against in-flight drafts, not just main

### DIFF
--- a/.github/workflows/pr-from-approval.yml
+++ b/.github/workflows/pr-from-approval.yml
@@ -7,6 +7,9 @@ on:
 jobs:
   create_pr:
     if: github.event.label.name == 'approved'
+    concurrency:
+      group: hunt-id-reassign
+      cancel-in-progress: false
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -27,8 +30,10 @@ jobs:
       - name: "Fetch main"
         run: git fetch origin main
 
-      - name: "Reassign hunt ID if it collides with main"
+      - name: "Reassign hunt ID if it collides with main or another draft"
         id: reassign
+        env:
+          ISSUE_NUMBER: ${{ github.event.issue.number }}
         run: python scripts/reassign_hunt_id.py
 
       - name: "Commit and push reassigned hunt ID"

--- a/scripts/reassign_hunt_id.py
+++ b/scripts/reassign_hunt_id.py
@@ -1,18 +1,26 @@
 #!/usr/bin/env python3
-"""Reassign a draft hunt's ID if it collides with an ID already on ``main``.
+"""Reassign a draft hunt's ID if it collides with one already taken.
 
-Run on a checked-out draft branch with ``origin/main`` fetched. For each hunt
-file the branch ADDS under ``Flames/`` whose ``HNNN`` number already
-exists on main, rename it to the next free number (rewriting the heading and
-any populated Hunt# cell), and stage the rename.
+Run on a checked-out draft branch with ``origin/main`` fetched. A draft's ID
+collides if the same ``HNNN`` number is already on ``main`` OR is claimed by
+another open ``draft/issue-*`` branch belonging to a lower-numbered issue
+(lower issue == earlier submission == priority). Colliding files are renamed to
+the next free number — considering main and every other draft branch — and the
+rename is staged.
 
-Emits ``changed`` and ``hunt_id`` to ``$GITHUB_OUTPUT``. Always exits 0 — no
-collision is a no-op.
+Tiebreak by issue number makes a batch of approvals collision-free regardless
+of the order they run in: the earliest issue keeps the contested number and
+each later one yields. The workflow also serialises these jobs (a concurrency
+group) so two reassignments can't read each other's branch mid-flight.
+
+Reads ``ISSUE_NUMBER`` from the environment. Emits ``changed`` and ``hunt_id``
+to ``$GITHUB_OUTPUT``. Always exits 0 — no collision is a no-op.
 """
 
 from __future__ import annotations
 
 import os
+import re
 import subprocess
 import sys
 from pathlib import Path
@@ -30,12 +38,22 @@ from scripts.hunt_ids import (
 )
 
 FLAMES = "Flames"
+_DRAFT_RE = re.compile(r"draft/issue-(\d+)$")
 
 
 def _git(*args: str) -> str:
     return subprocess.run(
         ["git", *args], check=True, capture_output=True, text=True
     ).stdout
+
+
+def _added_numbers(ref: str) -> set[int]:
+    """Hunt numbers a ref ADDS under Flames/ relative to main."""
+    out = _git(
+        "diff", "--diff-filter=A", "--name-only", f"origin/main...{ref}",
+        "--", f"{FLAMES}/",
+    )
+    return existing_numbers(p for p in out.splitlines() if p.endswith(".md"))
 
 
 def _main_numbers() -> set[int]:
@@ -45,14 +63,35 @@ def _main_numbers() -> set[int]:
 
 def _added_files() -> list[Path]:
     out = _git(
-        "diff",
-        "--diff-filter=A",
-        "--name-only",
-        "origin/main...HEAD",
-        "--",
-        f"{FLAMES}/",
+        "diff", "--diff-filter=A", "--name-only", "origin/main...HEAD",
+        "--", f"{FLAMES}/",
     )
     return [Path(p) for p in out.splitlines() if p.endswith(".md")]
+
+
+def _other_draft_claims(current_issue: int) -> dict[int, int]:
+    """Map each hunt number claimed by another open draft branch to the lowest
+    issue number claiming it. Empty/offline is a safe no-op."""
+    subprocess.run(
+        ["git", "fetch", "origin", "refs/heads/draft/*:refs/remotes/origin/draft/*"],
+        check=False, capture_output=True, text=True,
+    )
+    claims: dict[int, int] = {}
+    out = subprocess.run(
+        ["git", "for-each-ref", "--format=%(refname)", "refs/remotes/origin/draft/"],
+        check=False, capture_output=True, text=True,
+    ).stdout
+    for ref in out.splitlines():
+        match = _DRAFT_RE.search(ref)
+        if not match:
+            continue
+        issue = int(match.group(1))
+        if issue == current_issue:
+            continue
+        for num in _added_numbers(ref):
+            if num not in claims or issue < claims[num]:
+                claims[num] = issue
+    return claims
 
 
 def _set_output(changed: bool, hunt_id: str) -> None:
@@ -65,8 +104,17 @@ def _set_output(changed: bool, hunt_id: str) -> None:
 
 
 def main() -> int:
+    current_issue = int(os.environ.get("ISSUE_NUMBER", "0") or "0")
     main_nums = _main_numbers()
-    claimed = set(main_nums)
+    other_claims = _other_draft_claims(current_issue)
+
+    # Must not KEEP a number on main or held by a lower-numbered issue.
+    blocked = set(main_nums) | {
+        num for num, issue in other_claims.items() if issue < current_issue
+    }
+    # When allocating a fresh number, avoid everything known to be claimed.
+    claimed = set(main_nums) | set(other_claims)
+
     changed = False
     final_id = ""
 
@@ -75,17 +123,19 @@ def main() -> int:
         if num is None:
             continue
         final_id = path.stem
-        if num in main_nums:
+        if num in blocked:
             new_num = next_free_number(claimed)
             new_id = format_hunt_id(new_num)
             new_path = rewrite_hunt_id(path, new_id)
             _git("add", "-A", "--", FLAMES)
             claimed.add(new_num)
+            blocked.add(new_num)
             final_id = new_id
             changed = True
-            print(f"Reassigned {path.name} -> {new_path.name} (collided with main)")
+            print(f"Reassigned {path.name} -> {new_path.name} (id already claimed)")
         else:
             claimed.add(num)
+            blocked.add(num)
             print(f"{path.name}: ID free, no change")
 
     if not changed:


### PR DESCRIPTION
## Problem
Approving multiple issues before any of their PRs merged produced **colliding hunt IDs**. `get_next_hunt_id()` assigns `max(main)+1` at draft time, so every draft cut from the same `main` gets the same number — #297, #299, and #300 all drafted as **H210**. The approval-time reassigner (`reassign_hunt_id.py`) only compared against `main`, where H210 didn't exist yet, so it bumped nothing and the second PR to merge hit an add/add conflict on `Flames/H210.md`.

(Seen live: PRs #314 and #315 both added `Flames/H210.md` — already manually split to H210/H211.)

## Fix
1. **`reassign_hunt_id.py`** — a number is "claimed" if it's on `main` **or** held by another open `draft/issue-*` branch. Colliding drafts are renamed to the next free number considering *all* of them. **Tiebreak by issue number**: the earlier submission keeps the contested ID, later ones yield — so a batch of approvals is collision-free regardless of the order the jobs run in.
2. **`pr-from-approval.yml`** — passes `ISSUE_NUMBER` to the script and runs the job under a `concurrency: { group: hunt-id-reassign }` so two reassignments can't read each other's branch mid-flight.

## Verification (local, simulated origin + two H210 drafts)
| Approval order | issue #297 | issue #299 |
|---|---|---|
| 297 → 299 | keeps **H210** | → **H211** |
| 299 → 297 | keeps **H210** | → **H211** |

Order-independent and collision-free. Existing behavior preserved: a draft whose number is already on `main` still gets bumped (the claimed set is a superset of `main`).

## Note
This makes reassignment robust for concurrent approvals. The deeper root cause — IDs assigned optimistically at draft time — remains, but reconciling at approval (now against the full in-flight set, serialized) is sufficient and avoids a heavier merge-queue. Filed alongside the draft-branch-collision issue (#313).

🤖 Generated with [Claude Code](https://claude.com/claude-code)