### PR TITLE
Add Alchemy M026: alert triage / false-positive reduction (model-assisted)

### DIFF
--- a/Alchemy/M026.md
+++ b/Alchemy/M026.md
@@ -1,0 +1,33 @@
+---
+category: Alchemy
+id: M026
+hypothesis: "A machine learning model can predict which SOC alerts an analyst will grade a true positive — from the alert's CONTEXT at triage time (its ATT&CK tactic/technique, the entity type it fired on, its evidence role, the detector that raised it) — well enough to safely de-prioritise the benign and false positives that drive alert fatigue. The naive triage shortcut, trusting the alert's own suspicion flag, barely beats the base rate because most true positives never carry one; the separating signal is the surrounding context, learned across many graded alerts. Two rules keep it honest rather than a leak: the model must use ONLY fields known when the alert fires (never the resolution verdict or the remediation action, which are outcomes), and it must be evaluated with an incident-grouped split, since alerts of one incident share a grade."
+notes: "ALCHEMY ANALYTIC — supervised alert triage / false-positive reduction (detection-operations, cross-tactic). Platform: SOC / SIEM / XDR alert pipeline. PROBLEM: analysts trge far more alerts than are real; blanket rules (escalate all High, trust the detector's suspicion flag) either bury the team or miss true positives. DATA SOURCES: graded alert/incident records — Microsoft GUIDE (13.7M evidence rows, 1M+ alerts, 6k orgs, real analyst IncidentGrade), Sentinel/Defender incidents with analyst disposition, any SOAR case store with closure codes. REQUIRED FIELDS (alert-time only): alert category/tactic, MITRE technique, entity type, evidence role, detector id, suspicion level, timestamp, incident id (for grouping), and the analyst grade (TruePositive / BenignPositive / FalsePositive) as the label. FEATURE ENGINEERING: low-cardinality categoricals (category, entity type, evidence role, suspicion level) as native categoricals; high-cardinality identifiers (technique, detector) frequency-encoded (label-independent, no leak). MODEL: gradient-boosted trees (or similar) predicting P(TruePositive). NAIVE FOIL: escalate iff suspicion_level is set — provably weak (sparse, most TPs unflagged). LEAKAGE GUARD: exclude last_verdict / action_grouped (resolution + remediation are outcomes); score with GroupKFold on incident so no incident spans train and test. VALIDATION (Microsoft GUIDE): incident-grouped precision ~0.84, recall ~0.70, PR-AUC ~0.85, versus the suspicion foil at ~0.23 precision. TUNING: pick the escalation threshold for the recall you can afford; monitor drift per detector/category; retrain as detections change. CROSS-REF: complements every detection hunt — this one triages their output rather than raising new detections."
+submitter:
+  name: Lauren Proehl
+  link: https://x.com/jotunvillur
+tactics:
+  - Multiple
+tags:
+  - alert_triage
+  - false_positive_reduction
+  - detection_engineering
+  - soc_operations
+  - model_assisted
+  - supervised
+  - machinelearning
+---
+
+## Why
+
+- **Alert fatigue is the attacker's ally.** A SOC that can't keep up with benign and false positives misses the real one in the pile. A model that predicts the analyst's own grade from context lets the team spend attention where it pays off — de-prioritising the noise without a human reading every alert first.
+- **The suspicion flag is not the signal.** Trusting an alert's own suspicion level (or a blanket severity rule) barely beats guessing — most true positives never carry the flag. What separates true from benign/false positives is the surrounding context: which tactic and technique fired, on what kind of entity, from which detector. That's exactly what a model can learn across many graded alerts and a rule can't hand-code.
+- **Honest by construction, or it's a leak.** The temptation is to train on fields that already contain the answer — the resolution verdict, the remediation taken. Those are outcomes, not triage-time inputs; using them inflates the score and fails in production. Likewise, alerts of one incident share a grade, so a random train/test split leaks — evaluation must group by incident. Get both right and the result holds up (validated on Microsoft GUIDE's real analyst grades).
+- **It complements detection hunts rather than competing.** Every other Alchemy hunt raises detections; this one triages the alert stream they and everything else produce. It's the model-assisted layer between detection and the analyst.
+
+## References
+
+- [Microsoft GUIDE dataset — a benchmark for evaluating SOC alert triage (arXiv 2407.09017)](https://arxiv.org/abs/2407.09017)
+- [MITRE ATT&CK](https://attack.mitre.org/)
+- [Alert fatigue in security operations (SANS)](https://www.sans.org/blog/)
+- [scikit-learn — Histogram-based Gradient Boosting with native categorical support](https://scikit-learn.org/stable/modules/ensemble.html#histogram-based-gradient-boosting)


### PR DESCRIPTION
## M026 — Alert triage / false-positive reduction

Adds a new Alchemy hypothesis for **model-assisted alert triage** — a detection-*operations* hunt (cross-tactic) rather than a single-technique detection. It predicts which SOC alerts an analyst will grade **TruePositive** from the alert's context at triage time, so benign/false positives can be de-prioritised — the alert-fatigue problem.

**The idea:** the naive shortcut (trust the alert's own suspicion flag) barely beats the base rate, because most true positives never carry one. The separating signal is *context* — which tactic/technique fired, on what entity, from which detector — learned across many graded alerts.

**Honest by construction, or it's a leak:**
- **No outcome features** — never train on the resolution verdict or the remediation action (those are the answer); use only fields known when the alert fires.
- **Incident-grouped evaluation** — alerts of one incident share a grade, so a random split leaks.

**Grounded in real data (Microsoft GUIDE, arXiv 2407.09017):** incident-grouped precision **~0.84**, recall **~0.70**, PR-AUC **~0.85**, versus the naive suspicion foil at **~0.23** precision.

Format mirrors the existing Alchemy entries (M024/M025). Complements the detection hunts rather than competing — it triages the alert stream they produce.