### PR TITLE
fix(ci): catch in-place hunt overwrites in collision check (#325)

### DIFF
--- a/scripts/check_hunt_id_collisions.py
+++ b/scripts/check_hunt_id_collisions.py
@@ -3,8 +3,10 @@
 
 Run on a PR with the head checked out and ``origin/main`` fetched. Detects:
   1. a hunt file ADDED by the PR whose ID already exists on main,
-  2. an added file whose ``# <id>`` heading disagrees with its filename,
-  3. two files in the working tree sharing an ID.
+  2. an added or modified file whose declared ID disagrees with its filename,
+  3. a hunt file MODIFIED in place whose submitter changed — i.e. one
+     contributor's hunt overwritten by a different hunt under the same ID,
+  4. two files in the working tree sharing an ID.
 
 Exits 1 (printing each problem) on any collision, else 0.
 """
@@ -19,7 +21,10 @@ _REPO_ROOT = str(Path(__file__).resolve().parent.parent)
 if _REPO_ROOT not in sys.path:
     sys.path.insert(0, _REPO_ROOT)
 
+import frontmatter
+
 from scripts.hunt_ids import find_id_problems
+from scripts.hunt_parser import _parse_legacy_table
 
 DIRS = ("Flames", "Embers", "Alchemy")
 
@@ -30,12 +35,46 @@ def _git(*args: str) -> str:
     ).stdout
 
 
-def _heading_id(path: Path) -> str | None:
+def extract_identity(text: str, stem: str) -> tuple[str | None, str | None]:
+    """Best-effort ``(declared_id, submitter_name)`` for a hunt file's text.
+
+    Handles both the canonical frontmatter format and the legacy table format,
+    so a frontmatter PR can be compared against a legacy version on ``main``.
+    The declared ID is the frontmatter ``id`` (or the line-1 ``# <id>`` heading
+    for legacy hunts). Never raises — unreadable fields come back as ``None``.
+    """
     try:
-        first = path.read_text(encoding="utf-8").split("\n", 1)[0].strip()
-    except OSError:
-        return None
-    return first[2:].strip() if first.startswith("# ") else None
+        post = frontmatter.loads(text)
+    except Exception:
+        post = None
+
+    if post is not None and post.metadata:
+        declared = post.metadata.get("id")
+        submitter = post.metadata.get("submitter")
+        name = submitter.get("name") if isinstance(submitter, dict) else submitter
+        return (
+            str(declared).strip() if declared else None,
+            str(name).strip() if name else None,
+        )
+
+    # Legacy table format (or no frontmatter): line-1 heading + table submitter.
+    first = text.split("\n", 1)[0].strip()
+    declared = first[2:].strip() if first.startswith("# ") else None
+    name: str | None = None
+    try:
+        name = _parse_legacy_table(text, hunt_id=stem, category="")["submitter"][
+            "name"
+        ].strip()
+    except Exception:
+        name = None
+    return (declared, name or None)
+
+
+def _show_main(path: str) -> str:
+    try:
+        return _git("show", f"origin/main:{path}")
+    except subprocess.CalledProcessError:
+        return ""
 
 
 def main() -> int:
@@ -43,14 +82,27 @@ def main() -> int:
         "diff", "--diff-filter=A", "--name-only", "origin/main...HEAD", "--", *DIRS
     )
     added_paths = [Path(p) for p in added_out.splitlines() if p.endswith(".md")]
-    added = [(p.stem, _heading_id(p)) for p in added_paths]
+    added = [
+        (p.stem, extract_identity(p.read_text(encoding="utf-8"), p.stem)[0])
+        for p in added_paths
+    ]
+
+    modified_out = _git(
+        "diff", "--diff-filter=M", "--name-only", "origin/main...HEAD", "--", *DIRS
+    )
+    modified_paths = [Path(p) for p in modified_out.splitlines() if p.endswith(".md")]
+    modified: list[tuple[str, str | None, str | None, str | None]] = []
+    for p in modified_paths:
+        pr_id, pr_submitter = extract_identity(p.read_text(encoding="utf-8"), p.stem)
+        _, main_submitter = extract_identity(_show_main(p.as_posix()), p.stem)
+        modified.append((p.stem, pr_id, pr_submitter, main_submitter))
 
     main_out = _git("ls-tree", "-r", "--name-only", "origin/main", "--", *DIRS)
     main_ids = {Path(p).stem for p in main_out.splitlines() if p.endswith(".md")}
 
     all_stems = [p.stem for d in DIRS for p in Path(d).glob("*.md")]
 
-    problems = find_id_problems(added, main_ids, all_stems)
+    problems = find_id_problems(added, main_ids, all_stems, modified)
     if problems:
         print("Hunt ID collision check FAILED:")
         for problem in problems:

--- a/scripts/hunt_ids.py
+++ b/scripts/hunt_ids.py
@@ -70,25 +70,55 @@ def rewrite_hunt_id(path: Path, new_id: str) -> Path:
     return new_path
 
 
+def _norm_submitter(name: str | None) -> str:
+    """Case/space-insensitive submitter name for identity comparison."""
+    return re.sub(r"\s+", " ", (name or "").strip()).casefold()
+
+
 def find_id_problems(
     added: list[tuple[str, str | None]],
     main_ids: set[str],
     all_stems: list[str],
+    modified: list[tuple[str, str | None, str | None, str | None]] | None = None,
 ) -> list[str]:
     """Return human-readable collision problems for a PR (empty list = clean).
 
-    ``added`` is ``[(stem, heading_id), ...]`` for hunt files the PR adds.
+    ``added`` is ``[(stem, declared_id), ...]`` for hunt files the PR adds, where
+    ``declared_id`` is the file's frontmatter ``id`` (or line-1 heading for legacy
+    hunts), or None if none is present.
+
+    ``modified`` is ``[(stem, declared_id, pr_submitter, main_submitter), ...]``
+    for hunt files the PR changes in place. A modified hunt whose submitter no
+    longer matches the version on ``main`` is overwriting a different
+    contributor's hunt under the same ID — it should get a new ID instead.
+
     ``main_ids`` is the set of hunt stems already on ``main``.
     ``all_stems`` is every hunt stem in the working tree (for duplicate detection).
     """
     problems: list[str] = []
 
-    for stem, heading_id in added:
+    for stem, declared_id in added:
         if stem in main_ids:
             problems.append(f"{stem}.md: hunt ID '{stem}' already exists on main")
-        if heading_id is not None and heading_id != stem:
+        if declared_id is not None and declared_id != stem:
             problems.append(
-                f"{stem}.md: heading ID '{heading_id}' does not match filename '{stem}'"
+                f"{stem}.md: declared ID '{declared_id}' does not match filename '{stem}'"
+            )
+
+    for stem, declared_id, pr_submitter, main_submitter in modified or []:
+        if declared_id is not None and declared_id != stem:
+            problems.append(
+                f"{stem}.md: declared ID '{declared_id}' does not match filename '{stem}'"
+            )
+        if (
+            pr_submitter
+            and main_submitter
+            and _norm_submitter(pr_submitter) != _norm_submitter(main_submitter)
+        ):
+            problems.append(
+                f"{stem}.md: modifies an existing hunt in place but changes its "
+                f"submitter ('{main_submitter}' -> '{pr_submitter}'), which overwrites "
+                f"a different contributor's hunt under the same ID; reassign a new ID instead"
             )
 
     seen: set[str] = set()

--- a/scripts/tests/test_check_hunt_id_collisions.py
+++ b/scripts/tests/test_check_hunt_id_collisions.py
@@ -1,0 +1,64 @@
+"""Tests for identity extraction used by the hunt-ID collision check."""
+
+from scripts.check_hunt_id_collisions import extract_identity
+
+# The original H210 as it lived on main: legacy table format, submitter th3CyF0x.
+LEGACY_H210 = """# H210
+
+Threat actors are using PowerShell's `Add-Type` cmdlet ...
+
+| Hunt # | Idea / Hypothesis | Tactic | Notes | Tags | Submitter |
+|--------|---|---|---|---|---|
+|  | Threat actors are using PowerShell's `Add-Type` cmdlet ... | Execution | Based on ATT&CK technique T1059.001. | #execution #powershell | [th3CyF0x](https://x.com/th3cyf0x) |
+
+## Why
+- reasons
+"""
+
+# The overwrite from PR #320: frontmatter format, different submitter/hunt.
+FRONTMATTER_H210_OVERWRITE = """---
+id: H210
+category: Flames
+title: Windchill login JSP web shell followed by application-server command execution
+hypothesis: An adversary exploits PTC Windchill ...
+tactics:
+  - Initial Access
+tags:
+  - windchill
+submitter:
+  name: Joshua Strickland
+  link: https://novasky.io
+---
+# H210
+
+CISA added CVE-2026-12569 ...
+
+## Why
+- reasons
+"""
+
+
+def test_extract_identity_legacy_table():
+    declared, submitter = extract_identity(LEGACY_H210, "H210")
+    assert declared == "H210"
+    assert submitter == "th3CyF0x"
+
+
+def test_extract_identity_frontmatter():
+    declared, submitter = extract_identity(FRONTMATTER_H210_OVERWRITE, "H210")
+    assert declared == "H210"
+    assert submitter == "Joshua Strickland"
+
+
+def test_extract_identity_detects_320_overwrite():
+    # Same declared ID + filename, but the submitter differs across versions —
+    # exactly the signal that caught nothing before this fix.
+    _, pr_submitter = extract_identity(FRONTMATTER_H210_OVERWRITE, "H210")
+    _, main_submitter = extract_identity(LEGACY_H210, "H210")
+    assert pr_submitter != main_submitter
+
+
+def test_extract_identity_handles_garbage():
+    declared, submitter = extract_identity("not a hunt file", "H999")
+    assert declared is None
+    assert submitter is None

--- a/scripts/tests/test_hunt_ids.py
+++ b/scripts/tests/test_hunt_ids.py
@@ -90,3 +90,48 @@ def test_find_id_problems_heading_mismatch():
 def test_find_id_problems_duplicate_in_tree():
     problems = find_id_problems([], main_ids=set(), all_stems=["H200", "H200"])
     assert any("duplicate" in p.lower() for p in problems)
+
+
+def test_find_id_problems_flags_modified_hunt_overwrite():
+    # Regression for #320: H210.md kept its ID but was overwritten with a
+    # different contributor's hunt. The submitter change is the tell.
+    modified = [("H210", "H210", "Joshua Strickland", "th3CyF0x")]
+    problems = find_id_problems(
+        [], main_ids={"H210"}, all_stems=["H210"], modified=modified
+    )
+    assert any("submitter" in p.lower() for p in problems)
+
+
+def test_find_id_problems_allows_same_submitter_edit():
+    # A contributor editing their own hunt in place is fine.
+    modified = [("H210", "H210", "th3CyF0x", "th3CyF0x")]
+    problems = find_id_problems(
+        [], main_ids={"H210"}, all_stems=["H210"], modified=modified
+    )
+    assert problems == []
+
+
+def test_find_id_problems_submitter_compare_is_normalized():
+    # Whitespace/case differences are not an identity change.
+    modified = [("H210", "H210", "  th3CyF0x  ", "th3cyf0x")]
+    problems = find_id_problems(
+        [], main_ids={"H210"}, all_stems=["H210"], modified=modified
+    )
+    assert problems == []
+
+
+def test_find_id_problems_flags_modified_id_filename_mismatch():
+    modified = [("H210", "H999", "same", "same")]
+    problems = find_id_problems(
+        [], main_ids={"H210"}, all_stems=["H210"], modified=modified
+    )
+    assert any("does not match filename" in p for p in problems)
+
+
+def test_find_id_problems_skips_identity_when_submitter_unknown():
+    # If either side's submitter can't be determined, don't guess.
+    modified = [("H210", "H210", "New Person", None)]
+    problems = find_id_problems(
+        [], main_ids={"H210"}, all_stems=["H210"], modified=modified
+    )
+    assert problems == []


### PR DESCRIPTION
Closes #325.

## Problem

`scripts/check_hunt_id_collisions.py` only inspected files a PR **adds** (`--diff-filter=A`). A PR that **modifies** an existing hunt file in place — keeping the filename/ID but replacing it with a different contributor's hunt — sailed through CI. This is how **PR #320** nearly clobbered `H210` (th3CyF0x's ClickFix hunt) with an unrelated Windchill hunt: the filename stayed `H210.md`, the frontmatter `id` still said `H210`, so nothing flagged it.

## Fix

Extend the check to also inspect **modified** hunt files under `Flames|Embers|Alchemy`:

1. **Declared ID must match filename** for added *and* modified files (frontmatter `id`, or the line-1 `# <id>` heading for legacy hunts). This also closes the gap where an *added* frontmatter hunt's `id` was never validated against its filename.
2. **Submitter-change guard** — if a modified hunt's `submitter` differs from the version on `origin/main`, it's overwriting a different contributor's hunt under the same ID → fail with a message telling the author to reassign a new ID.

`extract_identity()` normalizes **both** the canonical frontmatter format and the legacy table format, so a frontmatter PR can be compared against a legacy version on `main` — the exact #320 shape (legacy H210 → frontmatter overwrite). Submitter comparison is case/whitespace-normalized, and the guard is skipped when either side's submitter can't be determined (no guessing).

## Why the submitter signal

A contributor editing their **own** hunt keeps their submitter — those edits pass. Dropping a **different** hunt onto an existing ID changes the submitter. That's the highest-precision tell, and it's what distinguishes #320 (th3CyF0x → Joshua Strickland) from a legitimate edit. ID/title alone would false-positive on ordinary title tweaks.

## Verification

- **New unit tests** (`test_hunt_ids.py`, `test_check_hunt_id_collisions.py`): the #320 overwrite is flagged; same-submitter edits pass; normalized submitter differences pass; ID/filename mismatch on a modified file fails; identity extraction works across frontmatter and legacy formats; unknown submitter is skipped.
- **End-to-end against the real CLI** (simulated commits, `origin/main...HEAD`):
  - Overwrite `H210` in place with a different submitter → `FAILED … changes its submitter ('th3CyF0x' -> 'Joshua Strickland')`, exit 1. ✅
  - Same-submitter edit (even legacy→frontmatter migration) → `check passed`, exit 0. ✅
- Full test suite green (68 passed; one unrelated pre-existing `test_cti_extract` failure that also fails on `main`).
- `flake8 --select=E9,F63,F7,F82` clean.

## Acceptance criteria (from #325)

- [x] CI fails when a PR modifies an existing `Flames/HNNN.md` such that it represents a different hunt (submitter change).
- [x] Declared `id` must match the filename stem for added **and** modified hunt files.
- [x] Regression test reproduces the #320 scenario.

🤖 Generated with [Claude Code](https://claude.com/claude-code)