### PR TITLE
fix(ci): stop concurrent-push and superseded-deploy failures on rapid merges

### DIFF
--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -21,11 +21,15 @@ permissions:
   pages: write
   id-token: write
 
-# Allow only one concurrent deployment, skipping runs queued between the run in-progress and latest queued.
-# However, do NOT cancel in-progress runs as we want to allow these production deployments to complete.
+# Allow only one concurrent deployment. When rapid back-to-back merges to main
+# each trigger a deploy, GitHub Pages supersedes the older deployment, which
+# otherwise surfaces as a red "Deployment failed, try again later" on the
+# earlier run. Cancelling in-progress runs is safe here because a Pages deploy
+# is atomic (the newer run always rebuilds from HEAD and fully replaces the
+# site), so the superseded run cancels cleanly instead of failing.
 concurrency:
   group: "pages"
-  cancel-in-progress: false
+  cancel-in-progress: true
 
 jobs:
   # Single deploy job since we're just deploying

--- a/.github/workflows/update-hunts.yml
+++ b/.github/workflows/update-hunts.yml
@@ -9,6 +9,13 @@ on:
       - "Embers/**.md"
       - "Alchemy/**.md"
 
+# Serialize runs of this workflow so two rebuilds never race each other on the
+# same generated files. Don't cancel in-progress runs — each carries a real data
+# commit we want to land.
+concurrency:
+  group: update-hunts-data
+  cancel-in-progress: false
+
 jobs:
   update-data:
     runs-on: ubuntu-latest
@@ -37,9 +44,22 @@ jobs:
           git config --global user.email 'github-actions[bot]@users.noreply.github.com'
           git add hunts-data.js public/hunts-data.json public/actor-mentions.json
           # Commit only if there are changes
-          if ! git diff --staged --quiet; then
-            git commit -m "chore: Auto-update hunt database"
-            git push
-          else
+          if git diff --staged --quiet; then
             echo "No changes to commit."
+            exit 0
           fi
+          git commit -m "chore: Auto-update hunt database"
+          # Retry with rebase: the sibling update-hunt-database job (pushes
+          # database/hunts.db) or a rapid second merge can land on main between
+          # checkout and push, causing a non-fast-forward rejection. Those touch
+          # different files, so a rebase reconciles cleanly.
+          for attempt in 1 2 3 4 5; do
+            if git push; then
+              exit 0
+            fi
+            echo "Push failed (attempt $attempt), rebasing on origin/main and retrying..."
+            git pull --rebase origin main
+            sleep 2
+          done
+          echo "::error::Failed to push hunt data after 5 attempts"
+          exit 1


### PR DESCRIPTION
## Problem

Merging #320 and #323 seconds apart produced two red CI runs on `aef9f89` (the #320 merge), even though the content was fine and `main` self-healed on the next commit. Both were races between push-triggered workflows:

| Failed job | Root cause (from logs) |
|---|---|
| `update-hunts.yml` → `update-data` | `! [rejected] main -> main (non-fast-forward)` — a bare `git push` with **no retry**. The sibling `update-hunt-database.yml` (which commits `database/hunts.db`) or the second merge landed on main between checkout and push. |
| `static.yml` → `deploy` | `Deployment failed, try again later` — GitHub Pages superseded the older deployment. The workflow serialized on the `pages` group but with `cancel-in-progress: false`, so the superseded run **failed red** instead of cancelling. |

## Fix

**`update-hunts.yml`**
- Add a `concurrency` group (`update-hunts-data`) so two rebuilds never race each other on the same generated files.
- Replace the bare `git push` with a **rebase-retry loop** (5 attempts). The sibling `update-hunt-database.yml` job touches a disjoint file (`database/hunts.db`), so a `git pull --rebase` reconciles the ref race cleanly. This mirrors the pattern already proven in `update-hunt-database.yml`, which succeeded on the same double-merge.

**`static.yml`**
- Flip `cancel-in-progress: false` → `true`. A Pages deploy is atomic and the newer run always rebuilds from `HEAD` and fully replaces the site, so a superseded run should **cancel cleanly** (grey) rather than fail (red). Updated the comment to explain the reasoning.

## Verification

- Both files validated as YAML.
- The push-retry shell was exercised locally under `bash -e` (Actions' default shell): fail-twice → succeeds on attempt 3 (exit 0); always-fail → exit 1 after 5 attempts. `set -e` does not abort on a failed `git push` because it sits in an `if` condition.

## Notes / call-outs

- **`static.yml` behavior change:** the existing comment explicitly said *don't* cancel in-progress deploys. That's GitHub's boilerplate from the Pages starter workflow; for a static site the tradeoff it warns about (interrupting a partially-applied production rollout) doesn't apply — Pages deploys are atomic. If you'd rather keep `false` and just tolerate the occasional red X, revert that one hunk; the `update-hunts.yml` fix stands on its own.
- These failures were **cosmetic** — `main` was never broken. This just removes the recurring red X on rapid back-to-back merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)