### PR TITLE
Add H221: ClickFix PowerShell staging into ResiLoader and StealC

### DIFF
--- a/Flames/H221.md
+++ b/Flames/H221.md
@@ -1,0 +1,63 @@
+---
+id: H221
+category: Flames
+title: ClickFix PowerShell staging into ResiLoader and StealC
+hypothesis: >-
+  An adversary uses a ClickFix page to make a user run PowerShell, stage payloads under ProgramData, impair security tools with ResiLoader, and hollow a trusted process to run StealC.
+tactics:
+  - Execution
+  - Persistence
+  - Stealth
+  - Defense Impairment
+  - Credential Access
+  - Command and Control
+techniques:
+  - T1059.001
+  - T1105
+  - T1574.002
+  - T1547.001
+  - T1055
+  - T1562.001
+  - T1555.003
+tags:
+  - clickfix
+  - powershell
+  - resiloader
+  - stealc
+  - byovd
+  - process_hollowing
+submitter:
+  name: Joshua Strickland
+  link: https://novasky.io
+required_data_sources:
+  - Endpoint process telemetry
+  - Endpoint file telemetry
+  - Endpoint registry telemetry
+  - Endpoint module and driver load telemetry
+  - Endpoint network telemetry
+  - Windows security events
+false_positive_notes: |
+  PowerShell download cradles and ProgramData writes can show up in legitimate admin work, software deployment, and developer activity. Keep the alert focused on the chain: copied PowerShell with iex and irm, ProgramData Zooms or tmp ps1 staging, ResiLoader artifacts, pcdhost.sys driver activity, fake Google Update Run key persistence, and ServiceModelReg.exe hollowing or StealC behavior. Suppress managed deployment activity only when the parent tool, signer, install path, and absence of security process tamper all line up.
+notes: |
+  Endpoint process telemetry - Core filter: user shell or browser lineage that runs `powershell.exe` with `iex`, `irm`, `iwr`, `wget`, or `curl`. Triage values: `process command line`, `parent process command line`, `user`, `file path`. Pivot: creation of `C:\ProgramData\Zooms`, `tmp*.tmp.ps1`, or payload retrieval over HTTP ports `6600`, `9900`, `5506`, `7895`, `7493`, `149`, or `8442`. Strong red flags: PowerShell started from a paste or Run dialog pattern with no admin tool parent.
+  Endpoint file, module, and driver telemetry - Core filter: writes or loads of `msys-crypto-3.dll`, `pcdhost.sys`, `ssh-add.exe`, `ServiceModelReg.exe`, or DLLs from `C:\ProgramData\Google Update` or `C:\ProgramData\Zooms`. Triage values: `file path`, `loaded module path`, `driver file path`, `signer`. Correlation: the same lineage drops or decrypts the OPSWAT AppRemover driver and then attempts to terminate security processes.
+  Registry and persistence telemetry - Core filter: Run key writes under `HKCU\Software\Microsoft\Windows\CurrentVersion\Run` or `HKLM\Software\Microsoft\Windows\CurrentVersion\Run` with value data pointing to `C:\ProgramData\Google Update`, `ssh-add.exe`, or the staged loader directory. Triage values: `registry key path`, `registry value data`, `process command line`. Strong red flags: fake Google Update persistence created by the same loader chain that touched security tooling.
+  Network and post-compromise telemetry - Core filter: outbound HTTPS from `powershell.exe`, `ssh-add.exe`, or hollowed `ServiceModelReg.exe` after the copied command runs. Pivot: DNS or HTTP connections to Cloudflare R2 buckets, `.pages.dev`, or small HTTP responses containing `hehe`, then StealC traffic or credential-store reads. False positive: developer PowerShell downloads should not also load `pcdhost.sys`, tamper with security tools, write fake Google Update persistence, and hollow `ServiceModelReg.exe`.
+---
+# H221
+
+Malwarebytes reported active ClickFix campaigns that use fake verification pages to convince users to copy and run malicious PowerShell. The campaign delivers several malware families, with one chain staging ResiLoader before StealC. The useful hunting angle is not the page theme. It is the ordered endpoint chain from copied PowerShell into ProgramData staging, loader activity, security tool impairment, persistence, and StealC execution.
+
+## Why
+
+- ClickFix remains useful to attackers because the first execution step is performed by the user, but this hunt moves past the page text and keys on the copied PowerShell, ProgramData staging, ResiLoader loader artifacts, and StealC execution chain.
+- The ProgramData Zooms path, tmp ps1 staging, msys-crypto-3.dll, pcdhost.sys, fake Google Update Run key, and ServiceModelReg.exe hollowing are concrete artifacts that survive page rebrands and domain churn.
+- The required telemetry is common in endpoint MDR coverage: process creation, file writes, registry changes, driver or module loads, and outbound connection metadata are enough to follow the chain without relying on proxy or browser internals.
+- False positives are controllable because normal admin PowerShell and software installers should not chain driver-based security tool impairment, fake Google Update persistence, and process hollowing into an infostealer.
+
+## References
+
+- [Malwarebytes: Fake Google and Cloudflare verification pages spread multiple malware families](https://www.malwarebytes.com/blog/threat-intel/2026/07/fake-google-and-cloudflare-verification-pages-spread-multiple-malware-families)
+- [MITRE ATT&CK T1059.001: PowerShell](https://attack.mitre.org/techniques/T1059/001/)
+- [MITRE ATT&CK T1562.001: Impair Defenses](https://attack.mitre.org/techniques/T1562/001/)
+- [MITRE ATT&CK T1055: Process Injection](https://attack.mitre.org/techniques/T1055/)


### PR DESCRIPTION
## Summary
Adds `H221`: ClickFix PowerShell staging into ResiLoader and StealC.

## Sources
- https://www.malwarebytes.com/blog/threat-intel/2026/07/fake-google-and-cloudflare-verification-pages-spread-multiple-malware-families

## Validation
- Draft reviewed locally before submission.
- Source links are preserved in the hunt writeup.
- Local HEARTH validation passed: hunt ID collision check, full hunt parse, and parser/schema tests.