### PR TITLE
fix(ci): force-push fresh draft branches to avoid collisions (fixes #313)

### DIFF
--- a/.github/workflows/issue-generate-hunts.yml
+++ b/.github/workflows/issue-generate-hunts.yml
@@ -321,12 +321,14 @@ jobs:
           git add Flames/*.md
           git commit -m "feat(draft): Update hunt from issue #${{ github.event.issue.number }}"
           git remote set-url origin https://x-access-token:${{ secrets.HEARTH_TOKEN }}@github.com/${{ github.repository }}
-          # Use --set-upstream for the initial push, and force push for subsequent regenerations.
-          # Force push is safe for draft branches since they're meant to be overwritten during regeneration.
+          # Draft branches are disposable: a fresh submission or a regeneration
+          # fully replaces any existing draft for the issue, so force-push in both
+          # cases. Otherwise re-triggering an issue that already has a draft branch
+          # fails with a non-fast-forward push rejection (issue #313).
           if [ "${{ github.event.label.name }}" == "regenerate" ]; then
             git push --force
           else
-            git push --set-upstream origin draft/issue-${{ github.event.issue.number }}
+            git push --force --set-upstream origin draft/issue-${{ github.event.issue.number }}
           fi
 
       - name: "Comment on issue with draft link"


### PR DESCRIPTION
Closes #313.

## Problem
The first-generation draft path pushed with `git push --set-upstream` (no force). If the issue already had a `draft/issue-N` branch (e.g. from a re-trigger), the push was rejected:
```
! [rejected]        draft/issue-299 -> draft/issue-299 (non-fast-forward)
```
The draft generated correctly but never landed; the manual workaround was `git push origin --delete draft/issue-N` first. (Hit repeatedly while recovering #299.)

## Fix
Force-push in **both** the fresh and `regenerate` paths — the `regenerate` path already does. Draft branches are disposable, and a fresh submission is meant to replace any existing draft for that issue.

```diff
-          git push --set-upstream origin draft/issue-${{ github.event.issue.number }}
+          git push --force --set-upstream origin draft/issue-${{ github.event.issue.number }}
```

One-line change plus a clarified comment. Validation is the next re-trigger of an already-drafted issue (this workflow only runs on issue events, so PR CI doesn't exercise it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)