### PR TITLE
fix(cti): decode HTML to str before readability (fixes #312)

### DIFF
--- a/.github/scripts/process_issue.py
+++ b/.github/scripts/process_issue.py
@@ -7,6 +7,13 @@ import docx
 import io
 from pathlib import Path
 import random
+import sys
+
+_REPO_ROOT = str(Path(__file__).resolve().parent.parent.parent)
+if _REPO_ROOT not in sys.path:
+    sys.path.insert(0, _REPO_ROOT)
+
+from scripts.cti_extract import extract_readable_text
 
 def get_user_agent():
     """
@@ -239,7 +246,6 @@ def try_js_rendering(url):
     This is a lightweight approach that works in GitHub Actions.
     """
     try:
-        from readability import Document
         import urllib.request
 
         # Fetch with a real browser user agent
@@ -251,21 +257,7 @@ def try_js_rendering(url):
         with urllib.request.urlopen(req, timeout=20) as response:
             html = response.read()
 
-        # Use readability to extract main content
-        doc = Document(html)
-        content_html = doc.summary()
-
-        # Parse the cleaned HTML
-        soup = BeautifulSoup(content_html, 'html.parser')
-
-        # Extract text preserving structure
-        paragraphs = []
-        for element in soup.find_all(['p', 'h1', 'h2', 'h3', 'h4', 'li', 'blockquote']):
-            text = element.get_text(strip=True)
-            if text and len(text) > 20:
-                paragraphs.append(text)
-
-        return '\n\n'.join(paragraphs)
+        return extract_readable_text(html)
 
     except ImportError:
         print("⚠️  readability-lxml not available, skipping JS rendering")
@@ -292,22 +284,6 @@ def fetch_with_browser(url, attempts=3, min_words=120):
         print("⚠️  playwright not available, skipping browser fallback")
         return None
 
-    def _extract(html):
-        try:
-            from readability import Document
-            html = Document(html).summary()
-        except Exception:
-            pass
-        soup = BeautifulSoup(html, 'html.parser')
-        for junk in soup(["script", "style", "meta", "noscript"]):
-            junk.decompose()
-        paragraphs = [
-            el.get_text(strip=True)
-            for el in soup.find_all(['p', 'h1', 'h2', 'h3', 'h4', 'li', 'blockquote'])
-            if len(el.get_text(strip=True)) > 20
-        ]
-        return '\n\n'.join(paragraphs)
-
     for attempt in range(1, attempts + 1):
         text = ''
         try:
@@ -324,7 +300,7 @@ def fetch_with_browser(url, attempts=3, min_words=120):
                     # Poll until real content appears; nudge with a reload if stuck.
                     for i in range(15):
                         page.wait_for_timeout(2000)
-                        text = _extract(page.content())
+                        text = extract_readable_text(page.content())
                         if len(text.split()) >= min_words:
                             break
                         if i in (5, 10):

--- a/.github/workflows/validate-hunt-schema.yml
+++ b/.github/workflows/validate-hunt-schema.yml
@@ -8,6 +8,7 @@ on:
       - "Alchemy/**.md"
       - "scripts/hunt_parser.py"
       - "scripts/hunt_schema.py"
+      - "scripts/cti_extract.py"
       - "scripts/tests/**"
   push:
     branches: [main]

--- a/scripts/cti_extract.py
+++ b/scripts/cti_extract.py
@@ -1,0 +1,44 @@
+"""Extract clean article text from raw HTML for the CTI fetch pipeline.
+
+Used by ``.github/scripts/process_issue.py`` to turn a fetched or browser
+rendered page into plain paragraphs for hunt generation. Prefers ``readability``
+to strip nav/footer chrome and falls back to a plain tag sweep when it is
+unavailable or fails.
+"""
+
+from __future__ import annotations
+
+from bs4 import BeautifulSoup
+
+_BLOCK_TAGS = ["p", "h1", "h2", "h3", "h4", "li", "blockquote"]
+
+
+def extract_readable_text(html, min_paragraph_len: int = 20) -> str:
+    """Return article text from ``html`` as blank-line-separated paragraphs.
+
+    Accepts ``str`` or ``bytes``. ``bytes`` is decoded to ``str`` first:
+    passing bytes straight to ``readability`` trips a str/bytes regex crash in
+    its encoding sniffer (``cannot use a string pattern on a bytes-like
+    object``), which silently disabled this extraction path — see issue #312.
+    """
+    if isinstance(html, bytes):
+        html = html.decode("utf-8", errors="ignore")
+
+    # readability isolates the main article; tolerate its absence or failure
+    # and fall back to parsing the page as-is.
+    try:
+        from readability import Document
+
+        html = Document(html).summary()
+    except Exception:
+        pass
+
+    soup = BeautifulSoup(html, "html.parser")
+    for junk in soup(["script", "style", "meta", "noscript"]):
+        junk.decompose()
+    paragraphs = [
+        el.get_text(strip=True)
+        for el in soup.find_all(_BLOCK_TAGS)
+        if len(el.get_text(strip=True)) > min_paragraph_len
+    ]
+    return "\n\n".join(paragraphs)

--- a/scripts/tests/fixtures/cti_article.html
+++ b/scripts/tests/fixtures/cti_article.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html>
+<head><title>Test CTI Report</title></head>
+<body>
+  <nav>
+    <a href="/">Home</a>
+    <a href="/products">Products and Pricing Plans</a>
+    <a href="/login">Sign in to your account dashboard</a>
+  </nav>
+  <article>
+    <h1>Critical Vulnerability in Example Plugin</h1>
+    <p>On March 30th 2026 we disclosed a sensitive information exposure vulnerability
+       affecting an estimated one hundred thousand active installations of the plugin.</p>
+    <p>Attackers send unauthenticated HTTP GET requests to the REST API endpoint to
+       exfiltrate API keys, OAuth tokens, and detailed system configuration data from
+       vulnerable sites running the affected versions.</p>
+    <p>We strongly recommend updating to the patched version immediately and rotating
+       any exposed secrets that may have been disclosed to unauthorized parties.</p>
+  </article>
+  <footer>
+    <p>Copyright 2026 Example Corp. All rights reserved. Contact sales for enterprise
+       support options and managed incident response services today.</p>
+  </footer>
+</body>
+</html>

--- a/scripts/tests/test_cti_extract.py
+++ b/scripts/tests/test_cti_extract.py
@@ -1,0 +1,25 @@
+from scripts.cti_extract import extract_readable_text
+
+
+def test_extracts_article_text(fixtures_dir):
+    html = (fixtures_dir / "cti_article.html").read_text(encoding="utf-8")
+    text = extract_readable_text(html)
+    assert "unauthenticated HTTP GET requests" in text
+    assert "patched version" in text
+
+
+def test_bytes_input_does_not_crash(fixtures_dir):
+    # Regression for #312: passing bytes used to crash readability's encoding
+    # sniffer ("cannot use a string pattern on a bytes-like object"), silently
+    # disabling this extraction path.
+    raw = (fixtures_dir / "cti_article.html").read_bytes()
+    text = extract_readable_text(raw)
+    assert "unauthenticated HTTP GET requests" in text
+    assert text == extract_readable_text(raw.decode("utf-8"))
+
+
+def test_strips_nav_and_footer_chrome(fixtures_dir):
+    html = (fixtures_dir / "cti_article.html").read_text(encoding="utf-8")
+    text = extract_readable_text(html)
+    assert "Sign in to your account dashboard" not in text
+    assert "All rights reserved" not in text


### PR DESCRIPTION
Closes #312.

## Problem
`try_js_rendering()` read raw **bytes** from urllib and passed them to `readability.Document()`. readability's encoding sniffer runs a `str` regex over the input and crashes on bytes:
```
TypeError: cannot use a string pattern on a bytes-like object
```
The exception was swallowed, so the lightweight JS/readability fallback **always returned nothing** — silently dead.

## Fix
- New `scripts/cti_extract.py` with `extract_readable_text(html)` that **decodes bytes → str up front** (the actual fix), then runs readability with a raw-parse fallback.
- Replaces the readability+BeautifulSoup logic that was **duplicated** in `try_js_rendering` and `fetch_with_browser` with this one shared, tested helper.

## Test
`scripts/tests/test_cti_extract.py` + an HTML fixture, covering:
1. **bytes regression** — `extract_readable_text(bytes)` no longer crashes and equals the str result.
2. article text is extracted.
3. nav/footer chrome is stripped (readability working).

Runs in the existing `validate-hunt-schema.yml` pytest job (added `scripts/cti_extract.py` to its trigger paths). Local: **60 passed** (57 + 3 new).

## Verified
- `Document(bytes)` → `Unparseable`; `Document(str)` → OK (reproduced before/after).
- Errors-only flake8 guard clean; no orphaned imports (F401 clean).

🤖 Generated with [Claude Code](https://claude.com/claude-code)