### PR TITLE
Enrich MITRE matrix with platforms + deprecated map for local validation

### DIFF
--- a/public/mitre-matrix.json
+++ b/public/mitre-matrix.json
@@ -86,7 +86,10 @@
       ],
       "description": "Adversaries may gather information about the victim's identity that can be used during targeting. Information about identities may include a variety of details, including personal data (ex: employee…",
       "url": "https://attack.mitre.org/techniques/T1589",
-      "is_subtechnique": false
+      "is_subtechnique": false,
+      "platforms": [
+        "PRE"
+      ]
     },
     {
       "id": "T1589.001",
@@ -97,7 +100,10 @@
       ],
       "description": "Adversaries may gather credentials that can be used during targeting. Account credentials gathered by adversaries may be those directly associated with the target victim organization or attempt to…",
       "url": "https://attack.mitre.org/techniques/T1589/001",
-      "is_subtechnique": true
+      "is_subtechnique": true,
+      "platforms": [
+        "PRE"
+      ]
     },
     {
       "id": "T1589.002",
@@ -108,7 +114,10 @@
       ],
       "description": "Adversaries may gather email addresses that can be used during targeting. Even if internal instances exist, organizations may have public-facing email infrastructure and addresses for…",
       "url": "https://attack.mitre.org/techniques/T1589/002",
-      "is_subtechnique": true
+      "is_subtechnique": true,
+      "platforms": [
+        "PRE"
+      ]
     },
     {
       "id": "T1589.003",
@@ -119,7 +128,10 @@
       ],
       "description": "Adversaries may gather employee names that can be used during targeting. Employee names be used to derive email addresses as well as to help guide other reconnaissance efforts and/or craft…",
       "url": "https://attack.mitre.org/techniques/T1589/003",
-      "is_subtechnique": true
+      "is_subtechnique": true,
+      "platforms": [
+        "PRE"
+      ]
     },
     {
       "id": "T1590",
@@ -130,7 +142,10 @@
       ],
       "description": "Adversaries may gather information about the victim's networks that can be used during targeting. Information about networks may include a variety of details, including administrative data (ex: IP…",
       "url": "https://attack.mitre.org/techniques/T1590",
-      "is_subtechnique": false
+      "is_subtechnique": false,
+      "platforms": [
+        "PRE"
+      ]
     },
     {
       "id": "T1590.001",
@@ -141,7 +156,10 @@
       ],
       "description": "Adversaries may gather information about the victim's network domain(s) that can be used during targeting. Information about domains and their properties may include a variety of details, including…",
       "url": "https://attack.mitre.org/techniques/T1590/001",
-      "is_subtechnique": true
+      "is_subtechnique": true,
+      "platforms": [
+        "PRE"
+      ]
     },
     {
       "id": "T1590.002",
@@ -152,7 +170,10 @@
       ],
       "description": "Adversaries may gather information about the victim's DNS that can be used during targeting. DNS information may include a variety of details, including registered name servers as well as records…",
       "url": "https://attack.mitre.org/techniques/T1590/002",
-      "is_subtechnique": true
+      "is_subtechnique": true,
+      "platforms": [
+        "PRE"
+      ]
     },
     {
       "id": "T1590.003",
@@ -163,7 +184,10 @@
       ],
       "description": "Adversaries may gather information about the victim's network trust dependencies that can be used during targeting. Information about network trusts may include a variety of details, including second…",
       "url": "https://attack.mitre.org/techniques/T1590/003",
-      "is_subtechnique": true
+      "is_subtechnique": true,
+      "platforms": [
+        "PRE"
+      ]
     },
     {
       "id": "T1590.004",
@@ -174,7 +198,10 @@
       ],
       "description": "Adversaries may gather information about the victim's network topology that can be used during targeting. Information about network topologies may include a variety of details, including the physical…",
       "url": "https://attack.mitre.org/techniques/T1590/004",
-      "is_subtechnique": true
+      "is_subtechnique": true,
+      "platforms": [
+        "PRE"
+      ]
     },
     {
       "id": "T1590.005",
@@ -185,7 +212,10 @@
       ],
       "description": "Adversaries may gather the victim's IP addresses that can be used during targeting. Public IP addresses may be allocated to organizations by block, or a range of sequential addresses. Information…",
       "url": "https://attack.mitre.org/techniques/T1590/005",
-      "is_subtechnique": true
+      "is_subtechnique": true,
+      "platforms": [
+        "PRE"
+      ]
     },
     {
       "id": "T1590.006",
@@ -196,7 +226,10 @@
       ],
       "description": "Adversaries may gather information about the victim's network security appliances that can be used during targeting. Information about network security appliances may include a variety of details,…",
       "url": "https://attack.mitre.org/techniques/T1590/006",
-      "is_subtechnique": true
+      "is_subtechnique": true,
+      "platforms": [
+        "PRE"
+      ]
     },
     {
       "id": "T1591",
@@ -207,7 +240,10 @@
       ],
       "description": "Adversaries may gather information about the victim's organization that can be used during targeting. Information about an organization may include a variety of details, including the names of…",
       "url": "https://attack.mitre.org/techniques/T1591",
-      "is_subtechnique": false
+      "is_subtechnique": false,
+      "platforms": [
+        "PRE"
+      ]
     },
     {
       "id": "T1591.001",
@@ -218,7 +254,10 @@
       ],
       "description": "Adversaries may gather the victim's physical location(s) that can be used during targeting. Information about physical locations of a target organization may include a variety of details, including…",
       "url": "https://attack.mitre.org/techniques/T1591/001",
-      "is_subtechnique": true
+      "is_subtechnique": true,
+      "platforms": [
+        "PRE"
+      ]
     },
     {
       "id": "T1591.002",
@@ -229,7 +268,10 @@
       ],
       "description": "Adversaries may gather information about the victim's business relationships that can be used during targeting. Information about an organization’s business relationships may include a variety of…",
       "url": "https://attack.mitre.org/techniques/T1591/002",
-      "is_subtechnique": true
+      "is_subtechnique": true,
+      "platforms": [
+        "PRE"
+      ]
     },
     {
       "id": "T1591.003",
@@ -240,7 +282,10 @@
       ],
       "description": "Adversaries may gather information about the victim's business tempo that can be used during targeting. Information about an organization’s business tempo may include a variety of details, including…",
       "url": "https://attack.mitre.org/techniques/T1591/003",
-      "is_subtechnique": true
+      "is_subtechnique": true,
+      "platforms": [
+        "PRE"
+      ]
     },
     {
       "id": "T1591.004",
@@ -251,7 +296,10 @@
       ],
       "description": "Adversaries may gather information about identities and roles within the victim organization that can be used during targeting. Information about business roles may reveal a variety of targetable…",
       "url": "https://attack.mitre.org/techniques/T1591/004",
-      "is_subtechnique": true
+      "is_subtechnique": true,
+      "platforms": [
+        "PRE"
+      ]
     },
     {
       "id": "T1592",
@@ -262,7 +310,10 @@
       ],
       "description": "Adversaries may gather information about the victim's hosts that can be used during targeting. Information about hosts may include a variety of details, including administrative data (ex: name,…",
       "url": "https://attack.mitre.org/techniques/T1592",
-      "is_subtechnique": false
+      "is_subtechnique": false,
+      "platforms": [
+        "PRE"
+      ]
     },
     {
       "id": "T1592.001",
@@ -273,7 +324,10 @@
       ],
       "description": "Adversaries may gather information about the victim's host hardware that can be used during targeting. Information about hardware infrastructure may include a variety of details such as types and…",
       "url": "https://attack.mitre.org/techniques/T1592/001",
-      "is_subtechnique": true
+      "is_subtechnique": true,
+      "platforms": [
+        "PRE"
+      ]
     },
     {
       "id": "T1592.002",
@@ -284,7 +338,10 @@
       ],
       "description": "Adversaries may gather information about the victim's host software that can be used during targeting. Information about installed software may include a variety of details such as types and versions…",
       "url": "https://attack.mitre.org/techniques/T1592/002",
-      "is_subtechnique": true
+      "is_subtechnique": true,
+      "platforms": [
+        "PRE"
+      ]
     },
     {
       "id": "T1592.003",
@@ -295,7 +352,10 @@
       ],
       "description": "Adversaries may gather information about the victim's host firmware that can be used during targeting. Information about host firmware may include a variety of details such as type and versions on…",
       "url": "https://attack.mitre.org/techniques/T1592/003",
-      "is_subtechnique": true
+      "is_subtechnique": true,
+      "platforms": [
+        "PRE"
+      ]
     },
     {
       "id": "T1592.004",
@@ -306,7 +366,10 @@
       ],
       "description": "Adversaries may gather information about the victim's client configurations that can be used during targeting. Information about client configurations may include a variety of details and settings,…",
       "url": "https://attack.mitre.org/techniques/T1592/004",
-      "is_subtechnique": true
+      "is_subtechnique": true,
+      "platforms": [
+        "PRE"
+      ]
     },
     {
       "id": "T1593",
@@ -317,7 +380,10 @@
       ],
       "description": "Adversaries may search freely available websites and/or domains for information about victims that can be used during targeting. Information about victims may be available in various online sites,…",
       "url": "https://attack.mitre.org/techniques/T1593",
-      "is_subtechnique": false
+      "is_subtechnique": false,
+      "platforms": [
+        "PRE"
+      ]
     },
     {
       "id": "T1593.001",
@@ -328,7 +394,10 @@
       ],
       "description": "Adversaries may search social media for information about victims that can be used during targeting. Social media sites may contain various information about a victim organization, such as business…",
       "url": "https://attack.mitre.org/techniques/T1593/001",
-      "is_subtechnique": true
+      "is_subtechnique": true,
+      "platforms": [
+        "PRE"
+      ]
     },
     {
       "id": "T1593.002",
@@ -339,7 +408,10 @@
       ],
       "description": "Adversaries may use search engines to collect information about victims that can be used during targeting. Search engine services typical crawl online sites to index context and may provide users…",
       "url": "https://attack.mitre.org/techniques/T1593/002",
-      "is_subtechnique": true
+      "is_subtechnique": true,
+      "platforms": [
+        "PRE"
+      ]
     },
     {
       "id": "T1593.003",
@@ -350,7 +422,10 @@
       ],
       "description": "Adversaries may search public code repositories for information about victims that can be used during targeting. Victims may store code in repositories on various third-party websites such as GitHub,…",
       "url": "https://attack.mitre.org/techniques/T1593/003",
-      "is_subtechnique": true
+      "is_subtechnique": true,
+      "platforms": [
+        "PRE"
+      ]
     },
     {
       "id": "T1594",
@@ -361,7 +436,10 @@
       ],
       "description": "Adversaries may search websites owned by the victim for information that can be used during targeting. Victim-owned websites may contain a variety of details, including names of…",
       "url": "https://attack.mitre.org/techniques/T1594",
-      "is_subtechnique": false
+      "is_subtechnique": false,
+      "platforms": [
+        "PRE"
+      ]
     },
     {
       "id": "T1595",
@@ -372,7 +450,10 @@
       ],
       "description": "Adversaries may execute active reconnaissance scans to gather information that can be used during targeting. Active scans are those where the adversary probes victim infrastructure via network…",
       "url": "https://attack.mitre.org/techniques/T1595",
-      "is_subtechnique": false
+      "is_subtechnique": false,
+      "platforms": [
+        "PRE"
+      ]
     },
     {
       "id": "T1595.001",
@@ -383,7 +464,10 @@
       ],
       "description": "Adversaries may scan victim IP blocks to gather information that can be used during targeting. Public IP addresses may be allocated to organizations by block, or a range of sequential…",
       "url": "https://attack.mitre.org/techniques/T1595/001",
-      "is_subtechnique": true
+      "is_subtechnique": true,
+      "platforms": [
+        "PRE"
+      ]
     },
     {
       "id": "T1595.002",
@@ -394,7 +478,10 @@
       ],
       "description": "Adversaries may scan victims for vulnerabilities that can be used during targeting. Vulnerability scans typically check if the configuration of a target host/application (ex: software and version)…",
       "url": "https://attack.mitre.org/techniques/T1595/002",
-      "is_subtechnique": true
+      "is_subtechnique": true,
+      "platforms": [
+        "PRE"
+      ]
     },
     {
       "id": "T1595.003",
@@ -405,7 +492,10 @@
       ],
       "description": "Adversaries may iteratively probe infrastructure using brute-forcing and crawling techniques. While this technique employs similar methods to [Brute Force](https://attack.mitre.org/techniques/T1110),…",
       "url": "https://attack.mitre.org/techniques/T1595/003",
-      "is_subtechnique": true
+      "is_subtechnique": true,
+      "platforms": [
+        "PRE"
+      ]
     },
     {
       "id": "T1596",
@@ -416,7 +506,10 @@
       ],
       "description": "Adversaries may search freely available technical databases for information about victims that can be used during targeting. Information about victims may be available in online databases and…",
       "url": "https://attack.mitre.org/techniques/T1596",
-      "is_subtechnique": false
+      "is_subtechnique": false,
+      "platforms": [
+        "PRE"
+      ]
     },
     {
       "id": "T1596.001",
@@ -427,7 +520,10 @@
       ],
       "description": "Adversaries may search DNS data for information about victims that can be used during targeting. DNS information may include a variety of details, including registered name servers as well as records…",
       "url": "https://attack.mitre.org/techniques/T1596/001",
-      "is_subtechnique": true
+      "is_subtechnique": true,
+      "platforms": [
+        "PRE"
+      ]
     },
     {
       "id": "T1596.002",
@@ -438,7 +534,10 @@
       ],
       "description": "Adversaries may search public WHOIS data for information about victims that can be used during targeting. WHOIS data is stored by regional Internet registries (RIR) responsible for allocating and…",
       "url": "https://attack.mitre.org/techniques/T1596/002",
-      "is_subtechnique": true
+      "is_subtechnique": true,
+      "platforms": [
+        "PRE"
+      ]
     },
     {
       "id": "T1596.003",
@@ -449,7 +548,10 @@
       ],
       "description": "Adversaries may search public digital certificate data for information about victims that can be used during targeting. Digital certificates are issued by a certificate authority (CA) in order to…",
       "url": "https://attack.mitre.org/techniques/T1596/003",
-      "is_subtechnique": true
+      "is_subtechnique": true,
+      "platforms": [
+        "PRE"
+      ]
     },
     {
       "id": "T1596.004",
@@ -460,7 +562,10 @@
       ],
       "description": "Adversaries may search content delivery network (CDN) data about victims that can be used during targeting. CDNs allow an organization to host content from a distributed, load balanced array of…",
       "url": "https://attack.mitre.org/techniques/T1596/004",
-      "is_subtechnique": true
+      "is_subtechnique": true,
+      "platforms": [
+        "PRE"
+      ]
     },
     {
       "id": "T1596.005",
@@ -471,7 +576,10 @@
       ],
       "description": "Adversaries may search within public scan databases for information about victims that can be used during targeting. Various online services continuously publish the results of Internet…",
       "url": "https://attack.mitre.org/techniques/T1596/005",
-      "is_subtechnique": true
+      "is_subtechnique": true,
+      "platforms": [
+        "PRE"
+      ]
     },
     {
       "id": "T1597",
@@ -482,7 +590,10 @@
       ],
       "description": "Adversaries may search and gather information about victims from closed (e.g., paid, private, or otherwise not freely available) sources that can be used during targeting. Information about victims…",
       "url": "https://attack.mitre.org/techniques/T1597",
-      "is_subtechnique": false
+      "is_subtechnique": false,
+      "platforms": [
+        "PRE"
+      ]
     },
     {
       "id": "T1597.001",
@@ -493,7 +604,10 @@
       ],
       "description": "Adversaries may search private data from threat intelligence vendors for information that can be used during targeting. Threat intelligence vendors may offer paid feeds or portals that offer more…",
       "url": "https://attack.mitre.org/techniques/T1597/001",
-      "is_subtechnique": true
+      "is_subtechnique": true,
+      "platforms": [
+        "PRE"
+      ]
     },
     {
       "id": "T1597.002",
@@ -504,7 +618,10 @@
       ],
       "description": "Adversaries may purchase technical information about victims that can be used during targeting. Information about victims may be available for purchase within reputable private sources and databases,…",
       "url": "https://attack.mitre.org/techniques/T1597/002",
-      "is_subtechnique": true
+      "is_subtechnique": true,
+      "platforms": [
+        "PRE"
+      ]
     },
     {
       "id": "T1598",
@@ -515,7 +632,10 @@
       ],
       "description": "Adversaries may send phishing messages to elicit sensitive information that can be used during targeting. Phishing for information is an attempt to trick targets into divulging information,…",
       "url": "https://attack.mitre.org/techniques/T1598",
-      "is_subtechnique": false
+      "is_subtechnique": false,
+      "platforms": [
+        "PRE"
+      ]
     },
     {
       "id": "T1598.001",
@@ -526,7 +646,10 @@
       ],
       "description": "Adversaries may send spearphishing messages via third-party services to elicit sensitive information that can be used during targeting. Spearphishing for information is an attempt to trick targets…",
       "url": "https://attack.mitre.org/techniques/T1598/001",
-      "is_subtechnique": true
+      "is_subtechnique": true,
+      "platforms": [
+        "PRE"
+      ]
     },
     {
       "id": "T1598.002",
@@ -537,7 +660,10 @@
       ],
       "description": "Adversaries may send spearphishing messages with a malicious attachment to elicit sensitive information that can be used during targeting. Spearphishing for information is an attempt to trick targets…",
       "url": "https://attack.mitre.org/techniques/T1598/002",
-      "is_subtechnique": true
+      "is_subtechnique": true,
+      "platforms": [
+        "PRE"
+      ]
     },
     {
       "id": "T1598.003",
@@ -548,7 +674,10 @@
       ],
       "description": "Adversaries may send spearphishing messages with a malicious link to elicit sensitive information that can be used during targeting. Spearphishing for information is an attempt to trick targets into…",
       "url": "https://attack.mitre.org/techniques/T1598/003",
-      "is_subtechnique": true
+      "is_subtechnique": true,
+      "platforms": [
+        "PRE"
+      ]
     },
     {
       "id": "T1598.004",
@@ -559,7 +688,10 @@
       ],
       "description": "Adversaries may use voice communications to elicit sensitive information that can be used during targeting. Spearphishing for information is an attempt to trick targets into divulging information,…",
       "url": "https://attack.mitre.org/techniques/T1598/004",
-      "is_subtechnique": true
+      "is_subtechnique": true,
+      "platforms": [
+        "PRE"
+      ]
     },
     {
       "id": "T1681",
@@ -570,7 +702,10 @@
       ],
       "description": "Threat actors may seek information/indicators from closed or open threat intelligence sources gathered about their own campaigns, as well as those conducted by other adversaries that may align with…",
       "url": "https://attack.mitre.org/techniques/T1681",
-      "is_subtechnique": false
+      "is_subtechnique": false,
+      "platforms": [
+        "PRE"
+      ]
     },
     {
       "id": "T1682",
@@ -581,7 +716,10 @@
       ],
       "description": "Adversaries may query publicly accessible artificial intelligence (AI) services, such as large language models (LLMs), to support targeting and operations. In addition to searching websites or…",
       "url": "https://attack.mitre.org/techniques/T1682",
-      "is_subtechnique": false
+      "is_subtechnique": false,
+      "platforms": [
+        "PRE"
+      ]
     },
     {
       "id": "T1583",
@@ -592,7 +730,10 @@
       ],
       "description": "Adversaries may buy, lease, rent, or obtain infrastructure that can be used during targeting. A wide variety of infrastructure exists for hosting and orchestrating adversary operations.…",
       "url": "https://attack.mitre.org/techniques/T1583",
-      "is_subtechnique": false
+      "is_subtechnique": false,
+      "platforms": [
+        "PRE"
+      ]
     },
     {
       "id": "T1583.001",
@@ -603,7 +744,10 @@
       ],
       "description": "Adversaries may acquire domains that can be used during targeting. Domain names are the human readable names used to represent one or more IP addresses. They can be purchased or, in some cases,…",
       "url": "https://attack.mitre.org/techniques/T1583/001",
-      "is_subtechnique": true
+      "is_subtechnique": true,
+      "platforms": [
+        "PRE"
+      ]
     },
     {
       "id": "T1583.002",
@@ -614,7 +758,10 @@
       ],
       "description": "Adversaries may set up their own Domain Name System (DNS) servers that can be used during targeting. During post-compromise activity, adversaries may utilize DNS traffic for various tasks, including…",
       "url": "https://attack.mitre.org/techniques/T1583/002",
-      "is_subtechnique": true
+      "is_subtechnique": true,
+      "platforms": [
+        "PRE"
+      ]
     },
     {
       "id": "T1583.003",
@@ -625,7 +772,10 @@
       ],
       "description": "Adversaries may rent Virtual Private Servers (VPSs) that can be used during targeting. There exist a variety of cloud service providers that will sell virtual machines/containers as a service. By…",
       "url": "https://attack.mitre.org/techniques/T1583/003",
-      "is_subtechnique": true
+      "is_subtechnique": true,
+      "platforms": [
+        "PRE"
+      ]
     },
     {
       "id": "T1583.004",
@@ -636,7 +786,10 @@
       ],
       "description": "Adversaries may buy, lease, rent, or obtain physical servers that can be used during targeting. Use of servers allows an adversary to stage, launch, and execute an operation. During post-compromise…",
       "url": "https://attack.mitre.org/techniques/T1583/004",
-      "is_subtechnique": true
+      "is_subtechnique": true,
+      "platforms": [
+        "PRE"
+      ]
     },
     {
       "id": "T1583.005",
@@ -647,7 +800,10 @@
       ],
       "description": "Adversaries may buy, lease, or rent a network of compromised systems that can be used during targeting. A botnet is a network of compromised systems that can be instructed to perform coordinated…",
       "url": "https://attack.mitre.org/techniques/T1583/005",
-      "is_subtechnique": true
+      "is_subtechnique": true,
+      "platforms": [
+        "PRE"
+      ]
     },
     {
       "id": "T1583.006",
@@ -658,7 +814,10 @@
       ],
       "description": "Adversaries may register for web services that can be used during targeting. A variety of popular websites exist for adversaries to register for a web-based service that can be abused during later…",
       "url": "https://attack.mitre.org/techniques/T1583/006",
-      "is_subtechnique": true
+      "is_subtechnique": true,
+      "platforms": [
+        "PRE"
+      ]
     },
     {
       "id": "T1583.007",
@@ -669,7 +828,10 @@
       ],
       "description": "Adversaries may purchase and configure serverless cloud infrastructure, such as Cloudflare Workers, AWS Lambda functions, or Google Apps Scripts, that can be used during targeting. By utilizing…",
       "url": "https://attack.mitre.org/techniques/T1583/007",
-      "is_subtechnique": true
+      "is_subtechnique": true,
+      "platforms": [
+        "PRE"
+      ]
     },
     {
       "id": "T1583.008",
@@ -680,7 +842,10 @@
       ],
       "description": "Adversaries may purchase online advertisements that can be abused to distribute malware to victims. Ads can be purchased to plant as well as favorably position artifacts in specific locations …",
       "url": "https://attack.mitre.org/techniques/T1583/008",
-      "is_subtechnique": true
+      "is_subtechnique": true,
+      "platforms": [
+        "PRE"
+      ]
     },
     {
       "id": "T1584",
@@ -691,7 +856,10 @@
       ],
       "description": "Adversaries may compromise third-party infrastructure that can be used during targeting. Infrastructure solutions include physical or cloud servers, domains, network devices, and third-party web and…",
       "url": "https://attack.mitre.org/techniques/T1584",
-      "is_subtechnique": false
+      "is_subtechnique": false,
+      "platforms": [
+        "PRE"
+      ]
     },
     {
       "id": "T1584.001",
@@ -702,7 +870,10 @@
       ],
       "description": "Adversaries may hijack domains and/or subdomains that can be used during targeting. Domain registration hijacking is the act of changing the registration of a domain name without the permission of…",
       "url": "https://attack.mitre.org/techniques/T1584/001",
-      "is_subtechnique": true
+      "is_subtechnique": true,
+      "platforms": [
+        "PRE"
+      ]
     },
     {
       "id": "T1584.002",
@@ -713,7 +884,10 @@
       ],
       "description": "Adversaries may compromise third-party DNS servers that can be used during targeting. During post-compromise activity, adversaries may utilize DNS traffic for various tasks, including for Command and…",
       "url": "https://attack.mitre.org/techniques/T1584/002",
-      "is_subtechnique": true
+      "is_subtechnique": true,
+      "platforms": [
+        "PRE"
+      ]
     },
     {
       "id": "T1584.003",
@@ -724,7 +898,10 @@
       ],
       "description": "Adversaries may compromise third-party Virtual Private Servers (VPSs) that can be used during targeting. There exist a variety of cloud service providers that will sell virtual machines/containers as…",
       "url": "https://attack.mitre.org/techniques/T1584/003",
-      "is_subtechnique": true
+      "is_subtechnique": true,
+      "platforms": [
+        "PRE"
+      ]
     },
     {
       "id": "T1584.004",
@@ -735,7 +912,10 @@
       ],
       "description": "Adversaries may compromise third-party servers that can be used during targeting. Use of servers allows an adversary to stage, launch, and execute an operation. During post-compromise activity,…",
       "url": "https://attack.mitre.org/techniques/T1584/004",
-      "is_subtechnique": true
+      "is_subtechnique": true,
+      "platforms": [
+        "PRE"
+      ]
     },
     {
       "id": "T1584.005",
@@ -746,7 +926,10 @@
       ],
       "description": "Adversaries may compromise numerous third-party systems to form a botnet that can be used during targeting. A botnet is a network of compromised systems that can be instructed to perform coordinated…",
       "url": "https://attack.mitre.org/techniques/T1584/005",
-      "is_subtechnique": true
+      "is_subtechnique": true,
+      "platforms": [
+        "PRE"
+      ]
     },
     {
       "id": "T1584.006",
@@ -757,7 +940,10 @@
       ],
       "description": "Adversaries may compromise access to third-party web services that can be used during targeting. A variety of popular websites exist for legitimate users to register for web-based services, such as…",
       "url": "https://attack.mitre.org/techniques/T1584/006",
-      "is_subtechnique": true
+      "is_subtechnique": true,
+      "platforms": [
+        "PRE"
+      ]
     },
     {
       "id": "T1584.007",
@@ -768,7 +954,10 @@
       ],
       "description": "Adversaries may compromise serverless cloud infrastructure, such as Cloudflare Workers, AWS Lambda functions, or Google Apps Scripts, that can be used during targeting. By utilizing serverless…",
       "url": "https://attack.mitre.org/techniques/T1584/007",
-      "is_subtechnique": true
+      "is_subtechnique": true,
+      "platforms": [
+        "PRE"
+      ]
     },
     {
       "id": "T1584.008",
@@ -779,7 +968,10 @@
       ],
       "description": "Adversaries may compromise third-party network devices that can be used during targeting. Network devices, such as small office/home office (SOHO) routers, may be compromised where the adversary's…",
       "url": "https://attack.mitre.org/techniques/T1584/008",
-      "is_subtechnique": true
+      "is_subtechnique": true,
+      "platforms": [
+        "PRE"
+      ]
     },
     {
       "id": "T1585",
@@ -790,7 +982,10 @@
       ],
       "description": "Adversaries may create and cultivate accounts with services that can be used during targeting. Adversaries can create accounts that can be used to build a persona to further operations. Persona…",
       "url": "https://attack.mitre.org/techniques/T1585",
-      "is_subtechnique": false
+      "is_subtechnique": false,
+      "platforms": [
+        "PRE"
+      ]
     },
     {
       "id": "T1585.001",
@@ -801,7 +996,10 @@
       ],
       "description": "Adversaries may create and cultivate social media accounts that can be used during targeting. Adversaries can create social media accounts that can be used to build a persona to further operations.…",
       "url": "https://attack.mitre.org/techniques/T1585/001",
-      "is_subtechnique": true
+      "is_subtechnique": true,
+      "platforms": [
+        "PRE"
+      ]
     },
     {
       "id": "T1585.002",
@@ -812,7 +1010,10 @@
       ],
       "description": "Adversaries may create email accounts that can be used during targeting. Adversaries can use accounts created with email providers to further their operations, such as leveraging them to conduct…",
       "url": "https://attack.mitre.org/techniques/T1585/002",
-      "is_subtechnique": true
+      "is_subtechnique": true,
+      "platforms": [
+        "PRE"
+      ]
     },
     {
       "id": "T1585.003",
@@ -823,7 +1024,10 @@
       ],
       "description": "Adversaries may create accounts with cloud providers that can be used during targeting. Adversaries can use cloud accounts to further their operations, including leveraging cloud storage services…",
       "url": "https://attack.mitre.org/techniques/T1585/003",
-      "is_subtechnique": true
+      "is_subtechnique": true,
+      "platforms": [
+        "PRE"
+      ]
     },
     {
       "id": "T1586",
@@ -834,7 +1038,10 @@
       ],
       "description": "Adversaries may compromise accounts with services that can be used during targeting. For operations incorporating social engineering, the utilization of an online persona may be important. Rather…",
       "url": "https://attack.mitre.org/techniques/T1586",
-      "is_subtechnique": false
+      "is_subtechnique": false,
+      "platforms": [
+        "PRE"
+      ]
     },
     {
       "id": "T1586.001",
@@ -845,7 +1052,10 @@
       ],
       "description": "Adversaries may compromise social media accounts that can be used during targeting. For operations incorporating social engineering, the utilization of an online persona may be important. Rather than…",
       "url": "https://attack.mitre.org/techniques/T1586/001",
-      "is_subtechnique": true
+      "is_subtechnique": true,
+      "platforms": [
+        "PRE"
+      ]
     },
     {
       "id": "T1586.002",
@@ -856,7 +1066,10 @@
       ],
       "description": "Adversaries may compromise email accounts that can be used during targeting. Adversaries can use compromised email accounts to further their operations, such as leveraging them to conduct [Phishing…",
       "url": "https://attack.mitre.org/techniques/T1586/002",
-      "is_subtechnique": true
+      "is_subtechnique": true,
+      "platforms": [
+        "PRE"
+      ]
     },
     {
       "id": "T1586.003",
@@ -867,7 +1080,10 @@
       ],
       "description": "Adversaries may compromise cloud accounts that can be used during targeting. Adversaries can use compromised cloud accounts to further their operations, including leveraging cloud storage services…",
       "url": "https://attack.mitre.org/techniques/T1586/003",
-      "is_subtechnique": true
+      "is_subtechnique": true,
+      "platforms": [
+        "PRE"
+      ]
     },
     {
       "id": "T1587",
@@ -878,7 +1094,10 @@
       ],
       "description": "Adversaries may build capabilities that can be used during targeting. Rather than purchasing, freely downloading, or stealing capabilities, adversaries may develop their own capabilities in-house.…",
       "url": "https://attack.mitre.org/techniques/T1587",
-      "is_subtechnique": false
+      "is_subtechnique": false,
+      "platforms": [
+        "PRE"
+      ]
     },
     {
       "id": "T1587.001",
@@ -889,7 +1108,10 @@
       ],
       "description": "Adversaries may develop malware and malware components that can be used during targeting. Building malicious software can include the development of payloads, droppers, post-compromise tools,…",
       "url": "https://attack.mitre.org/techniques/T1587/001",
-      "is_subtechnique": true
+      "is_subtechnique": true,
+      "platforms": [
+        "PRE"
+      ]
     },
     {
       "id": "T1587.002",
@@ -900,7 +1122,10 @@
       ],
       "description": "Adversaries may create self-signed code signing certificates that can be used during targeting. Code signing is the process of digitally signing executables and scripts to confirm the software author…",
       "url": "https://attack.mitre.org/techniques/T1587/002",
-      "is_subtechnique": true
+      "is_subtechnique": true,
+      "platforms": [
+        "PRE"
+      ]
     },
     {
       "id": "T1587.003",
@@ -911,7 +1136,10 @@
       ],
       "description": "Adversaries may create self-signed SSL/TLS certificates that can be used during targeting. SSL/TLS certificates are designed to instill trust. They include information about the key, information…",
       "url": "https://attack.mitre.org/techniques/T1587/003",
-      "is_subtechnique": true
+      "is_subtechnique": true,
+      "platforms": [
+        "PRE"
+      ]
     },
     {
       "id": "T1587.004",
@@ -922,7 +1150,10 @@
       ],
       "description": "Adversaries may develop exploits that can be used during targeting. An exploit takes advantage of a bug or vulnerability in order to cause unintended or unanticipated behavior to occur on computer…",
       "url": "https://attack.mitre.org/techniques/T1587/004",
-      "is_subtechnique": true
+      "is_subtechnique": true,
+      "platforms": [
+        "PRE"
+      ]
     },
     {
       "id": "T1588",
@@ -933,7 +1164,10 @@
       ],
       "description": "Adversaries may buy and/or steal capabilities that can be used during targeting. Rather than developing their own capabilities in-house, adversaries may purchase, freely download, or steal them.…",
       "url": "https://attack.mitre.org/techniques/T1588",
-      "is_subtechnique": false
+      "is_subtechnique": false,
+      "platforms": [
+        "PRE"
+      ]
     },
     {
       "id": "T1588.001",
@@ -944,7 +1178,10 @@
       ],
       "description": "Adversaries may buy, steal, or download malware that can be used during targeting. Malicious software can include payloads, droppers, post-compromise tools, backdoors, packers, and C2 protocols.…",
       "url": "https://attack.mitre.org/techniques/T1588/001",
-      "is_subtechnique": true
+      "is_subtechnique": true,
+      "platforms": [
+        "PRE"
+      ]
     },
     {
       "id": "T1588.002",
@@ -955,7 +1192,10 @@
       ],
       "description": "Adversaries may buy, steal, or download software tools that can be used during targeting. Tools can be open or closed source, free or commercial. A tool can be used for malicious purposes by an…",
       "url": "https://attack.mitre.org/techniques/T1588/002",
-      "is_subtechnique": true
+      "is_subtechnique": true,
+      "platforms": [
+        "PRE"
+      ]
     },
     {
       "id": "T1588.003",
@@ -966,7 +1206,10 @@
       ],
       "description": "Adversaries may buy and/or steal code signing certificates that can be used during targeting. Code signing is the process of digitally signing executables and scripts to confirm the software author…",
       "url": "https://attack.mitre.org/techniques/T1588/003",
-      "is_subtechnique": true
+      "is_subtechnique": true,
+      "platforms": [
+        "PRE"
+      ]
     },
     {
       "id": "T1588.004",
@@ -977,7 +1220,10 @@
       ],
       "description": "Adversaries may buy and/or steal SSL/TLS certificates that can be used during targeting. SSL/TLS certificates are designed to instill trust. They include information about the key, information about…",
       "url": "https://attack.mitre.org/techniques/T1588/004",
-      "is_subtechnique": true
+      "is_subtechnique": true,
+      "platforms": [
+        "PRE"
+      ]
     },
     {
       "id": "T1588.005",
@@ -988,7 +1234,10 @@
       ],
       "description": "Adversaries may buy, steal, or download exploits that can be used during targeting. An exploit takes advantage of a bug or vulnerability in order to cause unintended or unanticipated behavior to…",
       "url": "https://attack.mitre.org/techniques/T1588/005",
-      "is_subtechnique": true
+      "is_subtechnique": true,
+      "platforms": [
+        "PRE"
+      ]
     },
     {
       "id": "T1588.006",
@@ -999,7 +1248,10 @@
       ],
       "description": "Adversaries may acquire information about vulnerabilities that can be used during targeting. A vulnerability is a weakness in computer hardware or software that can, potentially, be exploited by an…",
       "url": "https://attack.mitre.org/techniques/T1588/006",
-      "is_subtechnique": true
+      "is_subtechnique": true,
+      "platforms": [
+        "PRE"
+      ]
     },
     {
       "id": "T1588.007",
@@ -1010,7 +1262,10 @@
       ],
       "description": "Adversaries may obtain access to generative artificial intelligence tools, such as large language models (LLMs), to aid various techniques during targeting. These tools may be used to inform,…",
       "url": "https://attack.mitre.org/techniques/T1588/007",
-      "is_subtechnique": true
+      "is_subtechnique": true,
+      "platforms": [
+        "PRE"
+      ]
     },
     {
       "id": "T1608",
@@ -1021,7 +1276,10 @@
       ],
       "description": "Adversaries may upload, install, or otherwise set up capabilities that can be used during targeting. To support their operations, an adversary may need to take capabilities they developed ([Develop…",
       "url": "https://attack.mitre.org/techniques/T1608",
-      "is_subtechnique": false
+      "is_subtechnique": false,
+      "platforms": [
+        "PRE"
+      ]
     },
     {
       "id": "T1608.001",
@@ -1032,7 +1290,10 @@
       ],
       "description": "Adversaries may upload malware to third-party or adversary controlled infrastructure to make it accessible during targeting. Malicious software can include payloads, droppers, post-compromise tools,…",
       "url": "https://attack.mitre.org/techniques/T1608/001",
-      "is_subtechnique": true
+      "is_subtechnique": true,
+      "platforms": [
+        "PRE"
+      ]
     },
     {
       "id": "T1608.002",
@@ -1043,7 +1304,10 @@
       ],
       "description": "Adversaries may upload tools to third-party or adversary controlled infrastructure to make it accessible during targeting. Tools can be open or closed source, free or commercial. Tools can be used…",
       "url": "https://attack.mitre.org/techniques/T1608/002",
-      "is_subtechnique": true
+      "is_subtechnique": true,
+      "platforms": [
+        "PRE"
+      ]
     },
     {
       "id": "T1608.003",
@@ -1054,7 +1318,10 @@
       ],
       "description": "Adversaries may install SSL/TLS certificates that can be used during targeting. SSL/TLS certificates are files that can be installed on servers to enable secure communications between systems.…",
       "url": "https://attack.mitre.org/techniques/T1608/003",
-      "is_subtechnique": true
+      "is_subtechnique": true,
+      "platforms": [
+        "PRE"
+      ]
     },
     {
       "id": "T1608.004",
@@ -1065,7 +1332,10 @@
       ],
       "description": "Adversaries may prepare an operational environment to infect systems that visit a website over the normal course of browsing. Endpoint systems may be compromised through browsing to adversary…",
       "url": "https://attack.mitre.org/techniques/T1608/004",
-      "is_subtechnique": true
+      "is_subtechnique": true,
+      "platforms": [
+        "PRE"
+      ]
     },
     {
       "id": "T1608.005",
@@ -1076,7 +1346,10 @@
       ],
       "description": "Adversaries may put in place resources that are referenced by a link that can be used during targeting. An adversary may rely upon a user clicking a malicious link in order to divulge information…",
       "url": "https://attack.mitre.org/techniques/T1608/005",
-      "is_subtechnique": true
+      "is_subtechnique": true,
+      "platforms": [
+        "PRE"
+      ]
     },
     {
       "id": "T1608.006",
@@ -1087,7 +1360,10 @@
       ],
       "description": "Adversaries may poison mechanisms that influence search engine optimization (SEO) to further lure staged capabilities towards potential victims. Search engines typically display results to users…",
       "url": "https://attack.mitre.org/techniques/T1608/006",
-      "is_subtechnique": true
+      "is_subtechnique": true,
+      "platforms": [
+        "PRE"
+      ]
     },
     {
       "id": "T1650",
@@ -1098,7 +1374,10 @@
       ],
       "description": "Adversaries may purchase or otherwise acquire an existing access to a target system or network. A variety of online services and initial access broker networks are available to sell access to…",
       "url": "https://attack.mitre.org/techniques/T1650",
-      "is_subtechnique": false
+      "is_subtechnique": false,
+      "platforms": [
+        "PRE"
+      ]
     },
     {
       "id": "T1683",
@@ -1109,7 +1388,10 @@
       ],
       "description": "Adversaries may create or generate content to support targeting and operations. This content may be used to establish personas, impersonate known individuals or organizations, and support [Social…",
       "url": "https://attack.mitre.org/techniques/T1683",
-      "is_subtechnique": false
+      "is_subtechnique": false,
+      "platforms": [
+        "PRE"
+      ]
     },
     {
       "id": "T1683.001",
@@ -1120,7 +1402,10 @@
       ],
       "description": "Adversaries may create or tailor written materials to support targeting and malicious operations. Content may include phishing lures, fraudulent financial communications, fabricated job postings,…",
       "url": "https://attack.mitre.org/techniques/T1683/001",
-      "is_subtechnique": true
+      "is_subtechnique": true,
+      "platforms": [
+        "PRE"
+      ]
     },
     {
       "id": "T1683.002",
@@ -1131,7 +1416,10 @@
       ],
       "description": "Adversaries may create or manipulate audio, image, and video content to support targeting and malicious operations. Adversaries may also use synthetic voice recordings, real-time altered audio or…",
       "url": "https://attack.mitre.org/techniques/T1683/002",
-      "is_subtechnique": true
+      "is_subtechnique": true,
+      "platforms": [
+        "PRE"
+      ]
     },
     {
       "id": "T1189",
@@ -1142,7 +1430,13 @@
       ],
       "description": "Adversaries may gain access to a system through a user visiting a website over the normal course of browsing. Multiple ways of delivering exploit code to a browser exist (i.e., [Drive-by…",
       "url": "https://attack.mitre.org/techniques/T1189",
-      "is_subtechnique": false
+      "is_subtechnique": false,
+      "platforms": [
+        "Identity Provider",
+        "Linux",
+        "macOS",
+        "Windows"
+      ]
     },
     {
       "id": "T1190",
@@ -1153,7 +1447,16 @@
       ],
       "description": "Adversaries may attempt to exploit a weakness in an Internet-facing host or system to initially access a network. The weakness in the system can be a software bug, a temporary glitch, or a…",
       "url": "https://attack.mitre.org/techniques/T1190",
-      "is_subtechnique": false
+      "is_subtechnique": false,
+      "platforms": [
+        "Containers",
+        "ESXi",
+        "IaaS",
+        "Linux",
+        "macOS",
+        "Network Devices",
+        "Windows"
+      ]
     },
     {
       "id": "T1195",
@@ -1164,7 +1467,13 @@
       ],
       "description": "Adversaries may manipulate products or product delivery mechanisms prior to receipt by a final consumer for the purpose of data or system compromise.\n\nSupply chain compromise can take place at any…",
       "url": "https://attack.mitre.org/techniques/T1195",
-      "is_subtechnique": false
+      "is_subtechnique": false,
+      "platforms": [
+        "Linux",
+        "Windows",
+        "macOS",
+        "SaaS"
+      ]
     },
     {
       "id": "T1195.001",
@@ -1175,7 +1484,12 @@
       ],
       "description": "Adversaries may manipulate software dependencies and development tools prior to receipt by a final consumer for the purpose of data or system compromise. Applications often depend on external…",
       "url": "https://attack.mitre.org/techniques/T1195/001",
-      "is_subtechnique": true
+      "is_subtechnique": true,
+      "platforms": [
+        "Linux",
+        "macOS",
+        "Windows"
+      ]
     },
     {
       "id": "T1195.002",
@@ -1186,7 +1500,12 @@
       ],
       "description": "Adversaries may manipulate application software prior to receipt by a final consumer for the purpose of data or system compromise. Supply chain compromise of software can take place in a number of…",
       "url": "https://attack.mitre.org/techniques/T1195/002",
-      "is_subtechnique": true
+      "is_subtechnique": true,
+      "platforms": [
+        "Linux",
+        "Windows",
+        "macOS"
+      ]
     },
     {
       "id": "T1195.003",
@@ -1197,7 +1516,12 @@
       ],
       "description": "Adversaries may manipulate hardware components in products prior to receipt by a final consumer for the purpose of data or system compromise. By modifying hardware or firmware in the supply chain,…",
       "url": "https://attack.mitre.org/techniques/T1195/003",
-      "is_subtechnique": true
+      "is_subtechnique": true,
+      "platforms": [
+        "Linux",
+        "macOS",
+        "Windows"
+      ]
     },
     {
       "id": "T1199",
@@ -1208,7 +1532,16 @@
       ],
       "description": "Adversaries may breach or otherwise leverage organizations who have access to intended victims. Access through trusted third party relationship abuses an existing connection that may not be protected…",
       "url": "https://attack.mitre.org/techniques/T1199",
-      "is_subtechnique": false
+      "is_subtechnique": false,
+      "platforms": [
+        "IaaS",
+        "Identity Provider",
+        "Linux",
+        "macOS",
+        "Office Suite",
+        "SaaS",
+        "Windows"
+      ]
     },
     {
       "id": "T1200",
@@ -1219,7 +1552,12 @@
       ],
       "description": "Adversaries may physically introduce computer accessories, networking hardware, or other computing devices into a system or network that can be used as a vector to gain access. Rather than just…",
       "url": "https://attack.mitre.org/techniques/T1200",
-      "is_subtechnique": false
+      "is_subtechnique": false,
+      "platforms": [
+        "Windows",
+        "Linux",
+        "macOS"
+      ]
     },
     {
       "id": "T1566",
@@ -1230,7 +1568,15 @@
       ],
       "description": "Adversaries may send phishing messages to gain access to victim systems. All forms of phishing are electronically delivered social engineering. Phishing can be targeted, known as spearphishing. In…",
       "url": "https://attack.mitre.org/techniques/T1566",
-      "is_subtechnique": false
+      "is_subtechnique": false,
+      "platforms": [
+        "Identity Provider",
+        "Linux",
+        "macOS",
+        "Office Suite",
+        "SaaS",
+        "Windows"
+      ]
     },
     {
       "id": "T1566.001",
@@ -1241,7 +1587,12 @@
       ],
       "description": "Adversaries may send spearphishing emails with a malicious attachment in an attempt to gain access to victim systems. Spearphishing attachment is a specific variant of spearphishing. Spearphishing…",
       "url": "https://attack.mitre.org/techniques/T1566/001",
-      "is_subtechnique": true
+      "is_subtechnique": true,
+      "platforms": [
+        "Linux",
+        "macOS",
+        "Windows"
+      ]
     },
     {
       "id": "T1566.002",
@@ -1252,7 +1603,15 @@
       ],
       "description": "Adversaries may send spearphishing emails with a malicious link in an attempt to gain access to victim systems. Spearphishing with a link is a specific variant of spearphishing. It is different from…",
       "url": "https://attack.mitre.org/techniques/T1566/002",
-      "is_subtechnique": true
+      "is_subtechnique": true,
+      "platforms": [
+        "Identity Provider",
+        "Linux",
+        "macOS",
+        "Office Suite",
+        "SaaS",
+        "Windows"
+      ]
     },
     {
       "id": "T1566.003",
@@ -1263,7 +1622,12 @@
       ],
       "description": "Adversaries may send spearphishing messages via third-party services in an attempt to gain access to victim systems. Spearphishing via service is a specific variant of spearphishing. It is different…",
       "url": "https://attack.mitre.org/techniques/T1566/003",
-      "is_subtechnique": true
+      "is_subtechnique": true,
+      "platforms": [
+        "Linux",
+        "macOS",
+        "Windows"
+      ]
     },
     {
       "id": "T1566.004",
@@ -1274,7 +1638,13 @@
       ],
       "description": "Adversaries may use voice communications to ultimately gain access to victim systems. Spearphishing voice is a specific variant of spearphishing. It is different from other forms of spearphishing in…",
       "url": "https://attack.mitre.org/techniques/T1566/004",
-      "is_subtechnique": true
+      "is_subtechnique": true,
+      "platforms": [
+        "Linux",
+        "macOS",
+        "Windows",
+        "Identity Provider"
+      ]
     },
     {
       "id": "T1659",
@@ -1286,7 +1656,12 @@
       ],
       "description": "Adversaries may gain access and continuously communicate with victims by injecting malicious content into systems through online network traffic. Rather than luring victims to malicious payloads…",
       "url": "https://attack.mitre.org/techniques/T1659",
-      "is_subtechnique": false
+      "is_subtechnique": false,
+      "platforms": [
+        "Linux",
+        "macOS",
+        "Windows"
+      ]
     },
     {
       "id": "T1669",
@@ -1297,7 +1672,13 @@
       ],
       "description": "Adversaries may gain initial access to target systems by connecting to wireless networks. They may accomplish this by exploiting open Wi-Fi networks used by target devices or by accessing secured…",
       "url": "https://attack.mitre.org/techniques/T1669",
-      "is_subtechnique": false
+      "is_subtechnique": false,
+      "platforms": [
+        "Linux",
+        "Network Devices",
+        "Windows",
+        "macOS"
+      ]
     },
     {
       "id": "T1047",
@@ -1308,7 +1689,10 @@
       ],
       "description": "Adversaries may abuse Windows Management Instrumentation (WMI) to execute malicious commands and payloads. WMI is designed for programmers and is the infrastructure for management data and operations…",
       "url": "https://attack.mitre.org/techniques/T1047",
-      "is_subtechnique": false
+      "is_subtechnique": false,
+      "platforms": [
+        "Windows"
+      ]
     },
     {
       "id": "T1053",
@@ -1321,7 +1705,15 @@
       ],
       "description": "Adversaries may abuse task scheduling functionality to facilitate initial or recurring execution of malicious code. Utilities exist within all major operating systems to schedule programs or scripts…",
       "url": "https://attack.mitre.org/techniques/T1053",
-      "is_subtechnique": false
+      "is_subtechnique": false,
+      "platforms": [
+        "Containers",
+        "ESXi",
+        "Linux",
+        "macOS",
+        "Network Devices",
+        "Windows"
+      ]
     },
     {
       "id": "T1053.002",
@@ -1334,7 +1726,12 @@
       ],
       "description": "Adversaries may abuse the [at](https://attack.mitre.org/software/S0110) utility to perform task scheduling for initial or recurring execution of malicious code. The…",
       "url": "https://attack.mitre.org/techniques/T1053/002",
-      "is_subtechnique": true
+      "is_subtechnique": true,
+      "platforms": [
+        "Windows",
+        "Linux",
+        "macOS"
+      ]
     },
     {
       "id": "T1053.003",
@@ -1347,7 +1744,12 @@
       ],
       "description": "Adversaries may abuse the <code>cron</code> utility to perform task scheduling for initial or recurring execution of malicious code.(Citation: 20 macOS Common Tools and Techniques) The…",
       "url": "https://attack.mitre.org/techniques/T1053/003",
-      "is_subtechnique": true
+      "is_subtechnique": true,
+      "platforms": [
+        "Linux",
+        "macOS",
+        "ESXi"
+      ]
     },
     {
       "id": "T1053.005",
@@ -1360,7 +1762,10 @@
       ],
       "description": "Adversaries may abuse the Windows Task Scheduler to perform task scheduling for initial or recurring execution of malicious code. There are multiple ways to access the Task Scheduler in Windows. The…",
       "url": "https://attack.mitre.org/techniques/T1053/005",
-      "is_subtechnique": true
+      "is_subtechnique": true,
+      "platforms": [
+        "Windows"
+      ]
     },
     {
       "id": "T1053.006",
@@ -1373,7 +1778,10 @@
       ],
       "description": "Adversaries may abuse systemd timers to perform task scheduling for initial or recurring execution of malicious code. Systemd timers are unit files with file extension <code>.timer</code> that…",
       "url": "https://attack.mitre.org/techniques/T1053/006",
-      "is_subtechnique": true
+      "is_subtechnique": true,
+      "platforms": [
+        "Linux"
+      ]
     },
     {
       "id": "T1053.007",
@@ -1386,7 +1794,10 @@
       ],
       "description": "Adversaries may abuse task scheduling functionality provided by container orchestration tools such as Kubernetes to schedule deployment of containers configured to execute malicious code. Container…",
       "url": "https://attack.mitre.org/techniques/T1053/007",
-      "is_subtechnique": true
+      "is_subtechnique": true,
+      "platforms": [
+        "Containers"
+      ]
     },
     {
       "id": "T1059",
@@ -1397,7 +1808,19 @@
       ],
       "description": "Adversaries may abuse command and script interpreters to execute commands, scripts, or binaries. These interfaces and languages provide ways of interacting with computer systems and are a common…",
       "url": "https://attack.mitre.org/techniques/T1059",
-      "is_subtechnique": false
+      "is_subtechnique": false,
+      "platforms": [
+        "Containers",
+        "ESXi",
+        "IaaS",
+        "Identity Provider",
+        "Linux",
+        "macOS",
+        "Network Devices",
+        "Office Suite",
+        "SaaS",
+        "Windows"
+      ]
     },
     {
       "id": "T1059.001",
@@ -1408,7 +1831,10 @@
       ],
       "description": "Adversaries may abuse PowerShell commands and scripts for execution. PowerShell is a powerful interactive command-line interface and scripting environment included in the Windows operating…",
       "url": "https://attack.mitre.org/techniques/T1059/001",
-      "is_subtechnique": true
+      "is_subtechnique": true,
+      "platforms": [
+        "Windows"
+      ]
     },
     {
       "id": "T1059.002",
@@ -1419,7 +1845,10 @@
       ],
       "description": "Adversaries may abuse AppleScript for execution. AppleScript is a macOS scripting language designed to control applications and parts of the OS via inter-application messages called…",
       "url": "https://attack.mitre.org/techniques/T1059/002",
-      "is_subtechnique": true
+      "is_subtechnique": true,
+      "platforms": [
+        "macOS"
+      ]
     },
     {
       "id": "T1059.003",
@@ -1430,7 +1859,10 @@
       ],
       "description": "Adversaries may abuse the Windows command shell for execution. The Windows command shell ([cmd](https://attack.mitre.org/software/S0106)) is the primary command prompt on Windows systems. The Windows…",
       "url": "https://attack.mitre.org/techniques/T1059/003",
-      "is_subtechnique": true
+      "is_subtechnique": true,
+      "platforms": [
+        "Windows"
+      ]
     },
     {
       "id": "T1059.004",
@@ -1441,7 +1873,13 @@
       ],
       "description": "Adversaries may abuse Unix shell commands and scripts for execution. Unix shells are the primary command prompt on Linux, macOS, and ESXi systems, though many variations of the Unix shell exist (e.g.…",
       "url": "https://attack.mitre.org/techniques/T1059/004",
-      "is_subtechnique": true
+      "is_subtechnique": true,
+      "platforms": [
+        "ESXi",
+        "Linux",
+        "macOS",
+        "Network Devices"
+      ]
     },
     {
       "id": "T1059.005",
@@ -1452,7 +1890,12 @@
       ],
       "description": "Adversaries may abuse Visual Basic (VB) for execution. VB is a programming language created by Microsoft with interoperability with many Windows technologies such as [Component Object…",
       "url": "https://attack.mitre.org/techniques/T1059/005",
-      "is_subtechnique": true
+      "is_subtechnique": true,
+      "platforms": [
+        "Linux",
+        "macOS",
+        "Windows"
+      ]
     },
     {
       "id": "T1059.006",
@@ -1463,7 +1906,13 @@
       ],
       "description": "Adversaries may abuse Python commands and scripts for execution. Python is a very popular scripting/programming language, with capabilities to perform many functions. Python can be executed…",
       "url": "https://attack.mitre.org/techniques/T1059/006",
-      "is_subtechnique": true
+      "is_subtechnique": true,
+      "platforms": [
+        "ESXi",
+        "Linux",
+        "macOS",
+        "Windows"
+      ]
     },
     {
       "id": "T1059.007",
@@ -1474,7 +1923,12 @@
       ],
       "description": "Adversaries may abuse various implementations of JavaScript for execution. JavaScript (JS) is a platform-independent scripting language (compiled just-in-time at runtime) commonly associated with…",
       "url": "https://attack.mitre.org/techniques/T1059/007",
-      "is_subtechnique": true
+      "is_subtechnique": true,
+      "platforms": [
+        "Linux",
+        "macOS",
+        "Windows"
+      ]
     },
     {
       "id": "T1059.008",
@@ -1485,7 +1939,10 @@
       ],
       "description": "Adversaries may abuse scripting or built-in command line interpreters (CLI) on network devices to execute malicious command and payloads. The CLI is the primary means through which users and…",
       "url": "https://attack.mitre.org/techniques/T1059/008",
-      "is_subtechnique": true
+      "is_subtechnique": true,
+      "platforms": [
+        "Network Devices"
+      ]
     },
     {
       "id": "T1059.009",
@@ -1496,7 +1953,13 @@
       ],
       "description": "Adversaries may abuse cloud APIs to execute malicious commands. APIs available in cloud environments provide various functionalities and are a feature-rich method for programmatic access to nearly…",
       "url": "https://attack.mitre.org/techniques/T1059/009",
-      "is_subtechnique": true
+      "is_subtechnique": true,
+      "platforms": [
+        "IaaS",
+        "Identity Provider",
+        "Office Suite",
+        "SaaS"
+      ]
     },
     {
       "id": "T1059.010",
@@ -1507,7 +1970,10 @@
       ],
       "description": "Adversaries may execute commands and perform malicious tasks using AutoIT and AutoHotKey automation scripts. AutoIT and AutoHotkey (AHK) are scripting languages that enable users to automate Windows…",
       "url": "https://attack.mitre.org/techniques/T1059/010",
-      "is_subtechnique": true
+      "is_subtechnique": true,
+      "platforms": [
+        "Windows"
+      ]
     },
     {
       "id": "T1059.011",
@@ -1518,7 +1984,13 @@
       ],
       "description": "Adversaries may abuse Lua commands and scripts for execution. Lua is a cross-platform scripting and programming language primarily designed for embedded use in applications. Lua can be executed on…",
       "url": "https://attack.mitre.org/techniques/T1059/011",
-      "is_subtechnique": true
+      "is_subtechnique": true,
+      "platforms": [
+        "Linux",
+        "Network Devices",
+        "Windows",
+        "macOS"
+      ]
     },
     {
       "id": "T1059.012",
@@ -1529,7 +2001,10 @@
       ],
       "description": "Adversaries may abuse hypervisor command line interpreters (CLIs) to execute malicious commands. Hypervisor CLIs typically enable a wide variety of functionality for managing both the hypervisor…",
       "url": "https://attack.mitre.org/techniques/T1059/012",
-      "is_subtechnique": true
+      "is_subtechnique": true,
+      "platforms": [
+        "ESXi"
+      ]
     },
     {
       "id": "T1059.013",
@@ -1540,7 +2015,10 @@
       ],
       "description": "Adversaries may abuse built-in CLI tools or API calls to execute malicious commands in containerized environments.\n\nThe Docker CLI is used for managing containers via an exposed API point from the…",
       "url": "https://attack.mitre.org/techniques/T1059/013",
-      "is_subtechnique": true
+      "is_subtechnique": true,
+      "platforms": [
+        "Containers"
+      ]
     },
     {
       "id": "T1072",
@@ -1552,7 +2030,14 @@
       ],
       "description": "Adversaries may gain access to and use centralized software suites installed within an enterprise to execute commands and move laterally through the network. Configuration management and software…",
       "url": "https://attack.mitre.org/techniques/T1072",
-      "is_subtechnique": false
+      "is_subtechnique": false,
+      "platforms": [
+        "Linux",
+        "macOS",
+        "Network Devices",
+        "SaaS",
+        "Windows"
+      ]
     },
     {
       "id": "T1106",
@@ -1563,7 +2048,12 @@
       ],
       "description": "Adversaries may interact with the native OS application programming interface (API) to execute behaviors. Native APIs provide a controlled means of calling low-level OS services within the kernel,…",
       "url": "https://attack.mitre.org/techniques/T1106",
-      "is_subtechnique": false
+      "is_subtechnique": false,
+      "platforms": [
+        "Linux",
+        "macOS",
+        "Windows"
+      ]
     },
     {
       "id": "T1129",
@@ -1574,7 +2064,12 @@
       ],
       "description": "Adversaries may execute malicious payloads via loading shared modules. Shared modules are executable files that are loaded into processes to provide access to reusable code, such as specific custom…",
       "url": "https://attack.mitre.org/techniques/T1129",
-      "is_subtechnique": false
+      "is_subtechnique": false,
+      "platforms": [
+        "Linux",
+        "macOS",
+        "Windows"
+      ]
     },
     {
       "id": "T1203",
@@ -1585,7 +2080,12 @@
       ],
       "description": "Adversaries may exploit software vulnerabilities in client applications to execute code. Vulnerabilities can exist in software due to unsecure coding practices that can lead to unanticipated…",
       "url": "https://attack.mitre.org/techniques/T1203",
-      "is_subtechnique": false
+      "is_subtechnique": false,
+      "platforms": [
+        "Linux",
+        "macOS",
+        "Windows"
+      ]
     },
     {
       "id": "T1204",
@@ -1596,7 +2096,14 @@
       ],
       "description": "An adversary may rely upon specific actions by a user in order to gain execution. Users may be subjected to social engineering to get them to execute malicious code by, for example, opening a…",
       "url": "https://attack.mitre.org/techniques/T1204",
-      "is_subtechnique": false
+      "is_subtechnique": false,
+      "platforms": [
+        "Linux",
+        "Windows",
+        "macOS",
+        "IaaS",
+        "Containers"
+      ]
     },
     {
       "id": "T1204.001",
@@ -1607,7 +2114,12 @@
       ],
       "description": "An adversary may rely upon a user clicking a malicious link in order to gain execution. Users may be subjected to social engineering to get them to click on a link that will lead to code execution.…",
       "url": "https://attack.mitre.org/techniques/T1204/001",
-      "is_subtechnique": true
+      "is_subtechnique": true,
+      "platforms": [
+        "Linux",
+        "macOS",
+        "Windows"
+      ]
     },
     {
       "id": "T1204.002",
@@ -1618,7 +2130,12 @@
       ],
       "description": "An adversary may rely upon a user opening a malicious file in order to gain execution. Users may be subjected to social engineering to get them to open a file that will lead to code execution. This…",
       "url": "https://attack.mitre.org/techniques/T1204/002",
-      "is_subtechnique": true
+      "is_subtechnique": true,
+      "platforms": [
+        "Linux",
+        "macOS",
+        "Windows"
+      ]
     },
     {
       "id": "T1204.003",
@@ -1629,7 +2146,11 @@
       ],
       "description": "Adversaries may rely on a user running a malicious image to facilitate execution. Amazon Web Services (AWS) Amazon Machine Images (AMIs), Google Cloud Platform (GCP) Images, and Azure Images as well…",
       "url": "https://attack.mitre.org/techniques/T1204/003",
-      "is_subtechnique": true
+      "is_subtechnique": true,
+      "platforms": [
+        "IaaS",
+        "Containers"
+      ]
     },
     {
       "id": "T1204.004",
@@ -1640,7 +2161,12 @@
       ],
       "description": "An adversary may rely upon a user copying and pasting code in order to gain execution. Users may be subjected to social engineering to get them to copy and paste code directly into a [Command and…",
       "url": "https://attack.mitre.org/techniques/T1204/004",
-      "is_subtechnique": true
+      "is_subtechnique": true,
+      "platforms": [
+        "Linux",
+        "macOS",
+        "Windows"
+      ]
     },
     {
       "id": "T1204.005",
@@ -1651,7 +2177,12 @@
       ],
       "description": "Adversaries may rely on a user installing a malicious library to facilitate execution. Threat actors may [Upload Malware](https://attack.mitre.org/techniques/T1608/001) to package managers such as…",
       "url": "https://attack.mitre.org/techniques/T1204/005",
-      "is_subtechnique": true
+      "is_subtechnique": true,
+      "platforms": [
+        "Linux",
+        "macOS",
+        "Windows"
+      ]
     },
     {
       "id": "T1559",
@@ -1662,7 +2193,12 @@
       ],
       "description": "Adversaries may abuse inter-process communication (IPC) mechanisms for local code or command execution. IPC is typically used by processes to share data, communicate with each other, or synchronize…",
       "url": "https://attack.mitre.org/techniques/T1559",
-      "is_subtechnique": false
+      "is_subtechnique": false,
+      "platforms": [
+        "Linux",
+        "macOS",
+        "Windows"
+      ]
     },
     {
       "id": "T1559.001",
@@ -1673,7 +2209,10 @@
       ],
       "description": "Adversaries may use the Windows Component Object Model (COM) for local code execution. COM is an inter-process communication (IPC) component of the native Windows application programming interface…",
       "url": "https://attack.mitre.org/techniques/T1559/001",
-      "is_subtechnique": true
+      "is_subtechnique": true,
+      "platforms": [
+        "Windows"
+      ]
     },
     {
       "id": "T1559.002",
@@ -1684,7 +2223,10 @@
       ],
       "description": "Adversaries may use Windows Dynamic Data Exchange (DDE) to execute arbitrary commands. DDE is a client-server protocol for one-time and/or continuous inter-process communication (IPC) between…",
       "url": "https://attack.mitre.org/techniques/T1559/002",
-      "is_subtechnique": true
+      "is_subtechnique": true,
+      "platforms": [
+        "Windows"
+      ]
     },
     {
       "id": "T1559.003",
@@ -1695,7 +2237,10 @@
       ],
       "description": "Adversaries can provide malicious content to an XPC service daemon for local code execution. macOS uses XPC services for basic inter-process communication between various processes, such as between…",
       "url": "https://attack.mitre.org/techniques/T1559/003",
-      "is_subtechnique": true
+      "is_subtechnique": true,
+      "platforms": [
+        "macOS"
+      ]
     },
     {
       "id": "T1569",
@@ -1706,7 +2251,12 @@
       ],
       "description": "Adversaries may abuse system services or daemons to execute commands or programs. Adversaries can execute malicious content by interacting with or creating services either locally or remotely. Many…",
       "url": "https://attack.mitre.org/techniques/T1569",
-      "is_subtechnique": false
+      "is_subtechnique": false,
+      "platforms": [
+        "Windows",
+        "macOS",
+        "Linux"
+      ]
     },
     {
       "id": "T1569.001",
@@ -1717,7 +2267,10 @@
       ],
       "description": "Adversaries may abuse launchctl to execute commands or programs. Launchctl interfaces with launchd, the service management framework for macOS. Launchctl supports taking subcommands on the…",
       "url": "https://attack.mitre.org/techniques/T1569/001",
-      "is_subtechnique": true
+      "is_subtechnique": true,
+      "platforms": [
+        "macOS"
+      ]
     },
     {
       "id": "T1569.002",
@@ -1728,7 +2281,10 @@
       ],
       "description": "Adversaries may abuse the Windows service control manager to execute malicious commands or payloads. The Windows service control manager (<code>services.exe</code>) is an interface to manage and…",
       "url": "https://attack.mitre.org/techniques/T1569/002",
-      "is_subtechnique": true
+      "is_subtechnique": true,
+      "platforms": [
+        "Windows"
+      ]
     },
     {
       "id": "T1569.003",
@@ -1739,7 +2295,10 @@
       ],
       "description": "Adversaries may abuse systemctl to execute commands or programs. Systemctl is the primary interface for systemd, the Linux init system and service manager. Typically invoked from a shell, Systemctl…",
       "url": "https://attack.mitre.org/techniques/T1569/003",
-      "is_subtechnique": true
+      "is_subtechnique": true,
+      "platforms": [
+        "Linux"
+      ]
     },
     {
       "id": "T1609",
@@ -1750,7 +2309,10 @@
       ],
       "description": "Adversaries may abuse a container administration service to execute commands within a container. A container administration service such as the Docker daemon, the Kubernetes API server, or the…",
       "url": "https://attack.mitre.org/techniques/T1609",
-      "is_subtechnique": false
+      "is_subtechnique": false,
+      "platforms": [
+        "Containers"
+      ]
     },
     {
       "id": "T1610",
@@ -1761,7 +2323,10 @@
       ],
       "description": "Adversaries may deploy a container into an environment to facilitate execution or evade defenses. In some cases, adversaries may deploy a new container to execute processes associated with a…",
       "url": "https://attack.mitre.org/techniques/T1610",
-      "is_subtechnique": false
+      "is_subtechnique": false,
+      "platforms": [
+        "Containers"
+      ]
     },
     {
       "id": "T1648",
@@ -1772,7 +2337,12 @@
       ],
       "description": "Adversaries may abuse serverless computing, integration, and automation services to execute arbitrary code in cloud environments. Many cloud providers offer a variety of serverless resources,…",
       "url": "https://attack.mitre.org/techniques/T1648",
-      "is_subtechnique": false
+      "is_subtechnique": false,
+      "platforms": [
+        "SaaS",
+        "IaaS",
+        "Office Suite"
+      ]
     },
     {
       "id": "T1651",
@@ -1783,7 +2353,10 @@
       ],
       "description": "Adversaries may abuse cloud management services to execute commands within virtual machines. Resources such as AWS Systems Manager, Azure RunCommand, and Runbooks allow users to remotely run scripts…",
       "url": "https://attack.mitre.org/techniques/T1651",
-      "is_subtechnique": false
+      "is_subtechnique": false,
+      "platforms": [
+        "IaaS"
+      ]
     },
     {
       "id": "T1674",
@@ -1794,7 +2367,12 @@
       ],
       "description": "Adversaries may simulate keystrokes on a victim’s computer by various means to perform any type of action on behalf of the user, such as launching the command interpreter using keyboard shortcuts, …",
       "url": "https://attack.mitre.org/techniques/T1674",
-      "is_subtechnique": false
+      "is_subtechnique": false,
+      "platforms": [
+        "Windows",
+        "macOS",
+        "Linux"
+      ]
     },
     {
       "id": "T1675",
@@ -1805,7 +2383,10 @@
       ],
       "description": "Adversaries may abuse ESXi administration services to execute commands on guest machines hosted within an ESXi virtual environment. Persistent background services on ESXi-hosted VMs, such as the…",
       "url": "https://attack.mitre.org/techniques/T1675",
-      "is_subtechnique": false
+      "is_subtechnique": false,
+      "platforms": [
+        "ESXi"
+      ]
     },
     {
       "id": "T1677",
@@ -1816,7 +2397,10 @@
       ],
       "description": "Adversaries may manipulate continuous integration / continuous development (CI/CD) processes by injecting malicious code into the build process. There are several mechanisms for poisoning pipelines:…",
       "url": "https://attack.mitre.org/techniques/T1677",
-      "is_subtechnique": false
+      "is_subtechnique": false,
+      "platforms": [
+        "SaaS"
+      ]
     },
     {
       "id": "T1037",
@@ -1828,7 +2412,14 @@
       ],
       "description": "Adversaries may use scripts automatically executed at boot or logon initialization to establish persistence.(Citation: Mandiant APT29 Eye Spy Email Nov 22)(Citation: Anomali Rocke March 2019)…",
       "url": "https://attack.mitre.org/techniques/T1037",
-      "is_subtechnique": false
+      "is_subtechnique": false,
+      "platforms": [
+        "ESXi",
+        "Linux",
+        "macOS",
+        "Network Devices",
+        "Windows"
+      ]
     },
     {
       "id": "T1037.001",
@@ -1840,7 +2431,10 @@
       ],
       "description": "Adversaries may use Windows logon scripts automatically executed at logon initialization to establish persistence. Windows allows logon scripts to be run whenever a specific user or group of users…",
       "url": "https://attack.mitre.org/techniques/T1037/001",
-      "is_subtechnique": true
+      "is_subtechnique": true,
+      "platforms": [
+        "Windows"
+      ]
     },
     {
       "id": "T1037.002",
@@ -1852,7 +2446,10 @@
       ],
       "description": "Adversaries may use a Login Hook to establish persistence executed upon user logon. A login hook is a plist file that points to a specific script to execute with root privileges upon user logon. The…",
       "url": "https://attack.mitre.org/techniques/T1037/002",
-      "is_subtechnique": true
+      "is_subtechnique": true,
+      "platforms": [
+        "macOS"
+      ]
     },
     {
       "id": "T1037.003",
@@ -1864,7 +2461,10 @@
       ],
       "description": "Adversaries may use network logon scripts automatically executed at logon initialization to establish persistence. Network logon scripts can be assigned using Active Directory or Group Policy…",
       "url": "https://attack.mitre.org/techniques/T1037/003",
-      "is_subtechnique": true
+      "is_subtechnique": true,
+      "platforms": [
+        "Windows"
+      ]
     },
     {
       "id": "T1037.004",
@@ -1876,7 +2476,13 @@
       ],
       "description": "Adversaries may establish persistence by modifying RC scripts, which are executed during a Unix-like system’s startup. These files allow system administrators to map and start custom services at…",
       "url": "https://attack.mitre.org/techniques/T1037/004",
-      "is_subtechnique": true
+      "is_subtechnique": true,
+      "platforms": [
+        "macOS",
+        "Linux",
+        "Network Devices",
+        "ESXi"
+      ]
     },
     {
       "id": "T1037.005",
@@ -1888,7 +2494,10 @@
       ],
       "description": "Adversaries may use startup items automatically executed at boot initialization to establish persistence. Startup items execute during the final phase of the boot process and contain shell scripts or…",
       "url": "https://attack.mitre.org/techniques/T1037/005",
-      "is_subtechnique": true
+      "is_subtechnique": true,
+      "platforms": [
+        "macOS"
+      ]
     },
     {
       "id": "T1098",
@@ -1900,7 +2509,19 @@
       ],
       "description": "Adversaries may manipulate accounts to maintain and/or elevate access to victim systems. Account manipulation may consist of any action that preserves or modifies adversary access to a compromised…",
       "url": "https://attack.mitre.org/techniques/T1098",
-      "is_subtechnique": false
+      "is_subtechnique": false,
+      "platforms": [
+        "Containers",
+        "ESXi",
+        "IaaS",
+        "Identity Provider",
+        "Linux",
+        "macOS",
+        "Network Devices",
+        "Office Suite",
+        "SaaS",
+        "Windows"
+      ]
     },
     {
       "id": "T1098.001",
@@ -1912,7 +2533,12 @@
       ],
       "description": "Adversaries may add adversary-controlled credentials to a cloud account to maintain persistent access to victim accounts and instances within the environment.\n\nFor example, adversaries may add…",
       "url": "https://attack.mitre.org/techniques/T1098/001",
-      "is_subtechnique": true
+      "is_subtechnique": true,
+      "platforms": [
+        "IaaS",
+        "Identity Provider",
+        "SaaS"
+      ]
     },
     {
       "id": "T1098.002",
@@ -1924,7 +2550,11 @@
       ],
       "description": "Adversaries may grant additional permission levels to maintain persistent access to an adversary-controlled email account. \n\nFor example, the <code>Add-MailboxPermission</code>…",
       "url": "https://attack.mitre.org/techniques/T1098/002",
-      "is_subtechnique": true
+      "is_subtechnique": true,
+      "platforms": [
+        "Windows",
+        "Office Suite"
+      ]
     },
     {
       "id": "T1098.003",
@@ -1936,7 +2566,13 @@
       ],
       "description": "An adversary may add additional roles or permissions to an adversary-controlled cloud account to maintain persistent access to a tenant. For example, adversaries may update IAM policies in…",
       "url": "https://attack.mitre.org/techniques/T1098/003",
-      "is_subtechnique": true
+      "is_subtechnique": true,
+      "platforms": [
+        "IaaS",
+        "Identity Provider",
+        "Office Suite",
+        "SaaS"
+      ]
     },
     {
       "id": "T1098.004",
@@ -1948,7 +2584,14 @@
       ],
       "description": "Adversaries may modify the SSH <code>authorized_keys</code> file to maintain persistence on a victim host. Linux distributions, macOS, and ESXi hypervisors commonly use key-based authentication to…",
       "url": "https://attack.mitre.org/techniques/T1098/004",
-      "is_subtechnique": true
+      "is_subtechnique": true,
+      "platforms": [
+        "ESXi",
+        "IaaS",
+        "Linux",
+        "macOS",
+        "Network Devices"
+      ]
     },
     {
       "id": "T1098.005",
@@ -1960,7 +2603,11 @@
       ],
       "description": "Adversaries may register a device to an adversary-controlled account. Devices may be registered in a multifactor authentication (MFA) system, which handles authentication to the network, or in a…",
       "url": "https://attack.mitre.org/techniques/T1098/005",
-      "is_subtechnique": true
+      "is_subtechnique": true,
+      "platforms": [
+        "Windows",
+        "Identity Provider"
+      ]
     },
     {
       "id": "T1098.006",
@@ -1972,7 +2619,10 @@
       ],
       "description": "An adversary may add additional roles or permissions to an adversary-controlled user or service account to maintain persistent access to a container orchestration system. For example, an adversary…",
       "url": "https://attack.mitre.org/techniques/T1098/006",
-      "is_subtechnique": true
+      "is_subtechnique": true,
+      "platforms": [
+        "Containers"
+      ]
     },
     {
       "id": "T1098.007",
@@ -1984,7 +2634,12 @@
       ],
       "description": "An adversary may add additional local or domain groups to an adversary-controlled account to maintain persistent access to a system or domain.\n\nOn Windows, accounts may use the `net localgroup` and…",
       "url": "https://attack.mitre.org/techniques/T1098/007",
-      "is_subtechnique": true
+      "is_subtechnique": true,
+      "platforms": [
+        "Windows",
+        "macOS",
+        "Linux"
+      ]
     },
     {
       "id": "T1133",
@@ -1996,7 +2651,13 @@
       ],
       "description": "Adversaries may leverage external-facing remote services to initially access and/or persist within a network. Remote services such as VPNs, Citrix, and other access mechanisms allow users to connect…",
       "url": "https://attack.mitre.org/techniques/T1133",
-      "is_subtechnique": false
+      "is_subtechnique": false,
+      "platforms": [
+        "Containers",
+        "Linux",
+        "macOS",
+        "Windows"
+      ]
     },
     {
       "id": "T1136",
@@ -2007,7 +2668,19 @@
       ],
       "description": "Adversaries may create an account to maintain access to victim systems.(Citation: Symantec WastedLocker June 2020) With a sufficient level of access, creating such accounts may be used to establish…",
       "url": "https://attack.mitre.org/techniques/T1136",
-      "is_subtechnique": false
+      "is_subtechnique": false,
+      "platforms": [
+        "Windows",
+        "IaaS",
+        "Linux",
+        "macOS",
+        "Network Devices",
+        "Containers",
+        "SaaS",
+        "Office Suite",
+        "Identity Provider",
+        "ESXi"
+      ]
     },
     {
       "id": "T1136.001",
@@ -2018,7 +2691,15 @@
       ],
       "description": "Adversaries may create a local account to maintain access to victim systems. Local accounts are those configured by an organization for use by users, remote support, services, or for administration…",
       "url": "https://attack.mitre.org/techniques/T1136/001",
-      "is_subtechnique": true
+      "is_subtechnique": true,
+      "platforms": [
+        "Containers",
+        "ESXi",
+        "Linux",
+        "macOS",
+        "Network Devices",
+        "Windows"
+      ]
     },
     {
       "id": "T1136.002",
@@ -2029,7 +2710,12 @@
       ],
       "description": "Adversaries may create a domain account to maintain access to victim systems. Domain accounts are those managed by Active Directory Domain Services where access and permissions are configured across…",
       "url": "https://attack.mitre.org/techniques/T1136/002",
-      "is_subtechnique": true
+      "is_subtechnique": true,
+      "platforms": [
+        "Linux",
+        "macOS",
+        "Windows"
+      ]
     },
     {
       "id": "T1136.003",
@@ -2040,7 +2726,13 @@
       ],
       "description": "Adversaries may create a cloud account to maintain access to victim systems. With a sufficient level of access, such accounts may be used to establish secondary credentialed access that does not…",
       "url": "https://attack.mitre.org/techniques/T1136/003",
-      "is_subtechnique": true
+      "is_subtechnique": true,
+      "platforms": [
+        "IaaS",
+        "SaaS",
+        "Office Suite",
+        "Identity Provider"
+      ]
     },
     {
       "id": "T1137",
@@ -2051,7 +2743,11 @@
       ],
       "description": "Adversaries may leverage Microsoft Office-based applications for persistence between startups. Microsoft Office is a fairly common application suite on Windows-based operating systems within an…",
       "url": "https://attack.mitre.org/techniques/T1137",
-      "is_subtechnique": false
+      "is_subtechnique": false,
+      "platforms": [
+        "Windows",
+        "Office Suite"
+      ]
     },
     {
       "id": "T1137.001",
@@ -2062,7 +2758,11 @@
       ],
       "description": "Adversaries may abuse Microsoft Office templates to obtain persistence on a compromised system. Microsoft Office contains templates that are part of common Office applications and are used to…",
       "url": "https://attack.mitre.org/techniques/T1137/001",
-      "is_subtechnique": true
+      "is_subtechnique": true,
+      "platforms": [
+        "Office Suite",
+        "Windows"
+      ]
     },
     {
       "id": "T1137.002",
@@ -2073,7 +2773,11 @@
       ],
       "description": "Adversaries may abuse the Microsoft Office \"Office Test\" Registry key to obtain persistence on a compromised system. An Office Test Registry location exists that allows a user to specify an arbitrary…",
       "url": "https://attack.mitre.org/techniques/T1137/002",
-      "is_subtechnique": true
+      "is_subtechnique": true,
+      "platforms": [
+        "Windows",
+        "Office Suite"
+      ]
     },
     {
       "id": "T1137.003",
@@ -2084,7 +2788,11 @@
       ],
       "description": "Adversaries may abuse Microsoft Outlook forms to obtain persistence on a compromised system. Outlook forms are used as templates for presentation and functionality in Outlook messages. Custom Outlook…",
       "url": "https://attack.mitre.org/techniques/T1137/003",
-      "is_subtechnique": true
+      "is_subtechnique": true,
+      "platforms": [
+        "Windows",
+        "Office Suite"
+      ]
     },
     {
       "id": "T1137.004",
@@ -2095,7 +2803,11 @@
       ],
       "description": "Adversaries may abuse Microsoft Outlook's Home Page feature to obtain persistence on a compromised system. Outlook Home Page is a legacy feature used to customize the presentation of Outlook folders.…",
       "url": "https://attack.mitre.org/techniques/T1137/004",
-      "is_subtechnique": true
+      "is_subtechnique": true,
+      "platforms": [
+        "Windows",
+        "Office Suite"
+      ]
     },
     {
       "id": "T1137.005",
@@ -2106,7 +2818,11 @@
       ],
       "description": "Adversaries may abuse Microsoft Outlook rules to obtain persistence on a compromised system. Outlook rules allow a user to define automated behavior to manage email messages. A benign rule might, for…",
       "url": "https://attack.mitre.org/techniques/T1137/005",
-      "is_subtechnique": true
+      "is_subtechnique": true,
+      "platforms": [
+        "Windows",
+        "Office Suite"
+      ]
     },
     {
       "id": "T1137.006",
@@ -2117,7 +2833,11 @@
       ],
       "description": "Adversaries may abuse Microsoft Office add-ins to obtain persistence on a compromised system. Office add-ins can be used to add functionality to Office programs. (Citation: Microsoft Office Add-ins)…",
       "url": "https://attack.mitre.org/techniques/T1137/006",
-      "is_subtechnique": true
+      "is_subtechnique": true,
+      "platforms": [
+        "Windows",
+        "Office Suite"
+      ]
     },
     {
       "id": "T1176",
@@ -2128,7 +2848,12 @@
       ],
       "description": "Adversaries may abuse software extensions to establish persistent access to victim systems. Software extensions are modular components that enhance or customize the functionality of software…",
       "url": "https://attack.mitre.org/techniques/T1176",
-      "is_subtechnique": false
+      "is_subtechnique": false,
+      "platforms": [
+        "Linux",
+        "macOS",
+        "Windows"
+      ]
     },
     {
       "id": "T1176.001",
@@ -2139,7 +2864,12 @@
       ],
       "description": "Adversaries may abuse internet browser extensions to establish persistent access to victim systems. Browser extensions or plugins are small programs that can add functionality to and customize…",
       "url": "https://attack.mitre.org/techniques/T1176/001",
-      "is_subtechnique": true
+      "is_subtechnique": true,
+      "platforms": [
+        "Linux",
+        "Windows",
+        "macOS"
+      ]
     },
     {
       "id": "T1176.002",
@@ -2150,7 +2880,12 @@
       ],
       "description": "Adversaries may abuse an integrated development environment (IDE) extension to establish persistent access to victim systems.(Citation: Mnemonic misuse visual studio) IDEs such as Visual Studio Code,…",
       "url": "https://attack.mitre.org/techniques/T1176/002",
-      "is_subtechnique": true
+      "is_subtechnique": true,
+      "platforms": [
+        "Linux",
+        "macOS",
+        "Windows"
+      ]
     },
     {
       "id": "T1505",
@@ -2161,7 +2896,14 @@
       ],
       "description": "Adversaries may abuse legitimate extensible development features of servers to establish persistent access to systems. Enterprise server applications may include features that allow developers to…",
       "url": "https://attack.mitre.org/techniques/T1505",
-      "is_subtechnique": false
+      "is_subtechnique": false,
+      "platforms": [
+        "Windows",
+        "Linux",
+        "macOS",
+        "Network Devices",
+        "ESXi"
+      ]
     },
     {
       "id": "T1505.001",
@@ -2172,7 +2914,11 @@
       ],
       "description": "Adversaries may abuse SQL stored procedures to establish persistent access to systems. SQL Stored Procedures are code that can be saved and reused so that database users do not waste time rewriting…",
       "url": "https://attack.mitre.org/techniques/T1505/001",
-      "is_subtechnique": true
+      "is_subtechnique": true,
+      "platforms": [
+        "Windows",
+        "Linux"
+      ]
     },
     {
       "id": "T1505.002",
@@ -2183,7 +2929,11 @@
       ],
       "description": "Adversaries may abuse Microsoft transport agents to establish persistent access to systems. Microsoft Exchange transport agents can operate on email messages passing through the transport pipeline to…",
       "url": "https://attack.mitre.org/techniques/T1505/002",
-      "is_subtechnique": true
+      "is_subtechnique": true,
+      "platforms": [
+        "Linux",
+        "Windows"
+      ]
     },
     {
       "id": "T1505.003",
@@ -2194,7 +2944,13 @@
       ],
       "description": "Adversaries may backdoor web servers with web shells to establish persistent access to systems. A Web shell is a Web script that is placed on an openly accessible Web server to allow an adversary to…",
       "url": "https://attack.mitre.org/techniques/T1505/003",
-      "is_subtechnique": true
+      "is_subtechnique": true,
+      "platforms": [
+        "Linux",
+        "macOS",
+        "Network Devices",
+        "Windows"
+      ]
     },
     {
       "id": "T1505.004",
@@ -2205,7 +2961,10 @@
       ],
       "description": "Adversaries may install malicious components that run on Internet Information Services (IIS) web servers to establish persistence. IIS provides several mechanisms to extend the functionality of the…",
       "url": "https://attack.mitre.org/techniques/T1505/004",
-      "is_subtechnique": true
+      "is_subtechnique": true,
+      "platforms": [
+        "Windows"
+      ]
     },
     {
       "id": "T1505.005",
@@ -2216,7 +2975,10 @@
       ],
       "description": "Adversaries may abuse components of Terminal Services to enable persistent access to systems. Microsoft Terminal Services, renamed to Remote Desktop Services in some Windows Server OSs as of 2022,…",
       "url": "https://attack.mitre.org/techniques/T1505/005",
-      "is_subtechnique": true
+      "is_subtechnique": true,
+      "platforms": [
+        "Windows"
+      ]
     },
     {
       "id": "T1505.006",
@@ -2227,7 +2989,10 @@
       ],
       "description": "Adversaries may abuse vSphere Installation Bundles (VIBs) to establish persistent access to ESXi hypervisors. VIBs are collections of files used for software distribution and virtual system…",
       "url": "https://attack.mitre.org/techniques/T1505/006",
-      "is_subtechnique": true
+      "is_subtechnique": true,
+      "platforms": [
+        "ESXi"
+      ]
     },
     {
       "id": "T1525",
@@ -2238,7 +3003,11 @@
       ],
       "description": "Adversaries may implant cloud or container images with malicious code to establish persistence after gaining access to an environment. Amazon Web Services (AWS) Amazon Machine Images (AMIs), Google…",
       "url": "https://attack.mitre.org/techniques/T1525",
-      "is_subtechnique": false
+      "is_subtechnique": false,
+      "platforms": [
+        "IaaS",
+        "Containers"
+      ]
     },
     {
       "id": "T1543",
@@ -2250,7 +3019,13 @@
       ],
       "description": "Adversaries may create or modify system-level processes to repeatedly execute malicious payloads as part of persistence. When operating systems boot up, they can start processes that perform…",
       "url": "https://attack.mitre.org/techniques/T1543",
-      "is_subtechnique": false
+      "is_subtechnique": false,
+      "platforms": [
+        "Containers",
+        "Linux",
+        "macOS",
+        "Windows"
+      ]
     },
     {
       "id": "T1543.001",
@@ -2262,7 +3037,10 @@
       ],
       "description": "Adversaries may create or modify launch agents to repeatedly execute malicious payloads as part of persistence. When a user logs in, a per-user launchd process is started which loads the parameters…",
       "url": "https://attack.mitre.org/techniques/T1543/001",
-      "is_subtechnique": true
+      "is_subtechnique": true,
+      "platforms": [
+        "macOS"
+      ]
     },
     {
       "id": "T1543.002",
@@ -2274,7 +3052,10 @@
       ],
       "description": "Adversaries may create or modify systemd services to repeatedly execute malicious payloads as part of persistence. Systemd is a system and service manager commonly used for managing background daemon…",
       "url": "https://attack.mitre.org/techniques/T1543/002",
-      "is_subtechnique": true
+      "is_subtechnique": true,
+      "platforms": [
+        "Linux"
+      ]
     },
     {
       "id": "T1543.003",
@@ -2286,7 +3067,10 @@
       ],
       "description": "Adversaries may create or modify Windows services to repeatedly execute malicious payloads as part of persistence. When Windows boots up, it starts programs or applications called services that…",
       "url": "https://attack.mitre.org/techniques/T1543/003",
-      "is_subtechnique": true
+      "is_subtechnique": true,
+      "platforms": [
+        "Windows"
+      ]
     },
     {
       "id": "T1543.004",
@@ -2298,7 +3082,10 @@
       ],
       "description": "Adversaries may create or modify Launch Daemons to execute malicious payloads as part of persistence. Launch Daemons are plist files used to interact with Launchd, the service management framework…",
       "url": "https://attack.mitre.org/techniques/T1543/004",
-      "is_subtechnique": true
+      "is_subtechnique": true,
+      "platforms": [
+        "macOS"
+      ]
     },
     {
       "id": "T1543.005",
@@ -2310,7 +3097,10 @@
       ],
       "description": "Adversaries may create or modify container or container cluster management tools that run as daemons, agents, or services on individual hosts. These include software for creating and managing…",
       "url": "https://attack.mitre.org/techniques/T1543/005",
-      "is_subtechnique": true
+      "is_subtechnique": true,
+      "platforms": [
+        "Containers"
+      ]
     },
     {
       "id": "T1546.017",
@@ -2322,7 +3112,10 @@
       ],
       "description": "Adversaries may maintain persistence through executing malicious content triggered using udev rules. Udev is the Linux kernel device manager that dynamically manages device nodes, handles access to…",
       "url": "https://attack.mitre.org/techniques/T1546/017",
-      "is_subtechnique": true
+      "is_subtechnique": true,
+      "platforms": [
+        "Linux"
+      ]
     },
     {
       "id": "T1546.018",
@@ -2334,7 +3127,12 @@
       ],
       "description": "Adversaries may achieve persistence by leveraging Python’s startup mechanisms, including path configuration (`.pth`) files and the `sitecustomize.py` or `usercustomize.py` modules. These files are…",
       "url": "https://attack.mitre.org/techniques/T1546/018",
-      "is_subtechnique": true
+      "is_subtechnique": true,
+      "platforms": [
+        "Linux",
+        "macOS",
+        "Windows"
+      ]
     },
     {
       "id": "T1547",
@@ -2346,7 +3144,13 @@
       ],
       "description": "Adversaries may configure system settings to automatically execute a program during system boot or logon to maintain persistence or gain higher-level privileges on compromised systems. Operating…",
       "url": "https://attack.mitre.org/techniques/T1547",
-      "is_subtechnique": false
+      "is_subtechnique": false,
+      "platforms": [
+        "Linux",
+        "macOS",
+        "Windows",
+        "Network Devices"
+      ]
     },
     {
       "id": "T1547.001",
@@ -2358,7 +3162,10 @@
       ],
       "description": "Adversaries may achieve persistence by adding a program to a startup folder or referencing it with a Registry run key. Adding an entry to the \"run keys\" in the Registry or startup folder will cause…",
       "url": "https://attack.mitre.org/techniques/T1547/001",
-      "is_subtechnique": true
+      "is_subtechnique": true,
+      "platforms": [
+        "Windows"
+      ]
     },
     {
       "id": "T1547.002",
@@ -2370,7 +3177,10 @@
       ],
       "description": "Adversaries may abuse authentication packages to execute DLLs when the system boots. Windows authentication package DLLs are loaded by the Local Security Authority (LSA) process at system start. They…",
       "url": "https://attack.mitre.org/techniques/T1547/002",
-      "is_subtechnique": true
+      "is_subtechnique": true,
+      "platforms": [
+        "Windows"
+      ]
     },
     {
       "id": "T1547.003",
@@ -2382,7 +3192,10 @@
       ],
       "description": "Adversaries may abuse time providers to execute DLLs when the system boots. The Windows Time service (W32Time) enables time synchronization across and within domains.(Citation: Microsoft W32Time Feb…",
       "url": "https://attack.mitre.org/techniques/T1547/003",
-      "is_subtechnique": true
+      "is_subtechnique": true,
+      "platforms": [
+        "Windows"
+      ]
     },
     {
       "id": "T1547.004",
@@ -2394,7 +3207,10 @@
       ],
       "description": "Adversaries may abuse features of Winlogon to execute DLLs and/or executables when a user logs in. Winlogon.exe is a Windows component responsible for actions at logon/logoff as well as the secure…",
       "url": "https://attack.mitre.org/techniques/T1547/004",
-      "is_subtechnique": true
+      "is_subtechnique": true,
+      "platforms": [
+        "Windows"
+      ]
     },
     {
       "id": "T1547.005",
@@ -2406,7 +3222,10 @@
       ],
       "description": "Adversaries may abuse security support providers (SSPs) to execute DLLs when the system boots. Windows SSP DLLs are loaded into the Local Security Authority (LSA) process at system start. Once loaded…",
       "url": "https://attack.mitre.org/techniques/T1547/005",
-      "is_subtechnique": true
+      "is_subtechnique": true,
+      "platforms": [
+        "Windows"
+      ]
     },
     {
       "id": "T1547.006",
@@ -2418,7 +3237,11 @@
       ],
       "description": "Adversaries may modify the kernel to automatically execute programs on system boot. Loadable Kernel Modules (LKMs) are pieces of code that can be loaded and unloaded into the kernel upon demand. They…",
       "url": "https://attack.mitre.org/techniques/T1547/006",
-      "is_subtechnique": true
+      "is_subtechnique": true,
+      "platforms": [
+        "macOS",
+        "Linux"
+      ]
     },
     {
       "id": "T1547.007",
@@ -2430,7 +3253,10 @@
       ],
       "description": "Adversaries may modify plist files to automatically run an application when a user logs in. When a user logs out or restarts via the macOS Graphical User Interface (GUI), a prompt is provided to the…",
       "url": "https://attack.mitre.org/techniques/T1547/007",
-      "is_subtechnique": true
+      "is_subtechnique": true,
+      "platforms": [
+        "macOS"
+      ]
     },
     {
       "id": "T1547.008",
@@ -2442,7 +3268,10 @@
       ],
       "description": "Adversaries may modify or add LSASS drivers to obtain persistence on compromised systems. The Windows security subsystem is a set of components that manage and enforce the security policy for a…",
       "url": "https://attack.mitre.org/techniques/T1547/008",
-      "is_subtechnique": true
+      "is_subtechnique": true,
+      "platforms": [
+        "Windows"
+      ]
     },
     {
       "id": "T1547.009",
@@ -2454,7 +3283,10 @@
       ],
       "description": "Adversaries may create or modify shortcuts that can execute a program during system boot or user login. Shortcuts or symbolic links are used to reference other files or programs that will be opened…",
       "url": "https://attack.mitre.org/techniques/T1547/009",
-      "is_subtechnique": true
+      "is_subtechnique": true,
+      "platforms": [
+        "Windows"
+      ]
     },
     {
       "id": "T1547.010",
@@ -2466,7 +3298,10 @@
       ],
       "description": "Adversaries may use port monitors to run an adversary supplied DLL during system boot for persistence or privilege escalation. A port monitor can be set through the <code>AddMonitor</code> API call…",
       "url": "https://attack.mitre.org/techniques/T1547/010",
-      "is_subtechnique": true
+      "is_subtechnique": true,
+      "platforms": [
+        "Windows"
+      ]
     },
     {
       "id": "T1547.012",
@@ -2478,7 +3313,10 @@
       ],
       "description": "Adversaries may abuse print processors to run malicious DLLs during system boot for persistence and/or privilege escalation. Print processors are DLLs that are loaded by the print spooler service,…",
       "url": "https://attack.mitre.org/techniques/T1547/012",
-      "is_subtechnique": true
+      "is_subtechnique": true,
+      "platforms": [
+        "Windows"
+      ]
     },
     {
       "id": "T1547.013",
@@ -2490,7 +3328,10 @@
       ],
       "description": "Adversaries may add or modify XDG Autostart Entries to execute malicious programs or commands when a user’s desktop environment is loaded at login. XDG Autostart entries are available for any…",
       "url": "https://attack.mitre.org/techniques/T1547/013",
-      "is_subtechnique": true
+      "is_subtechnique": true,
+      "platforms": [
+        "Linux"
+      ]
     },
     {
       "id": "T1547.014",
@@ -2502,7 +3343,10 @@
       ],
       "description": "Adversaries may achieve persistence by adding a Registry key to the Active Setup of the local machine. Active Setup is a Windows mechanism that is used to execute programs when a user logs in. The…",
       "url": "https://attack.mitre.org/techniques/T1547/014",
-      "is_subtechnique": true
+      "is_subtechnique": true,
+      "platforms": [
+        "Windows"
+      ]
     },
     {
       "id": "T1547.015",
@@ -2514,7 +3358,10 @@
       ],
       "description": "Adversaries may add login items to execute upon user login to gain persistence or escalate privileges. Login items are applications, documents, folders, or server connections that are automatically…",
       "url": "https://attack.mitre.org/techniques/T1547/015",
-      "is_subtechnique": true
+      "is_subtechnique": true,
+      "platforms": [
+        "macOS"
+      ]
     },
     {
       "id": "T1554",
@@ -2525,7 +3372,13 @@
       ],
       "description": "Adversaries may modify host software binaries to establish persistent access to systems. Software binaries/executables provide a wide range of system commands or services, programs, and libraries.…",
       "url": "https://attack.mitre.org/techniques/T1554",
-      "is_subtechnique": false
+      "is_subtechnique": false,
+      "platforms": [
+        "ESXi",
+        "Linux",
+        "macOS",
+        "Windows"
+      ]
     },
     {
       "id": "T1653",
@@ -2536,7 +3389,13 @@
       ],
       "description": "Adversaries may impair a system's ability to hibernate, reboot, or shut down in order to extend access to infected machines. When a computer enters a dormant state, some or all software and hardware…",
       "url": "https://attack.mitre.org/techniques/T1653",
-      "is_subtechnique": false
+      "is_subtechnique": false,
+      "platforms": [
+        "Windows",
+        "Linux",
+        "macOS",
+        "Network Devices"
+      ]
     },
     {
       "id": "T1668",
@@ -2547,7 +3406,12 @@
       ],
       "description": "Adversaries who successfully compromise a system may attempt to maintain persistence by “closing the door” behind them  – in other words, by preventing other threat actors from initially accessing or…",
       "url": "https://attack.mitre.org/techniques/T1668",
-      "is_subtechnique": false
+      "is_subtechnique": false,
+      "platforms": [
+        "Linux",
+        "macOS",
+        "Windows"
+      ]
     },
     {
       "id": "T1671",
@@ -2558,7 +3422,11 @@
       ],
       "description": "Adversaries may achieve persistence by leveraging OAuth application integrations in a software-as-a-service environment. Adversaries may create a custom application, add a legitimate application into…",
       "url": "https://attack.mitre.org/techniques/T1671",
-      "is_subtechnique": false
+      "is_subtechnique": false,
+      "platforms": [
+        "Office Suite",
+        "SaaS"
+      ]
     },
     {
       "id": "T1068",
@@ -2569,7 +3437,13 @@
       ],
       "description": "Adversaries may exploit software vulnerabilities in an attempt to elevate privileges. Exploitation of a software vulnerability occurs when an adversary takes advantage of a programming error in a…",
       "url": "https://attack.mitre.org/techniques/T1068",
-      "is_subtechnique": false
+      "is_subtechnique": false,
+      "platforms": [
+        "Containers",
+        "Linux",
+        "macOS",
+        "Windows"
+      ]
     },
     {
       "id": "T1546",
@@ -2581,7 +3455,15 @@
       ],
       "description": "Adversaries may establish persistence and/or elevate privileges using system mechanisms that trigger execution based on specific events. Various operating systems have means to monitor and subscribe…",
       "url": "https://attack.mitre.org/techniques/T1546",
-      "is_subtechnique": false
+      "is_subtechnique": false,
+      "platforms": [
+        "Linux",
+        "macOS",
+        "Windows",
+        "SaaS",
+        "IaaS",
+        "Office Suite"
+      ]
     },
     {
       "id": "T1546.001",
@@ -2593,7 +3475,10 @@
       ],
       "description": "Adversaries may establish persistence by executing malicious content triggered by a file type association. When a file is opened, the default program used to open the file (also called the file…",
       "url": "https://attack.mitre.org/techniques/T1546/001",
-      "is_subtechnique": true
+      "is_subtechnique": true,
+      "platforms": [
+        "Windows"
+      ]
     },
     {
       "id": "T1546.002",
@@ -2605,7 +3490,10 @@
       ],
       "description": "Adversaries may establish persistence by executing malicious content triggered by user inactivity. Screensavers are programs that execute after a configurable time of user inactivity and consist of…",
       "url": "https://attack.mitre.org/techniques/T1546/002",
-      "is_subtechnique": true
+      "is_subtechnique": true,
+      "platforms": [
+        "Windows"
+      ]
     },
     {
       "id": "T1546.003",
@@ -2617,7 +3505,10 @@
       ],
       "description": "Adversaries may establish persistence and elevate privileges by executing malicious content triggered by a Windows Management Instrumentation (WMI) event subscription. WMI can be used to install…",
       "url": "https://attack.mitre.org/techniques/T1546/003",
-      "is_subtechnique": true
+      "is_subtechnique": true,
+      "platforms": [
+        "Windows"
+      ]
     },
     {
       "id": "T1546.004",
@@ -2629,7 +3520,11 @@
       ],
       "description": "Adversaries may establish persistence through executing malicious commands triggered by a user’s shell. User [Unix Shell](https://attack.mitre.org/techniques/T1059/004)s execute several configuration…",
       "url": "https://attack.mitre.org/techniques/T1546/004",
-      "is_subtechnique": true
+      "is_subtechnique": true,
+      "platforms": [
+        "Linux",
+        "macOS"
+      ]
     },
     {
       "id": "T1546.005",
@@ -2641,7 +3536,11 @@
       ],
       "description": "Adversaries may establish persistence by executing malicious content triggered by an interrupt signal. The <code>trap</code> command allows programs and shells to specify commands that will be…",
       "url": "https://attack.mitre.org/techniques/T1546/005",
-      "is_subtechnique": true
+      "is_subtechnique": true,
+      "platforms": [
+        "macOS",
+        "Linux"
+      ]
     },
     {
       "id": "T1546.006",
@@ -2653,7 +3552,10 @@
       ],
       "description": "Adversaries may establish persistence by executing malicious content triggered by the execution of tainted binaries. Mach-O binaries have a series of headers that are used to perform certain…",
       "url": "https://attack.mitre.org/techniques/T1546/006",
-      "is_subtechnique": true
+      "is_subtechnique": true,
+      "platforms": [
+        "macOS"
+      ]
     },
     {
       "id": "T1546.007",
@@ -2665,7 +3567,10 @@
       ],
       "description": "Adversaries may establish persistence by executing malicious content triggered by Netsh Helper DLLs. Netsh.exe (also referred to as Netshell) is a command-line scripting utility used to interact with…",
       "url": "https://attack.mitre.org/techniques/T1546/007",
-      "is_subtechnique": true
+      "is_subtechnique": true,
+      "platforms": [
+        "Windows"
+      ]
     },
     {
       "id": "T1546.008",
@@ -2677,7 +3582,10 @@
       ],
       "description": "Adversaries may establish persistence and/or elevate privileges by executing malicious content triggered by accessibility features. Windows contains accessibility features that may be launched with a…",
       "url": "https://attack.mitre.org/techniques/T1546/008",
-      "is_subtechnique": true
+      "is_subtechnique": true,
+      "platforms": [
+        "Windows"
+      ]
     },
     {
       "id": "T1546.009",
@@ -2689,7 +3597,10 @@
       ],
       "description": "Adversaries may establish persistence and/or elevate privileges by executing malicious content triggered by AppCert DLLs loaded into processes. Dynamic-link libraries (DLLs) that are specified in the…",
       "url": "https://attack.mitre.org/techniques/T1546/009",
-      "is_subtechnique": true
+      "is_subtechnique": true,
+      "platforms": [
+        "Windows"
+      ]
     },
     {
       "id": "T1546.010",
@@ -2701,7 +3612,10 @@
       ],
       "description": "Adversaries may establish persistence and/or elevate privileges by executing malicious content triggered by AppInit DLLs loaded into processes. Dynamic-link libraries (DLLs) that are specified in the…",
       "url": "https://attack.mitre.org/techniques/T1546/010",
-      "is_subtechnique": true
+      "is_subtechnique": true,
+      "platforms": [
+        "Windows"
+      ]
     },
     {
       "id": "T1546.011",
@@ -2713,7 +3627,10 @@
       ],
       "description": "Adversaries may establish persistence and/or elevate privileges by executing malicious content triggered by application shims. The Microsoft Windows Application Compatibility Infrastructure/Framework…",
       "url": "https://attack.mitre.org/techniques/T1546/011",
-      "is_subtechnique": true
+      "is_subtechnique": true,
+      "platforms": [
+        "Windows"
+      ]
     },
     {
       "id": "T1546.012",
@@ -2725,7 +3642,10 @@
       ],
       "description": "Adversaries may establish persistence and/or elevate privileges by executing malicious content triggered by Image File Execution Options (IFEO) debuggers. IFEOs enable a developer to attach a…",
       "url": "https://attack.mitre.org/techniques/T1546/012",
-      "is_subtechnique": true
+      "is_subtechnique": true,
+      "platforms": [
+        "Windows"
+      ]
     },
     {
       "id": "T1546.013",
@@ -2737,7 +3657,10 @@
       ],
       "description": "Adversaries may gain persistence and elevate privileges by executing malicious content triggered by PowerShell profiles. A PowerShell profile  (<code>profile.ps1</code>) is a script that runs when…",
       "url": "https://attack.mitre.org/techniques/T1546/013",
-      "is_subtechnique": true
+      "is_subtechnique": true,
+      "platforms": [
+        "Windows"
+      ]
     },
     {
       "id": "T1546.014",
@@ -2749,7 +3672,10 @@
       ],
       "description": "Adversaries may gain persistence and elevate privileges by executing malicious content triggered by the Event Monitor Daemon (emond). Emond is a [Launch…",
       "url": "https://attack.mitre.org/techniques/T1546/014",
-      "is_subtechnique": true
+      "is_subtechnique": true,
+      "platforms": [
+        "macOS"
+      ]
     },
     {
       "id": "T1546.015",
@@ -2761,7 +3687,10 @@
       ],
       "description": "Adversaries may establish persistence by executing malicious content triggered by hijacked references to Component Object Model (COM) objects. COM is a system within Windows to enable interaction…",
       "url": "https://attack.mitre.org/techniques/T1546/015",
-      "is_subtechnique": true
+      "is_subtechnique": true,
+      "platforms": [
+        "Windows"
+      ]
     },
     {
       "id": "T1546.016",
@@ -2773,7 +3702,12 @@
       ],
       "description": "Adversaries may establish persistence and elevate privileges by using an installer to trigger the execution of malicious content. Installer packages are OS specific and contain the resources an…",
       "url": "https://attack.mitre.org/techniques/T1546/016",
-      "is_subtechnique": true
+      "is_subtechnique": true,
+      "platforms": [
+        "Linux",
+        "macOS",
+        "Windows"
+      ]
     },
     {
       "id": "T1548",
@@ -2784,7 +3718,15 @@
       ],
       "description": "Adversaries may circumvent mechanisms designed to control privilege elevation to gain higher-level permissions. Most modern systems contain native elevation control mechanisms that are intended to…",
       "url": "https://attack.mitre.org/techniques/T1548",
-      "is_subtechnique": false
+      "is_subtechnique": false,
+      "platforms": [
+        "Linux",
+        "macOS",
+        "Windows",
+        "IaaS",
+        "Office Suite",
+        "Identity Provider"
+      ]
     },
     {
       "id": "T1548.001",
@@ -2795,7 +3737,11 @@
       ],
       "description": "An adversary may abuse configurations where an application has the setuid or setgid bits set in order to get code running in a different (and possibly more privileged) user’s context. On Linux or…",
       "url": "https://attack.mitre.org/techniques/T1548/001",
-      "is_subtechnique": true
+      "is_subtechnique": true,
+      "platforms": [
+        "Linux",
+        "macOS"
+      ]
     },
     {
       "id": "T1548.002",
@@ -2806,7 +3752,10 @@
       ],
       "description": "Adversaries may bypass UAC mechanisms to elevate process privileges on system. Windows User Account Control (UAC) allows a program to elevate its privileges (tracked as integrity levels ranging from…",
       "url": "https://attack.mitre.org/techniques/T1548/002",
-      "is_subtechnique": true
+      "is_subtechnique": true,
+      "platforms": [
+        "Windows"
+      ]
     },
     {
       "id": "T1548.003",
@@ -2817,7 +3766,11 @@
       ],
       "description": "Adversaries may perform sudo caching and/or use the sudoers file to elevate privileges. Adversaries may do this to execute commands as other users or spawn processes with higher privileges.\n\nWithin…",
       "url": "https://attack.mitre.org/techniques/T1548/003",
-      "is_subtechnique": true
+      "is_subtechnique": true,
+      "platforms": [
+        "Linux",
+        "macOS"
+      ]
     },
     {
       "id": "T1548.004",
@@ -2828,7 +3781,10 @@
       ],
       "description": "Adversaries may leverage the <code>AuthorizationExecuteWithPrivileges</code> API to escalate privileges by prompting the user for credentials.(Citation: AppleDocs AuthorizationExecuteWithPrivileges)…",
       "url": "https://attack.mitre.org/techniques/T1548/004",
-      "is_subtechnique": true
+      "is_subtechnique": true,
+      "platforms": [
+        "macOS"
+      ]
     },
     {
       "id": "T1548.005",
@@ -2839,7 +3795,12 @@
       ],
       "description": "Adversaries may abuse permission configurations that allow them to gain temporarily elevated access to cloud resources. Many cloud environments allow administrators to grant user or service accounts…",
       "url": "https://attack.mitre.org/techniques/T1548/005",
-      "is_subtechnique": true
+      "is_subtechnique": true,
+      "platforms": [
+        "IaaS",
+        "Office Suite",
+        "Identity Provider"
+      ]
     },
     {
       "id": "T1548.006",
@@ -2850,7 +3811,10 @@
       ],
       "description": "Adversaries can manipulate or abuse the Transparency, Consent, & Control (TCC) service or database to grant malicious executables elevated permissions. TCC is a Privacy & Security macOS control…",
       "url": "https://attack.mitre.org/techniques/T1548/006",
-      "is_subtechnique": true
+      "is_subtechnique": true,
+      "platforms": [
+        "macOS"
+      ]
     },
     {
       "id": "T1611",
@@ -2861,7 +3825,13 @@
       ],
       "description": "Adversaries may break out of a container or virtualized environment to gain access to the underlying host. This can allow an adversary access to other containerized or virtualized resources from the…",
       "url": "https://attack.mitre.org/techniques/T1611",
-      "is_subtechnique": false
+      "is_subtechnique": false,
+      "platforms": [
+        "Windows",
+        "Linux",
+        "Containers",
+        "ESXi"
+      ]
     },
     {
       "id": "T1006",
@@ -2872,7 +3842,11 @@
       ],
       "description": "Adversaries may directly access a volume to bypass file access controls and file system monitoring. Windows allows programs to have direct access to logical volumes. Programs with direct access may…",
       "url": "https://attack.mitre.org/techniques/T1006",
-      "is_subtechnique": false
+      "is_subtechnique": false,
+      "platforms": [
+        "Network Devices",
+        "Windows"
+      ]
     },
     {
       "id": "T1014",
@@ -2883,7 +3857,12 @@
       ],
       "description": "Adversaries may use rootkits to hide the presence of programs, files, network connections, services, drivers, and other system components. Rootkits are programs that hide the existence of malware by…",
       "url": "https://attack.mitre.org/techniques/T1014",
-      "is_subtechnique": false
+      "is_subtechnique": false,
+      "platforms": [
+        "Linux",
+        "macOS",
+        "Windows"
+      ]
     },
     {
       "id": "T1027",
@@ -2894,7 +3873,14 @@
       ],
       "description": "Adversaries may attempt to make an executable or file difficult to discover or analyze by encrypting, encoding, or otherwise obfuscating its contents on the system or in transit. This is common…",
       "url": "https://attack.mitre.org/techniques/T1027",
-      "is_subtechnique": false
+      "is_subtechnique": false,
+      "platforms": [
+        "ESXi",
+        "Linux",
+        "macOS",
+        "Network Devices",
+        "Windows"
+      ]
     },
     {
       "id": "T1027.001",
@@ -2905,7 +3891,12 @@
       ],
       "description": "Adversaries may use binary padding to add junk data and change the on-disk representation of malware. This can be done without affecting the functionality or behavior of a binary, but can increase…",
       "url": "https://attack.mitre.org/techniques/T1027/001",
-      "is_subtechnique": true
+      "is_subtechnique": true,
+      "platforms": [
+        "Linux",
+        "macOS",
+        "Windows"
+      ]
     },
     {
       "id": "T1027.002",
@@ -2916,7 +3907,12 @@
       ],
       "description": "Adversaries may perform software packing or virtual machine software protection to conceal their code. Software packing is a method of compressing or encrypting an executable. Packing an executable…",
       "url": "https://attack.mitre.org/techniques/T1027/002",
-      "is_subtechnique": true
+      "is_subtechnique": true,
+      "platforms": [
+        "Linux",
+        "macOS",
+        "Windows"
+      ]
     },
     {
       "id": "T1027.003",
@@ -2927,7 +3923,12 @@
       ],
       "description": "Adversaries may use steganography techniques in order to prevent the detection of hidden information. Steganographic techniques can be used to hide data in digital media such as images, audio tracks,…",
       "url": "https://attack.mitre.org/techniques/T1027/003",
-      "is_subtechnique": true
+      "is_subtechnique": true,
+      "platforms": [
+        "Linux",
+        "macOS",
+        "Windows"
+      ]
     },
     {
       "id": "T1027.004",
@@ -2938,7 +3939,12 @@
       ],
       "description": "Adversaries may attempt to make payloads difficult to discover and analyze by delivering files to victims as uncompiled code. Text-based source code files may subvert analysis and scrutiny from…",
       "url": "https://attack.mitre.org/techniques/T1027/004",
-      "is_subtechnique": true
+      "is_subtechnique": true,
+      "platforms": [
+        "Linux",
+        "macOS",
+        "Windows"
+      ]
     },
     {
       "id": "T1027.005",
@@ -2949,7 +3955,12 @@
       ],
       "description": "Adversaries may remove indicators from tools if they believe their malicious tool was detected, quarantined, or otherwise curtailed. They can modify the tool by removing the indicator and using the…",
       "url": "https://attack.mitre.org/techniques/T1027/005",
-      "is_subtechnique": true
+      "is_subtechnique": true,
+      "platforms": [
+        "Linux",
+        "macOS",
+        "Windows"
+      ]
     },
     {
       "id": "T1027.006",
@@ -2960,7 +3971,12 @@
       ],
       "description": "Adversaries may smuggle data and files past content filters by hiding malicious payloads inside of seemingly benign HTML files. HTML documents can store large binary objects known as JavaScript Blobs…",
       "url": "https://attack.mitre.org/techniques/T1027/006",
-      "is_subtechnique": true
+      "is_subtechnique": true,
+      "platforms": [
+        "Linux",
+        "macOS",
+        "Windows"
+      ]
     },
     {
       "id": "T1027.007",
@@ -2971,7 +3987,10 @@
       ],
       "description": "Adversaries may obfuscate then dynamically resolve API functions called by their malware in order to conceal malicious functionalities and impair defensive analysis. Malware commonly uses various…",
       "url": "https://attack.mitre.org/techniques/T1027/007",
-      "is_subtechnique": true
+      "is_subtechnique": true,
+      "platforms": [
+        "Windows"
+      ]
     },
     {
       "id": "T1027.008",
@@ -2982,7 +4001,13 @@
       ],
       "description": "Adversaries may attempt to make a payload difficult to analyze by removing symbols, strings, and other human readable information. Scripts and executables may contain variables names and other…",
       "url": "https://attack.mitre.org/techniques/T1027/008",
-      "is_subtechnique": true
+      "is_subtechnique": true,
+      "platforms": [
+        "Linux",
+        "macOS",
+        "Network Devices",
+        "Windows"
+      ]
     },
     {
       "id": "T1027.009",
@@ -2993,7 +4018,12 @@
       ],
       "description": "Adversaries may embed payloads within other files to conceal malicious content from defenses. Otherwise seemingly benign files (such as scripts and executables) may be abused to carry and obfuscate…",
       "url": "https://attack.mitre.org/techniques/T1027/009",
-      "is_subtechnique": true
+      "is_subtechnique": true,
+      "platforms": [
+        "Linux",
+        "macOS",
+        "Windows"
+      ]
     },
     {
       "id": "T1027.010",
@@ -3004,7 +4034,12 @@
       ],
       "description": "Adversaries may obfuscate content during command execution to impede detection. Command-line obfuscation is a method of making strings and patterns within commands and scripts more difficult to…",
       "url": "https://attack.mitre.org/techniques/T1027/010",
-      "is_subtechnique": true
+      "is_subtechnique": true,
+      "platforms": [
+        "Linux",
+        "macOS",
+        "Windows"
+      ]
     },
     {
       "id": "T1027.011",
@@ -3015,7 +4050,11 @@
       ],
       "description": "Adversaries may store data in \"fileless\" formats to conceal malicious activity from defenses. Fileless storage can be broadly defined as any format other than a file. Common examples of non-volatile…",
       "url": "https://attack.mitre.org/techniques/T1027/011",
-      "is_subtechnique": true
+      "is_subtechnique": true,
+      "platforms": [
+        "Linux",
+        "Windows"
+      ]
     },
     {
       "id": "T1027.012",
@@ -3026,7 +4065,10 @@
       ],
       "description": "Adversaries may smuggle commands to download malicious payloads past content filters by hiding them within otherwise seemingly benign windows shortcut files. Windows shortcut files (.LNK) include…",
       "url": "https://attack.mitre.org/techniques/T1027/012",
-      "is_subtechnique": true
+      "is_subtechnique": true,
+      "platforms": [
+        "Windows"
+      ]
     },
     {
       "id": "T1027.013",
@@ -3037,7 +4079,12 @@
       ],
       "description": "Adversaries may encrypt or encode files to obfuscate strings, bytes, and other specific patterns to impede detection. Encrypting and/or encoding file content aims to conceal malicious artifacts…",
       "url": "https://attack.mitre.org/techniques/T1027/013",
-      "is_subtechnique": true
+      "is_subtechnique": true,
+      "platforms": [
+        "Linux",
+        "macOS",
+        "Windows"
+      ]
     },
     {
       "id": "T1027.014",
@@ -3048,7 +4095,12 @@
       ],
       "description": "Adversaries may utilize polymorphic code (also known as metamorphic or mutating code) to evade detection. Polymorphic code is a type of software capable of changing its runtime footprint during code…",
       "url": "https://attack.mitre.org/techniques/T1027/014",
-      "is_subtechnique": true
+      "is_subtechnique": true,
+      "platforms": [
+        "Linux",
+        "macOS",
+        "Windows"
+      ]
     },
     {
       "id": "T1027.015",
@@ -3059,7 +4111,12 @@
       ],
       "description": "Adversaries may use compression to obfuscate their payloads or files. Compressed file formats such as ZIP, gzip, 7z, and RAR can compress and archive multiple files together to make it easier and…",
       "url": "https://attack.mitre.org/techniques/T1027/015",
-      "is_subtechnique": true
+      "is_subtechnique": true,
+      "platforms": [
+        "Linux",
+        "macOS",
+        "Windows"
+      ]
     },
     {
       "id": "T1027.016",
@@ -3070,7 +4127,12 @@
       ],
       "description": "Adversaries may use junk code / dead code to obfuscate a malware’s functionality. Junk code is code that either does not execute, or if it does execute, does not change the functionality of the code.…",
       "url": "https://attack.mitre.org/techniques/T1027/016",
-      "is_subtechnique": true
+      "is_subtechnique": true,
+      "platforms": [
+        "Linux",
+        "macOS",
+        "Windows"
+      ]
     },
     {
       "id": "T1027.017",
@@ -3081,7 +4143,12 @@
       ],
       "description": "Adversaries may smuggle data and files past content filters by hiding malicious payloads inside of seemingly benign SVG files.(Citation: Trustwave SVG Smuggling 2025) SVGs, or Scalable Vector…",
       "url": "https://attack.mitre.org/techniques/T1027/017",
-      "is_subtechnique": true
+      "is_subtechnique": true,
+      "platforms": [
+        "Linux",
+        "macOS",
+        "Windows"
+      ]
     },
     {
       "id": "T1027.018",
@@ -3092,7 +4159,12 @@
       ],
       "description": "Adversaries may abuse invisible or non-printing Unicode characters to conceal malicious content within files, scripts, or text. By inserting characters that do not visibly render, adversaries may…",
       "url": "https://attack.mitre.org/techniques/T1027/018",
-      "is_subtechnique": true
+      "is_subtechnique": true,
+      "platforms": [
+        "Linux",
+        "macOS",
+        "Windows"
+      ]
     },
     {
       "id": "T1036",
@@ -3103,7 +4175,14 @@
       ],
       "description": "Adversaries may attempt to manipulate features of their artifacts to make them appear legitimate or benign to users and/or security tools. Masquerading occurs when the name or location of an object,…",
       "url": "https://attack.mitre.org/techniques/T1036",
-      "is_subtechnique": false
+      "is_subtechnique": false,
+      "platforms": [
+        "Containers",
+        "ESXi",
+        "Linux",
+        "macOS",
+        "Windows"
+      ]
     },
     {
       "id": "T1036.001",
@@ -3114,7 +4193,11 @@
       ],
       "description": "Adversaries may attempt to mimic features of valid code signatures to increase the chance of deceiving a user, analyst, or tool. Code signing provides a level of authenticity on a binary from the…",
       "url": "https://attack.mitre.org/techniques/T1036/001",
-      "is_subtechnique": true
+      "is_subtechnique": true,
+      "platforms": [
+        "macOS",
+        "Windows"
+      ]
     },
     {
       "id": "T1036.002",
@@ -3125,7 +4208,12 @@
       ],
       "description": "Adversaries may abuse the right-to-left override (RTLO or RLO) character (U+202E) to disguise a string and/or file name to make it appear benign. RTLO is a non-printing Unicode character that causes…",
       "url": "https://attack.mitre.org/techniques/T1036/002",
-      "is_subtechnique": true
+      "is_subtechnique": true,
+      "platforms": [
+        "Linux",
+        "macOS",
+        "Windows"
+      ]
     },
     {
       "id": "T1036.003",
@@ -3136,7 +4224,12 @@
       ],
       "description": "Adversaries may rename legitimate / system utilities to try to evade security mechanisms concerning the usage of those utilities. Security monitoring and control mechanisms may be in place for…",
       "url": "https://attack.mitre.org/techniques/T1036/003",
-      "is_subtechnique": true
+      "is_subtechnique": true,
+      "platforms": [
+        "Linux",
+        "macOS",
+        "Windows"
+      ]
     },
     {
       "id": "T1036.004",
@@ -3147,7 +4240,12 @@
       ],
       "description": "Adversaries may attempt to manipulate the name of a task or service to make it appear legitimate or benign. Tasks/services executed by the Task Scheduler or systemd will typically be given a name…",
       "url": "https://attack.mitre.org/techniques/T1036/004",
-      "is_subtechnique": true
+      "is_subtechnique": true,
+      "platforms": [
+        "Linux",
+        "macOS",
+        "Windows"
+      ]
     },
     {
       "id": "T1036.005",
@@ -3158,7 +4256,14 @@
       ],
       "description": "Adversaries may match or approximate the name or location of legitimate files, Registry keys, or other resources when naming/placing them. This is done for the sake of evading defenses and…",
       "url": "https://attack.mitre.org/techniques/T1036/005",
-      "is_subtechnique": true
+      "is_subtechnique": true,
+      "platforms": [
+        "Containers",
+        "ESXi",
+        "Linux",
+        "macOS",
+        "Windows"
+      ]
     },
     {
       "id": "T1036.006",
@@ -3169,7 +4274,11 @@
       ],
       "description": "Adversaries can hide a program's true filetype by changing the extension of a file. With certain file types (specifically this does not work with .app extensions), appending a space to the end of a…",
       "url": "https://attack.mitre.org/techniques/T1036/006",
-      "is_subtechnique": true
+      "is_subtechnique": true,
+      "platforms": [
+        "Linux",
+        "macOS"
+      ]
     },
     {
       "id": "T1036.007",
@@ -3180,7 +4289,10 @@
       ],
       "description": "Adversaries may abuse a double extension in the filename as a means of masquerading the true file type. A file name may include a secondary file type extension that may cause only the first extension…",
       "url": "https://attack.mitre.org/techniques/T1036/007",
-      "is_subtechnique": true
+      "is_subtechnique": true,
+      "platforms": [
+        "Windows"
+      ]
     },
     {
       "id": "T1036.008",
@@ -3191,7 +4303,12 @@
       ],
       "description": "Adversaries may masquerade malicious payloads as legitimate files through changes to the payload's formatting, including the file’s signature, extension, icon, and contents. Various file types have a…",
       "url": "https://attack.mitre.org/techniques/T1036/008",
-      "is_subtechnique": true
+      "is_subtechnique": true,
+      "platforms": [
+        "Linux",
+        "macOS",
+        "Windows"
+      ]
     },
     {
       "id": "T1036.009",
@@ -3202,7 +4319,11 @@
       ],
       "description": "An adversary may attempt to evade process tree-based analysis by modifying executed malware's parent process ID (PPID). If endpoint protection software leverages the “parent-child\" relationship for…",
       "url": "https://attack.mitre.org/techniques/T1036/009",
-      "is_subtechnique": true
+      "is_subtechnique": true,
+      "platforms": [
+        "Linux",
+        "macOS"
+      ]
     },
     {
       "id": "T1036.010",
@@ -3213,7 +4334,17 @@
       ],
       "description": "Adversaries may match or approximate the names of legitimate accounts to make newly created ones appear benign. This will typically occur during [Create…",
       "url": "https://attack.mitre.org/techniques/T1036/010",
-      "is_subtechnique": true
+      "is_subtechnique": true,
+      "platforms": [
+        "Containers",
+        "IaaS",
+        "Identity Provider",
+        "Linux",
+        "macOS",
+        "Office Suite",
+        "SaaS",
+        "Windows"
+      ]
     },
     {
       "id": "T1036.011",
@@ -3224,7 +4355,10 @@
       ],
       "description": "Adversaries may modify a process's in-memory arguments to change its name in order to appear as a legitimate or benign process. On Linux, the operating system stores command-line arguments in the…",
       "url": "https://attack.mitre.org/techniques/T1036/011",
-      "is_subtechnique": true
+      "is_subtechnique": true,
+      "platforms": [
+        "Linux"
+      ]
     },
     {
       "id": "T1036.012",
@@ -3235,7 +4369,12 @@
       ],
       "description": "Adversaries may attempt to blend in with legitimate traffic by spoofing browser and system attributes like operating system, system language, platform, user-agent string, resolution, time zone, etc. …",
       "url": "https://attack.mitre.org/techniques/T1036/012",
-      "is_subtechnique": true
+      "is_subtechnique": true,
+      "platforms": [
+        "Linux",
+        "macOS",
+        "Windows"
+      ]
     },
     {
       "id": "T1055",
@@ -3247,7 +4386,12 @@
       ],
       "description": "Adversaries may inject code into processes in order to evade process-based defenses as well as possibly elevate privileges. Process injection is a method of executing arbitrary code in the address…",
       "url": "https://attack.mitre.org/techniques/T1055",
-      "is_subtechnique": false
+      "is_subtechnique": false,
+      "platforms": [
+        "Linux",
+        "macOS",
+        "Windows"
+      ]
     },
     {
       "id": "T1055.001",
@@ -3259,7 +4403,10 @@
       ],
       "description": "Adversaries may inject dynamic-link libraries (DLLs) into processes in order to evade process-based defenses as well as possibly elevate privileges. DLL injection is a method of executing arbitrary…",
       "url": "https://attack.mitre.org/techniques/T1055/001",
-      "is_subtechnique": true
+      "is_subtechnique": true,
+      "platforms": [
+        "Windows"
+      ]
     },
     {
       "id": "T1055.002",
@@ -3271,7 +4418,10 @@
       ],
       "description": "Adversaries may inject portable executables (PE) into processes in order to evade process-based defenses as well as possibly elevate privileges. PE injection is a method of executing arbitrary code…",
       "url": "https://attack.mitre.org/techniques/T1055/002",
-      "is_subtechnique": true
+      "is_subtechnique": true,
+      "platforms": [
+        "Windows"
+      ]
     },
     {
       "id": "T1055.003",
@@ -3283,7 +4433,10 @@
       ],
       "description": "Adversaries may inject malicious code into hijacked processes in order to evade process-based defenses as well as possibly elevate privileges. Thread Execution Hijacking is a method of executing…",
       "url": "https://attack.mitre.org/techniques/T1055/003",
-      "is_subtechnique": true
+      "is_subtechnique": true,
+      "platforms": [
+        "Windows"
+      ]
     },
     {
       "id": "T1055.004",
@@ -3295,7 +4448,10 @@
       ],
       "description": "Adversaries may inject malicious code into processes via the asynchronous procedure call (APC) queue in order to evade process-based defenses as well as possibly elevate privileges. APC injection is…",
       "url": "https://attack.mitre.org/techniques/T1055/004",
-      "is_subtechnique": true
+      "is_subtechnique": true,
+      "platforms": [
+        "Windows"
+      ]
     },
     {
       "id": "T1055.005",
@@ -3307,7 +4463,10 @@
       ],
       "description": "Adversaries may inject malicious code into processes via thread local storage (TLS) callbacks in order to evade process-based defenses as well as possibly elevate privileges. TLS callback injection…",
       "url": "https://attack.mitre.org/techniques/T1055/005",
-      "is_subtechnique": true
+      "is_subtechnique": true,
+      "platforms": [
+        "Windows"
+      ]
     },
     {
       "id": "T1055.008",
@@ -3319,7 +4478,10 @@
       ],
       "description": "Adversaries may inject malicious code into processes via ptrace (process trace) system calls in order to evade process-based defenses as well as possibly elevate privileges. Ptrace system call…",
       "url": "https://attack.mitre.org/techniques/T1055/008",
-      "is_subtechnique": true
+      "is_subtechnique": true,
+      "platforms": [
+        "Linux"
+      ]
     },
     {
       "id": "T1055.009",
@@ -3331,7 +4493,10 @@
       ],
       "description": "Adversaries may inject malicious code into processes via the /proc filesystem in order to evade process-based defenses as well as possibly elevate privileges. Proc memory injection is a method of…",
       "url": "https://attack.mitre.org/techniques/T1055/009",
-      "is_subtechnique": true
+      "is_subtechnique": true,
+      "platforms": [
+        "Linux"
+      ]
     },
     {
       "id": "T1055.011",
@@ -3343,7 +4508,10 @@
       ],
       "description": "Adversaries may inject malicious code into process via Extra Window Memory (EWM) in order to evade process-based defenses as well as possibly elevate privileges. EWM injection is a method of…",
       "url": "https://attack.mitre.org/techniques/T1055/011",
-      "is_subtechnique": true
+      "is_subtechnique": true,
+      "platforms": [
+        "Windows"
+      ]
     },
     {
       "id": "T1055.012",
@@ -3355,7 +4523,10 @@
       ],
       "description": "Adversaries may inject malicious code into suspended and hollowed processes in order to evade process-based defenses. Process hollowing is a method of executing arbitrary code in the address space of…",
       "url": "https://attack.mitre.org/techniques/T1055/012",
-      "is_subtechnique": true
+      "is_subtechnique": true,
+      "platforms": [
+        "Windows"
+      ]
     },
     {
       "id": "T1055.013",
@@ -3367,7 +4538,10 @@
       ],
       "description": "Adversaries may inject malicious code into process via process doppelgänging in order to evade process-based defenses as well as possibly elevate privileges. Process doppelgänging is a method of…",
       "url": "https://attack.mitre.org/techniques/T1055/013",
-      "is_subtechnique": true
+      "is_subtechnique": true,
+      "platforms": [
+        "Windows"
+      ]
     },
     {
       "id": "T1055.014",
@@ -3379,7 +4553,10 @@
       ],
       "description": "Adversaries may inject malicious code into processes via VDSO hijacking in order to evade process-based defenses as well as possibly elevate privileges. Virtual dynamic shared object (vdso) hijacking…",
       "url": "https://attack.mitre.org/techniques/T1055/014",
-      "is_subtechnique": true
+      "is_subtechnique": true,
+      "platforms": [
+        "Linux"
+      ]
     },
     {
       "id": "T1055.015",
@@ -3391,7 +4568,10 @@
       ],
       "description": "Adversaries may abuse list-view controls to inject malicious code into hijacked processes in order to evade process-based defenses as well as possibly elevate privileges. ListPlanting is a method of…",
       "url": "https://attack.mitre.org/techniques/T1055/015",
-      "is_subtechnique": true
+      "is_subtechnique": true,
+      "platforms": [
+        "Windows"
+      ]
     },
     {
       "id": "T1070",
@@ -3402,7 +4582,16 @@
       ],
       "description": "Adversaries may selectively delete or modify artifacts generated to reduce indications of their presence and blend in with legitimate activity. Rather than broadly removing evidence, adversaries may…",
       "url": "https://attack.mitre.org/techniques/T1070",
-      "is_subtechnique": false
+      "is_subtechnique": false,
+      "platforms": [
+        "Containers",
+        "ESXi",
+        "Linux",
+        "macOS",
+        "Network Devices",
+        "Office Suite",
+        "Windows"
+      ]
     },
     {
       "id": "T1070.003",
@@ -3413,7 +4602,14 @@
       ],
       "description": "In addition to clearing system logs, an adversary may clear the command history of a compromised account to conceal the actions undertaken during an intrusion. Various command interpreters keep track…",
       "url": "https://attack.mitre.org/techniques/T1070/003",
-      "is_subtechnique": true
+      "is_subtechnique": true,
+      "platforms": [
+        "ESXi",
+        "Linux",
+        "macOS",
+        "Network Devices",
+        "Windows"
+      ]
     },
     {
       "id": "T1070.004",
@@ -3424,7 +4620,13 @@
       ],
       "description": "Adversaries may delete files left behind by the actions of their intrusion activity. Malware, tools, or other non-native files dropped or created on a system by an adversary (ex: [Ingress Tool…",
       "url": "https://attack.mitre.org/techniques/T1070/004",
-      "is_subtechnique": true
+      "is_subtechnique": true,
+      "platforms": [
+        "ESXi",
+        "Linux",
+        "macOS",
+        "Windows"
+      ]
     },
     {
       "id": "T1070.005",
@@ -3435,7 +4637,10 @@
       ],
       "description": "Adversaries may remove share connections that are no longer useful in order to clean up traces of their operation. Windows shared drive and [SMB/Windows Admin…",
       "url": "https://attack.mitre.org/techniques/T1070/005",
-      "is_subtechnique": true
+      "is_subtechnique": true,
+      "platforms": [
+        "Windows"
+      ]
     },
     {
       "id": "T1070.006",
@@ -3446,7 +4651,13 @@
       ],
       "description": "Adversaries may modify file time attributes to hide new files or changes to existing files. Timestomping is a technique that modifies the timestamps of a file (the modify, access, create, and change…",
       "url": "https://attack.mitre.org/techniques/T1070/006",
-      "is_subtechnique": true
+      "is_subtechnique": true,
+      "platforms": [
+        "ESXi",
+        "Linux",
+        "macOS",
+        "Windows"
+      ]
     },
     {
       "id": "T1070.007",
@@ -3457,7 +4668,13 @@
       ],
       "description": "Adversaries may clear or remove evidence of malicious network connections in order to clean up traces of their operations. Configuration settings as well as various artifacts that highlight…",
       "url": "https://attack.mitre.org/techniques/T1070/007",
-      "is_subtechnique": true
+      "is_subtechnique": true,
+      "platforms": [
+        "Linux",
+        "macOS",
+        "Windows",
+        "Network Devices"
+      ]
     },
     {
       "id": "T1070.008",
@@ -3468,7 +4685,13 @@
       ],
       "description": "Adversaries may modify mail and mail application data to remove evidence of their activity. Email applications allow users and other programs to export and delete mailbox data via command line tools…",
       "url": "https://attack.mitre.org/techniques/T1070/008",
-      "is_subtechnique": true
+      "is_subtechnique": true,
+      "platforms": [
+        "Linux",
+        "macOS",
+        "Office Suite",
+        "Windows"
+      ]
     },
     {
       "id": "T1070.009",
@@ -3479,7 +4702,13 @@
       ],
       "description": "Adversaries may clear artifacts associated with previously established persistence on a host system to remove evidence of their activity. This may involve various actions, such as removing services,…",
       "url": "https://attack.mitre.org/techniques/T1070/009",
-      "is_subtechnique": true
+      "is_subtechnique": true,
+      "platforms": [
+        "ESXi",
+        "Linux",
+        "macOS",
+        "Windows"
+      ]
     },
     {
       "id": "T1070.010",
@@ -3490,7 +4719,13 @@
       ],
       "description": "Once a payload is delivered, adversaries may reproduce copies of the same malware on the victim system to remove evidence of their presence and/or avoid defenses. Copying malware payloads to new…",
       "url": "https://attack.mitre.org/techniques/T1070/010",
-      "is_subtechnique": true
+      "is_subtechnique": true,
+      "platforms": [
+        "Linux",
+        "macOS",
+        "Network Devices",
+        "Windows"
+      ]
     },
     {
       "id": "T1078",
@@ -3504,7 +4739,19 @@
       ],
       "description": "Adversaries may obtain and abuse credentials of existing accounts as a means of gaining Initial Access, Persistence, Privilege Escalation, or Defense Evasion. Compromised credentials may be used to…",
       "url": "https://attack.mitre.org/techniques/T1078",
-      "is_subtechnique": false
+      "is_subtechnique": false,
+      "platforms": [
+        "Containers",
+        "ESXi",
+        "IaaS",
+        "Identity Provider",
+        "Linux",
+        "macOS",
+        "Network Devices",
+        "Office Suite",
+        "SaaS",
+        "Windows"
+      ]
     },
     {
       "id": "T1078.001",
@@ -3518,7 +4765,19 @@
       ],
       "description": "Adversaries may obtain and abuse credentials of a default account as a means of gaining Initial Access, Persistence, Privilege Escalation, or Defense Evasion. Default accounts are those that are…",
       "url": "https://attack.mitre.org/techniques/T1078/001",
-      "is_subtechnique": true
+      "is_subtechnique": true,
+      "platforms": [
+        "Containers",
+        "ESXi",
+        "IaaS",
+        "Identity Provider",
+        "Linux",
+        "macOS",
+        "Network Devices",
+        "Office Suite",
+        "SaaS",
+        "Windows"
+      ]
     },
     {
       "id": "T1078.002",
@@ -3532,7 +4791,13 @@
       ],
       "description": "Adversaries may obtain and abuse credentials of a domain account as a means of gaining Initial Access, Persistence, Privilege Escalation, or Defense Evasion.(Citation: TechNet Credential Theft)…",
       "url": "https://attack.mitre.org/techniques/T1078/002",
-      "is_subtechnique": true
+      "is_subtechnique": true,
+      "platforms": [
+        "ESXi",
+        "Linux",
+        "macOS",
+        "Windows"
+      ]
     },
     {
       "id": "T1078.003",
@@ -3546,7 +4811,15 @@
       ],
       "description": "Adversaries may obtain and abuse credentials of a local account as a means of gaining Initial Access, Persistence, Privilege Escalation, or Defense Evasion. Local accounts are those configured by an…",
       "url": "https://attack.mitre.org/techniques/T1078/003",
-      "is_subtechnique": true
+      "is_subtechnique": true,
+      "platforms": [
+        "Containers",
+        "ESXi",
+        "Linux",
+        "macOS",
+        "Network Devices",
+        "Windows"
+      ]
     },
     {
       "id": "T1078.004",
@@ -3560,7 +4833,13 @@
       ],
       "description": "Valid accounts in cloud environments may allow adversaries to perform actions to achieve Initial Access, Persistence, Privilege Escalation, or Defense Evasion. Cloud accounts are those created and…",
       "url": "https://attack.mitre.org/techniques/T1078/004",
-      "is_subtechnique": true
+      "is_subtechnique": true,
+      "platforms": [
+        "IaaS",
+        "Identity Provider",
+        "Office Suite",
+        "SaaS"
+      ]
     },
     {
       "id": "T1127",
@@ -3572,7 +4851,10 @@
       ],
       "description": "Adversaries may take advantage of trusted developer utilities to proxy execution of malicious payloads. There are many utilities used for software development related tasks that can be used to…",
       "url": "https://attack.mitre.org/techniques/T1127",
-      "is_subtechnique": false
+      "is_subtechnique": false,
+      "platforms": [
+        "Windows"
+      ]
     },
     {
       "id": "T1127.001",
@@ -3584,7 +4866,10 @@
       ],
       "description": "Adversaries may use MSBuild to proxy execution of code through a trusted Windows utility. MSBuild.exe (Microsoft Build Engine) is a software build platform used by Visual Studio. It handles XML…",
       "url": "https://attack.mitre.org/techniques/T1127/001",
-      "is_subtechnique": true
+      "is_subtechnique": true,
+      "platforms": [
+        "Windows"
+      ]
     },
     {
       "id": "T1127.002",
@@ -3596,7 +4881,10 @@
       ],
       "description": "Adversaries may use ClickOnce applications (.appref-ms and .application files) to proxy execution of code through a trusted Windows utility.(Citation: Burke/CISA ClickOnce BlackHat) ClickOnce is a…",
       "url": "https://attack.mitre.org/techniques/T1127/002",
-      "is_subtechnique": true
+      "is_subtechnique": true,
+      "platforms": [
+        "Windows"
+      ]
     },
     {
       "id": "T1127.003",
@@ -3608,7 +4896,10 @@
       ],
       "description": "Adversaries may use `JamPlus` to proxy the execution of a malicious script. `JamPlus` is a build utility tool for code and data build systems. It works with several popular compilers and can be used…",
       "url": "https://attack.mitre.org/techniques/T1127/003",
-      "is_subtechnique": true
+      "is_subtechnique": true,
+      "platforms": [
+        "Windows"
+      ]
     },
     {
       "id": "T1134",
@@ -3620,7 +4911,10 @@
       ],
       "description": "Adversaries may modify access tokens to operate under a different user or system security context to perform actions and bypass access controls. Windows uses access tokens to determine the ownership…",
       "url": "https://attack.mitre.org/techniques/T1134",
-      "is_subtechnique": false
+      "is_subtechnique": false,
+      "platforms": [
+        "Windows"
+      ]
     },
     {
       "id": "T1134.001",
@@ -3632,7 +4926,10 @@
       ],
       "description": "Adversaries may duplicate then impersonate another user's existing token to escalate privileges and bypass access controls. For example, an adversary can duplicate an existing token using…",
       "url": "https://attack.mitre.org/techniques/T1134/001",
-      "is_subtechnique": true
+      "is_subtechnique": true,
+      "platforms": [
+        "Windows"
+      ]
     },
     {
       "id": "T1134.002",
@@ -3644,7 +4941,10 @@
       ],
       "description": "Adversaries may create a new process with an existing token to escalate privileges and bypass access controls. Processes can be created with the token and resulting security context of another user…",
       "url": "https://attack.mitre.org/techniques/T1134/002",
-      "is_subtechnique": true
+      "is_subtechnique": true,
+      "platforms": [
+        "Windows"
+      ]
     },
     {
       "id": "T1134.003",
@@ -3656,7 +4956,10 @@
       ],
       "description": "Adversaries may make new tokens and impersonate users to escalate privileges and bypass access controls. For example, if an adversary has a username and password but the user is not logged onto the…",
       "url": "https://attack.mitre.org/techniques/T1134/003",
-      "is_subtechnique": true
+      "is_subtechnique": true,
+      "platforms": [
+        "Windows"
+      ]
     },
     {
       "id": "T1134.004",
@@ -3668,7 +4971,10 @@
       ],
       "description": "Adversaries may spoof the parent process identifier (PPID) of a new process to evade process-monitoring defenses or to elevate privileges. New processes are typically spawned directly from their…",
       "url": "https://attack.mitre.org/techniques/T1134/004",
-      "is_subtechnique": true
+      "is_subtechnique": true,
+      "platforms": [
+        "Windows"
+      ]
     },
     {
       "id": "T1134.005",
@@ -3680,7 +4986,10 @@
       ],
       "description": "Adversaries may use SID-History Injection to escalate privileges and bypass access controls. The Windows security identifier (SID) is a unique value that identifies a user or group account. SIDs are…",
       "url": "https://attack.mitre.org/techniques/T1134/005",
-      "is_subtechnique": true
+      "is_subtechnique": true,
+      "platforms": [
+        "Windows"
+      ]
     },
     {
       "id": "T1140",
@@ -3691,7 +5000,13 @@
       ],
       "description": "Adversaries may use [Obfuscated Files or Information](https://attack.mitre.org/techniques/T1027) to hide artifacts of an intrusion from analysis. They may require separate mechanisms to decode or…",
       "url": "https://attack.mitre.org/techniques/T1140",
-      "is_subtechnique": false
+      "is_subtechnique": false,
+      "platforms": [
+        "ESXi",
+        "Linux",
+        "macOS",
+        "Windows"
+      ]
     },
     {
       "id": "T1197",
@@ -3704,7 +5019,10 @@
       ],
       "description": "Adversaries may abuse BITS jobs to persistently execute code and perform various background tasks. Windows Background Intelligent Transfer Service (BITS) is a low-bandwidth, asynchronous file…",
       "url": "https://attack.mitre.org/techniques/T1197",
-      "is_subtechnique": false
+      "is_subtechnique": false,
+      "platforms": [
+        "Windows"
+      ]
     },
     {
       "id": "T1202",
@@ -3715,7 +5033,10 @@
       ],
       "description": "Adversaries may abuse utilities that allow for command execution to bypass security restrictions that limit the use of command-line interpreters. Various Windows utilities may be used to execute…",
       "url": "https://attack.mitre.org/techniques/T1202",
-      "is_subtechnique": false
+      "is_subtechnique": false,
+      "platforms": [
+        "Windows"
+      ]
     },
     {
       "id": "T1205",
@@ -3728,7 +5049,13 @@
       ],
       "description": "Adversaries may use traffic signaling to hide open ports or other malicious functionality used for persistence or command and control. Traffic signaling involves the use of a magic value or sequence…",
       "url": "https://attack.mitre.org/techniques/T1205",
-      "is_subtechnique": false
+      "is_subtechnique": false,
+      "platforms": [
+        "Linux",
+        "macOS",
+        "Network Devices",
+        "Windows"
+      ]
     },
     {
       "id": "T1205.001",
@@ -3741,7 +5068,13 @@
       ],
       "description": "Adversaries may use port knocking to hide open ports used for persistence or command and control. To enable a port, an adversary sends a series of attempted connections to a predefined sequence of…",
       "url": "https://attack.mitre.org/techniques/T1205/001",
-      "is_subtechnique": true
+      "is_subtechnique": true,
+      "platforms": [
+        "Linux",
+        "macOS",
+        "Network Devices",
+        "Windows"
+      ]
     },
     {
       "id": "T1205.002",
@@ -3754,7 +5087,12 @@
       ],
       "description": "Adversaries may attach filters to a network socket to monitor then activate backdoors used for persistence or command and control. With elevated permissions, adversaries can use features such as the…",
       "url": "https://attack.mitre.org/techniques/T1205/002",
-      "is_subtechnique": true
+      "is_subtechnique": true,
+      "platforms": [
+        "Linux",
+        "macOS",
+        "Windows"
+      ]
     },
     {
       "id": "T1211",
@@ -3765,7 +5103,14 @@
       ],
       "description": "Adversaries may exploit vulnerabilities to evade detection by hiding activity, suppressing logging, or operating within trusted or unmonitored components. \n\nAdversaries may exploit a system or…",
       "url": "https://attack.mitre.org/techniques/T1211",
-      "is_subtechnique": false
+      "is_subtechnique": false,
+      "platforms": [
+        "Linux",
+        "Windows",
+        "macOS",
+        "SaaS",
+        "IaaS"
+      ]
     },
     {
       "id": "T1216",
@@ -3776,7 +5121,10 @@
       ],
       "description": "Adversaries may use trusted scripts, often signed with certificates, to proxy the execution of malicious files. Several Microsoft signed scripts that have been downloaded from Microsoft or are…",
       "url": "https://attack.mitre.org/techniques/T1216",
-      "is_subtechnique": false
+      "is_subtechnique": false,
+      "platforms": [
+        "Windows"
+      ]
     },
     {
       "id": "T1216.001",
@@ -3787,7 +5135,10 @@
       ],
       "description": "Adversaries may use PubPrn to proxy execution of malicious remote files. PubPrn.vbs is a [Visual Basic](https://attack.mitre.org/techniques/T1059/005) script that publishes a printer to Active…",
       "url": "https://attack.mitre.org/techniques/T1216/001",
-      "is_subtechnique": true
+      "is_subtechnique": true,
+      "platforms": [
+        "Windows"
+      ]
     },
     {
       "id": "T1216.002",
@@ -3798,7 +5149,10 @@
       ],
       "description": "Adversaries may abuse SyncAppvPublishingServer.vbs to proxy execution of malicious [PowerShell](https://attack.mitre.org/techniques/T1059/001) commands. SyncAppvPublishingServer.vbs is a Visual Basic…",
       "url": "https://attack.mitre.org/techniques/T1216/002",
-      "is_subtechnique": true
+      "is_subtechnique": true,
+      "platforms": [
+        "Windows"
+      ]
     },
     {
       "id": "T1218",
@@ -3809,7 +5163,12 @@
       ],
       "description": "Adversaries may bypass process and/or signature-based defenses by proxying execution of malicious content with signed, or otherwise trusted, binaries. Binaries used in this technique are often…",
       "url": "https://attack.mitre.org/techniques/T1218",
-      "is_subtechnique": false
+      "is_subtechnique": false,
+      "platforms": [
+        "Linux",
+        "macOS",
+        "Windows"
+      ]
     },
     {
       "id": "T1218.001",
@@ -3820,7 +5179,10 @@
       ],
       "description": "Adversaries may abuse Compiled HTML files (.chm) to conceal malicious code. CHM files are commonly distributed as part of the Microsoft HTML Help system. CHM files are compressed compilations of…",
       "url": "https://attack.mitre.org/techniques/T1218/001",
-      "is_subtechnique": true
+      "is_subtechnique": true,
+      "platforms": [
+        "Windows"
+      ]
     },
     {
       "id": "T1218.002",
@@ -3831,7 +5193,10 @@
       ],
       "description": "Adversaries may abuse control.exe to proxy execution of malicious payloads. The Windows Control Panel process binary (control.exe) handles execution of Control Panel items, which are utilities that…",
       "url": "https://attack.mitre.org/techniques/T1218/002",
-      "is_subtechnique": true
+      "is_subtechnique": true,
+      "platforms": [
+        "Windows"
+      ]
     },
     {
       "id": "T1218.003",
@@ -3842,7 +5207,10 @@
       ],
       "description": "Adversaries may abuse CMSTP to proxy execution of malicious code. The Microsoft Connection Manager Profile Installer (CMSTP.exe) is a command-line program used to install Connection Manager service…",
       "url": "https://attack.mitre.org/techniques/T1218/003",
-      "is_subtechnique": true
+      "is_subtechnique": true,
+      "platforms": [
+        "Windows"
+      ]
     },
     {
       "id": "T1218.004",
@@ -3853,7 +5221,10 @@
       ],
       "description": "Adversaries may use InstallUtil to proxy execution of code through a trusted Windows utility. InstallUtil is a command-line utility that allows for installation and uninstallation of resources by…",
       "url": "https://attack.mitre.org/techniques/T1218/004",
-      "is_subtechnique": true
+      "is_subtechnique": true,
+      "platforms": [
+        "Windows"
+      ]
     },
     {
       "id": "T1218.005",
@@ -3864,7 +5235,10 @@
       ],
       "description": "Adversaries may abuse mshta.exe to proxy execution of malicious .hta files and Javascript or VBScript through a trusted Windows utility. There are several examples of different types of threats…",
       "url": "https://attack.mitre.org/techniques/T1218/005",
-      "is_subtechnique": true
+      "is_subtechnique": true,
+      "platforms": [
+        "Windows"
+      ]
     },
     {
       "id": "T1218.007",
@@ -3875,7 +5249,10 @@
       ],
       "description": "Adversaries may abuse msiexec.exe to proxy execution of malicious payloads. Msiexec.exe is the command-line utility for the Windows Installer and is thus commonly associated with executing…",
       "url": "https://attack.mitre.org/techniques/T1218/007",
-      "is_subtechnique": true
+      "is_subtechnique": true,
+      "platforms": [
+        "Windows"
+      ]
     },
     {
       "id": "T1218.008",
@@ -3886,7 +5263,10 @@
       ],
       "description": "Adversaries may abuse odbcconf.exe to proxy execution of malicious payloads. Odbcconf.exe is a Windows utility that allows you to configure Open Database Connectivity (ODBC) drivers and data source…",
       "url": "https://attack.mitre.org/techniques/T1218/008",
-      "is_subtechnique": true
+      "is_subtechnique": true,
+      "platforms": [
+        "Windows"
+      ]
     },
     {
       "id": "T1218.009",
@@ -3897,7 +5277,10 @@
       ],
       "description": "Adversaries may abuse Regsvcs and Regasm to proxy execution of code through a trusted Windows utility. Regsvcs and Regasm are Windows command-line utilities that are used to register .NET [Component…",
       "url": "https://attack.mitre.org/techniques/T1218/009",
-      "is_subtechnique": true
+      "is_subtechnique": true,
+      "platforms": [
+        "Windows"
+      ]
     },
     {
       "id": "T1218.010",
@@ -3908,7 +5291,10 @@
       ],
       "description": "Adversaries may abuse Regsvr32.exe to proxy execution of malicious code. Regsvr32.exe is a command-line program used to register and unregister object linking and embedding controls, including…",
       "url": "https://attack.mitre.org/techniques/T1218/010",
-      "is_subtechnique": true
+      "is_subtechnique": true,
+      "platforms": [
+        "Windows"
+      ]
     },
     {
       "id": "T1218.011",
@@ -3919,7 +5305,10 @@
       ],
       "description": "Adversaries may abuse rundll32.exe to proxy execution of malicious code. Using rundll32.exe, vice executing directly (i.e. [Shared Modules](https://attack.mitre.org/techniques/T1129)), may avoid…",
       "url": "https://attack.mitre.org/techniques/T1218/011",
-      "is_subtechnique": true
+      "is_subtechnique": true,
+      "platforms": [
+        "Windows"
+      ]
     },
     {
       "id": "T1218.012",
@@ -3930,7 +5319,10 @@
       ],
       "description": "Adversaries may abuse verclsid.exe to proxy execution of malicious code. Verclsid.exe is known as the Extension CLSID Verification Host and is responsible for verifying each shell extension before…",
       "url": "https://attack.mitre.org/techniques/T1218/012",
-      "is_subtechnique": true
+      "is_subtechnique": true,
+      "platforms": [
+        "Windows"
+      ]
     },
     {
       "id": "T1218.013",
@@ -3941,7 +5333,10 @@
       ],
       "description": "Adversaries may abuse mavinject.exe to proxy execution of malicious code. Mavinject.exe is the Microsoft Application Virtualization Injector, a Windows utility that can inject code into external…",
       "url": "https://attack.mitre.org/techniques/T1218/013",
-      "is_subtechnique": true
+      "is_subtechnique": true,
+      "platforms": [
+        "Windows"
+      ]
     },
     {
       "id": "T1218.014",
@@ -3952,7 +5347,10 @@
       ],
       "description": "Adversaries may abuse mmc.exe to proxy execution of malicious .msc files. Microsoft Management Console (MMC) is a binary that may be signed by Microsoft and is used in several ways in either its GUI…",
       "url": "https://attack.mitre.org/techniques/T1218/014",
-      "is_subtechnique": true
+      "is_subtechnique": true,
+      "platforms": [
+        "Windows"
+      ]
     },
     {
       "id": "T1218.015",
@@ -3963,7 +5361,12 @@
       ],
       "description": "Adversaries may abuse components of the Electron framework to execute malicious code. The Electron framework hosts many common applications such as Signal, Slack, and Microsoft Teams.(Citation:…",
       "url": "https://attack.mitre.org/techniques/T1218/015",
-      "is_subtechnique": true
+      "is_subtechnique": true,
+      "platforms": [
+        "Linux",
+        "macOS",
+        "Windows"
+      ]
     },
     {
       "id": "T1220",
@@ -3974,7 +5377,10 @@
       ],
       "description": "Adversaries may bypass application control and obscure execution of code by embedding scripts inside XSL files. Extensible Stylesheet Language (XSL) files are commonly used to describe the processing…",
       "url": "https://attack.mitre.org/techniques/T1220",
-      "is_subtechnique": false
+      "is_subtechnique": false,
+      "platforms": [
+        "Windows"
+      ]
     },
     {
       "id": "T1221",
@@ -3985,7 +5391,10 @@
       ],
       "description": "Adversaries may create or modify references in user document templates to conceal malicious code or force authentication attempts. For example, Microsoft’s Office Open XML (OOXML) specification…",
       "url": "https://attack.mitre.org/techniques/T1221",
-      "is_subtechnique": false
+      "is_subtechnique": false,
+      "platforms": [
+        "Windows"
+      ]
     },
     {
       "id": "T1480",
@@ -3996,7 +5405,13 @@
       ],
       "description": "Adversaries may use execution guardrails to constrain execution or actions based on adversary supplied and environment specific conditions that are expected to be present on the target. Guardrails…",
       "url": "https://attack.mitre.org/techniques/T1480",
-      "is_subtechnique": false
+      "is_subtechnique": false,
+      "platforms": [
+        "ESXi",
+        "Linux",
+        "macOS",
+        "Windows"
+      ]
     },
     {
       "id": "T1480.001",
@@ -4007,7 +5422,12 @@
       ],
       "description": "Adversaries may environmentally key payloads or other features of malware to evade defenses and constraint execution to a specific target environment. Environmental keying uses cryptography to…",
       "url": "https://attack.mitre.org/techniques/T1480/001",
-      "is_subtechnique": true
+      "is_subtechnique": true,
+      "platforms": [
+        "Linux",
+        "Windows",
+        "macOS"
+      ]
     },
     {
       "id": "T1480.002",
@@ -4018,7 +5438,12 @@
       ],
       "description": "Adversaries may constrain execution or actions based on the presence of a mutex associated with malware. A mutex is a locking mechanism used to synchronize access to a resource. Only one thread or…",
       "url": "https://attack.mitre.org/techniques/T1480/002",
-      "is_subtechnique": true
+      "is_subtechnique": true,
+      "platforms": [
+        "Linux",
+        "macOS",
+        "Windows"
+      ]
     },
     {
       "id": "T1497",
@@ -4030,7 +5455,12 @@
       ],
       "description": "Adversaries may employ various means to detect and avoid virtualization and analysis environments. This may include changing behaviors based on the results of checks for the presence of artifacts…",
       "url": "https://attack.mitre.org/techniques/T1497",
-      "is_subtechnique": false
+      "is_subtechnique": false,
+      "platforms": [
+        "Linux",
+        "macOS",
+        "Windows"
+      ]
     },
     {
       "id": "T1497.001",
@@ -4042,7 +5472,12 @@
       ],
       "description": "Adversaries may employ various system checks to detect and avoid virtualization and analysis environments. This may include changing behaviors based on the results of checks for the presence of…",
       "url": "https://attack.mitre.org/techniques/T1497/001",
-      "is_subtechnique": true
+      "is_subtechnique": true,
+      "platforms": [
+        "Linux",
+        "macOS",
+        "Windows"
+      ]
     },
     {
       "id": "T1497.002",
@@ -4054,7 +5489,12 @@
       ],
       "description": "Adversaries may employ various user activity checks to detect and avoid virtualization and analysis environments. This may include changing behaviors based on the results of checks for the presence…",
       "url": "https://attack.mitre.org/techniques/T1497/002",
-      "is_subtechnique": true
+      "is_subtechnique": true,
+      "platforms": [
+        "Linux",
+        "macOS",
+        "Windows"
+      ]
     },
     {
       "id": "T1497.003",
@@ -4066,7 +5506,12 @@
       ],
       "description": "Adversaries may employ various time-based methods to detect virtualization and analysis environments, particularly those that attempt to manipulate time mechanisms to simulate longer elapses of time.…",
       "url": "https://attack.mitre.org/techniques/T1497/003",
-      "is_subtechnique": true
+      "is_subtechnique": true,
+      "platforms": [
+        "Linux",
+        "macOS",
+        "Windows"
+      ]
     },
     {
       "id": "T1535",
@@ -4077,7 +5522,10 @@
       ],
       "description": "Adversaries may create cloud instances in unused geographic service regions in order to evade detection. Access is usually obtained through compromising accounts used to manage cloud…",
       "url": "https://attack.mitre.org/techniques/T1535",
-      "is_subtechnique": false
+      "is_subtechnique": false,
+      "platforms": [
+        "IaaS"
+      ]
     },
     {
       "id": "T1542",
@@ -4089,7 +5537,13 @@
       ],
       "description": "Adversaries may abuse Pre-OS Boot mechanisms as a way to establish persistence on a system. During the booting process of a computer, firmware and various startup services are loaded before the…",
       "url": "https://attack.mitre.org/techniques/T1542",
-      "is_subtechnique": false
+      "is_subtechnique": false,
+      "platforms": [
+        "Linux",
+        "macOS",
+        "Network Devices",
+        "Windows"
+      ]
     },
     {
       "id": "T1542.001",
@@ -4101,7 +5555,11 @@
       ],
       "description": "Adversaries may modify system firmware to persist on systems.The BIOS (Basic Input/Output System) and The Unified Extensible Firmware Interface (UEFI) or Extensible Firmware Interface (EFI) are…",
       "url": "https://attack.mitre.org/techniques/T1542/001",
-      "is_subtechnique": true
+      "is_subtechnique": true,
+      "platforms": [
+        "Network Devices",
+        "Windows"
+      ]
     },
     {
       "id": "T1542.002",
@@ -4113,7 +5571,12 @@
       ],
       "description": "Adversaries may modify component firmware to persist on systems. Some adversaries may employ sophisticated means to compromise computer components and install malicious firmware that will execute…",
       "url": "https://attack.mitre.org/techniques/T1542/002",
-      "is_subtechnique": true
+      "is_subtechnique": true,
+      "platforms": [
+        "Windows",
+        "Linux",
+        "macOS"
+      ]
     },
     {
       "id": "T1542.003",
@@ -4125,7 +5588,11 @@
       ],
       "description": "Adversaries may use bootkits to persist on systems. A bootkit is a malware variant that modifies the boot sectors of a hard drive, allowing malicious code to execute before a computer's operating…",
       "url": "https://attack.mitre.org/techniques/T1542/003",
-      "is_subtechnique": true
+      "is_subtechnique": true,
+      "platforms": [
+        "Linux",
+        "Windows"
+      ]
     },
     {
       "id": "T1542.004",
@@ -4137,7 +5604,10 @@
       ],
       "description": "Adversaries may abuse the ROM Monitor (ROMMON) by loading an unauthorized firmware with adversary code to provide persistent access and manipulate device behavior that is difficult to detect.…",
       "url": "https://attack.mitre.org/techniques/T1542/004",
-      "is_subtechnique": true
+      "is_subtechnique": true,
+      "platforms": [
+        "Network Devices"
+      ]
     },
     {
       "id": "T1542.005",
@@ -4149,7 +5619,10 @@
       ],
       "description": "Adversaries may abuse netbooting to load an unauthorized network device operating system from a Trivial File Transfer Protocol (TFTP) server. TFTP boot (netbooting) is commonly used by network…",
       "url": "https://attack.mitre.org/techniques/T1542/005",
-      "is_subtechnique": true
+      "is_subtechnique": true,
+      "platforms": [
+        "Network Devices"
+      ]
     },
     {
       "id": "T1564",
@@ -4160,7 +5633,14 @@
       ],
       "description": "Adversaries may attempt to hide artifacts associated with their behaviors to evade detection. Operating systems may have features to hide various artifacts, such as important system files and…",
       "url": "https://attack.mitre.org/techniques/T1564",
-      "is_subtechnique": false
+      "is_subtechnique": false,
+      "platforms": [
+        "ESXi",
+        "Linux",
+        "macOS",
+        "Office Suite",
+        "Windows"
+      ]
     },
     {
       "id": "T1564.001",
@@ -4171,7 +5651,12 @@
       ],
       "description": "Adversaries may set files and directories to be hidden to evade detection mechanisms. To prevent normal users from accidentally changing special files on a system, most operating systems have the…",
       "url": "https://attack.mitre.org/techniques/T1564/001",
-      "is_subtechnique": true
+      "is_subtechnique": true,
+      "platforms": [
+        "Linux",
+        "macOS",
+        "Windows"
+      ]
     },
     {
       "id": "T1564.002",
@@ -4182,7 +5667,12 @@
       ],
       "description": "Adversaries may use hidden users to hide the presence of user accounts they create or modify. Administrators may want to hide users when there are many user accounts on a given system or if they want…",
       "url": "https://attack.mitre.org/techniques/T1564/002",
-      "is_subtechnique": true
+      "is_subtechnique": true,
+      "platforms": [
+        "Linux",
+        "macOS",
+        "Windows"
+      ]
     },
     {
       "id": "T1564.003",
@@ -4193,7 +5683,12 @@
       ],
       "description": "Adversaries may use hidden windows to conceal malicious activity from the plain sight of users. In some cases, windows that would typically be displayed when an application carries out an operation…",
       "url": "https://attack.mitre.org/techniques/T1564/003",
-      "is_subtechnique": true
+      "is_subtechnique": true,
+      "platforms": [
+        "Linux",
+        "macOS",
+        "Windows"
+      ]
     },
     {
       "id": "T1564.004",
@@ -4204,7 +5699,10 @@
       ],
       "description": "Adversaries may use NTFS file attributes to hide their malicious data in order to evade detection. Every New Technology File System (NTFS) formatted partition contains a Master File Table (MFT) that…",
       "url": "https://attack.mitre.org/techniques/T1564/004",
-      "is_subtechnique": true
+      "is_subtechnique": true,
+      "platforms": [
+        "Windows"
+      ]
     },
     {
       "id": "T1564.005",
@@ -4215,7 +5713,12 @@
       ],
       "description": "Adversaries may use a hidden file system to conceal malicious activity from users and security tools. File systems provide a structure to store and access data from physical storage. Typically, a…",
       "url": "https://attack.mitre.org/techniques/T1564/005",
-      "is_subtechnique": true
+      "is_subtechnique": true,
+      "platforms": [
+        "Linux",
+        "macOS",
+        "Windows"
+      ]
     },
     {
       "id": "T1564.006",
@@ -4226,7 +5729,13 @@
       ],
       "description": "Adversaries may carry out malicious operations using a virtual instance to avoid detection. A wide variety of virtualization technologies exist that allow for the emulation of a computer or computing…",
       "url": "https://attack.mitre.org/techniques/T1564/006",
-      "is_subtechnique": true
+      "is_subtechnique": true,
+      "platforms": [
+        "ESXi",
+        "Linux",
+        "macOS",
+        "Windows"
+      ]
     },
     {
       "id": "T1564.007",
@@ -4237,7 +5746,12 @@
       ],
       "description": "Adversaries may hide malicious Visual Basic for Applications (VBA) payloads embedded within MS Office documents by replacing the VBA source code with benign data.(Citation: FireEye VBA stomp Feb…",
       "url": "https://attack.mitre.org/techniques/T1564/007",
-      "is_subtechnique": true
+      "is_subtechnique": true,
+      "platforms": [
+        "Linux",
+        "macOS",
+        "Windows"
+      ]
     },
     {
       "id": "T1564.008",
@@ -4248,7 +5762,13 @@
       ],
       "description": "Adversaries may use email rules to hide inbound emails in a compromised user's mailbox. Many email clients allow users to create inbox rules for various email functions, including moving emails to…",
       "url": "https://attack.mitre.org/techniques/T1564/008",
-      "is_subtechnique": true
+      "is_subtechnique": true,
+      "platforms": [
+        "Windows",
+        "Linux",
+        "macOS",
+        "Office Suite"
+      ]
     },
     {
       "id": "T1564.009",
@@ -4259,7 +5779,10 @@
       ],
       "description": "Adversaries may abuse resource forks to hide malicious code or executables to evade detection and bypass security applications. A resource fork provides applications a structured way to store…",
       "url": "https://attack.mitre.org/techniques/T1564/009",
-      "is_subtechnique": true
+      "is_subtechnique": true,
+      "platforms": [
+        "macOS"
+      ]
     },
     {
       "id": "T1564.010",
@@ -4270,7 +5793,10 @@
       ],
       "description": "Adversaries may attempt to hide process command-line arguments by overwriting process memory. Process command-line arguments are stored in the process environment block (PEB), a data structure used…",
       "url": "https://attack.mitre.org/techniques/T1564/010",
-      "is_subtechnique": true
+      "is_subtechnique": true,
+      "platforms": [
+        "Windows"
+      ]
     },
     {
       "id": "T1564.011",
@@ -4281,7 +5807,12 @@
       ],
       "description": "Adversaries may evade defensive mechanisms by executing commands that hide from process interrupt signals. Many operating systems use signals to deliver messages to control process behavior. Command…",
       "url": "https://attack.mitre.org/techniques/T1564/011",
-      "is_subtechnique": true
+      "is_subtechnique": true,
+      "platforms": [
+        "Linux",
+        "macOS",
+        "Windows"
+      ]
     },
     {
       "id": "T1564.012",
@@ -4292,7 +5823,12 @@
       ],
       "description": "Adversaries may attempt to hide their file-based artifacts by writing them to specific folders or file names excluded from antivirus (AV) scanning and other defensive capabilities. AV and other…",
       "url": "https://attack.mitre.org/techniques/T1564/012",
-      "is_subtechnique": true
+      "is_subtechnique": true,
+      "platforms": [
+        "Linux",
+        "macOS",
+        "Windows"
+      ]
     },
     {
       "id": "T1564.013",
@@ -4303,7 +5839,10 @@
       ],
       "description": "Adversaries may abuse bind mounts on file structures to hide their activity and artifacts from native utilities. A bind mount maps a directory or file from one location on the filesystem to another,…",
       "url": "https://attack.mitre.org/techniques/T1564/013",
-      "is_subtechnique": true
+      "is_subtechnique": true,
+      "platforms": [
+        "Linux"
+      ]
     },
     {
       "id": "T1564.014",
@@ -4314,7 +5853,11 @@
       ],
       "description": "Adversaries may abuse extended attributes (xattrs) on macOS and Linux to hide their malicious data in order to evade detection. Extended attributes are key-value pairs of file and directory metadata…",
       "url": "https://attack.mitre.org/techniques/T1564/014",
-      "is_subtechnique": true
+      "is_subtechnique": true,
+      "platforms": [
+        "Linux",
+        "macOS"
+      ]
     },
     {
       "id": "T1574",
@@ -4326,7 +5869,12 @@
       ],
       "description": "Adversaries may execute their own malicious payloads by hijacking the way operating systems run programs. Hijacking execution flow can be for the purposes of persistence, since this hijacked…",
       "url": "https://attack.mitre.org/techniques/T1574",
-      "is_subtechnique": false
+      "is_subtechnique": false,
+      "platforms": [
+        "Linux",
+        "macOS",
+        "Windows"
+      ]
     },
     {
       "id": "T1574.001",
@@ -4338,7 +5886,10 @@
       ],
       "description": "Adversaries may abuse dynamic-link library files (DLLs) in order to achieve persistence, escalate privileges, and evade defenses. DLLs are libraries that contain code and data that can be…",
       "url": "https://attack.mitre.org/techniques/T1574/001",
-      "is_subtechnique": true
+      "is_subtechnique": true,
+      "platforms": [
+        "Windows"
+      ]
     },
     {
       "id": "T1574.004",
@@ -4350,7 +5901,10 @@
       ],
       "description": "Adversaries may execute their own payloads by placing a malicious dynamic library (dylib) with an expected name in a path a victim application searches at runtime. The dynamic loader will try to find…",
       "url": "https://attack.mitre.org/techniques/T1574/004",
-      "is_subtechnique": true
+      "is_subtechnique": true,
+      "platforms": [
+        "macOS"
+      ]
     },
     {
       "id": "T1574.005",
@@ -4362,7 +5916,10 @@
       ],
       "description": "Adversaries may execute their own malicious payloads by hijacking the binaries used by an installer. These processes may automatically execute specific binaries as part of their functionality or to…",
       "url": "https://attack.mitre.org/techniques/T1574/005",
-      "is_subtechnique": true
+      "is_subtechnique": true,
+      "platforms": [
+        "Windows"
+      ]
     },
     {
       "id": "T1574.006",
@@ -4374,7 +5931,11 @@
       ],
       "description": "Adversaries may execute their own malicious payloads by hijacking environment variables the dynamic linker uses to load shared libraries. During the execution preparation phase of a program, the…",
       "url": "https://attack.mitre.org/techniques/T1574/006",
-      "is_subtechnique": true
+      "is_subtechnique": true,
+      "platforms": [
+        "Linux",
+        "macOS"
+      ]
     },
     {
       "id": "T1574.007",
@@ -4386,7 +5947,12 @@
       ],
       "description": "Adversaries may execute their own malicious payloads by hijacking environment variables used to load libraries. The PATH environment variable contains a list of directories (User and System) that the…",
       "url": "https://attack.mitre.org/techniques/T1574/007",
-      "is_subtechnique": true
+      "is_subtechnique": true,
+      "platforms": [
+        "Linux",
+        "macOS",
+        "Windows"
+      ]
     },
     {
       "id": "T1574.008",
@@ -4398,7 +5964,10 @@
       ],
       "description": "Adversaries may execute their own malicious payloads by hijacking the search order used to load other programs. Because some programs do not call other programs using the full path, adversaries may…",
       "url": "https://attack.mitre.org/techniques/T1574/008",
-      "is_subtechnique": true
+      "is_subtechnique": true,
+      "platforms": [
+        "Windows"
+      ]
     },
     {
       "id": "T1574.009",
@@ -4410,7 +5979,10 @@
       ],
       "description": "Adversaries may execute their own malicious payloads by hijacking vulnerable file path references. Adversaries can take advantage of paths that lack surrounding quotations by placing an executable in…",
       "url": "https://attack.mitre.org/techniques/T1574/009",
-      "is_subtechnique": true
+      "is_subtechnique": true,
+      "platforms": [
+        "Windows"
+      ]
     },
     {
       "id": "T1574.010",
@@ -4422,7 +5994,10 @@
       ],
       "description": "Adversaries may execute their own malicious payloads by hijacking the binaries used by services. Adversaries may use flaws in the permissions of Windows services to replace the binary that is…",
       "url": "https://attack.mitre.org/techniques/T1574/010",
-      "is_subtechnique": true
+      "is_subtechnique": true,
+      "platforms": [
+        "Windows"
+      ]
     },
     {
       "id": "T1574.011",
@@ -4434,7 +6009,10 @@
       ],
       "description": "Adversaries may execute their own malicious payloads by hijacking the Registry entries used by services. Flaws in the permissions for Registry keys related to services can allow adversaries to…",
       "url": "https://attack.mitre.org/techniques/T1574/011",
-      "is_subtechnique": true
+      "is_subtechnique": true,
+      "platforms": [
+        "Windows"
+      ]
     },
     {
       "id": "T1574.012",
@@ -4446,7 +6024,10 @@
       ],
       "description": "Adversaries may leverage the COR_PROFILER environment variable to hijack the execution flow of programs that load the .NET CLR. The COR_PROFILER is a .NET Framework feature which allows developers to…",
       "url": "https://attack.mitre.org/techniques/T1574/012",
-      "is_subtechnique": true
+      "is_subtechnique": true,
+      "platforms": [
+        "Windows"
+      ]
     },
     {
       "id": "T1574.013",
@@ -4458,7 +6039,10 @@
       ],
       "description": "Adversaries may abuse the <code>KernelCallbackTable</code> of a process to hijack its execution flow in order to run their own payloads.(Citation: Lazarus APT January 2022)(Citation: FinFisher…",
       "url": "https://attack.mitre.org/techniques/T1574/013",
-      "is_subtechnique": true
+      "is_subtechnique": true,
+      "platforms": [
+        "Windows"
+      ]
     },
     {
       "id": "T1574.014",
@@ -4470,7 +6054,10 @@
       ],
       "description": "Adversaries may execute their own malicious payloads by hijacking how the .NET `AppDomainManager` loads assemblies. The .NET framework uses the `AppDomainManager` class to create and manage one or…",
       "url": "https://attack.mitre.org/techniques/T1574/014",
-      "is_subtechnique": true
+      "is_subtechnique": true,
+      "platforms": [
+        "Windows"
+      ]
     },
     {
       "id": "T1612",
@@ -4481,7 +6068,10 @@
       ],
       "description": "Adversaries may build a container image directly on a host to bypass defenses that monitor for the retrieval of malicious images from a public registry. A remote <code>build</code> request may be…",
       "url": "https://attack.mitre.org/techniques/T1612",
-      "is_subtechnique": false
+      "is_subtechnique": false,
+      "platforms": [
+        "Containers"
+      ]
     },
     {
       "id": "T1620",
@@ -4492,7 +6082,12 @@
       ],
       "description": "Adversaries may reflectively load code into a process in order to conceal the execution of malicious payloads. Reflective loading involves allocating then executing payloads directly within the…",
       "url": "https://attack.mitre.org/techniques/T1620",
-      "is_subtechnique": false
+      "is_subtechnique": false,
+      "platforms": [
+        "Linux",
+        "macOS",
+        "Windows"
+      ]
     },
     {
       "id": "T1622",
@@ -4504,7 +6099,12 @@
       ],
       "description": "Adversaries may employ various means to detect and avoid debuggers. Debuggers are typically used by defenders to trace and/or analyze the execution of potential malware payloads.(Citation:…",
       "url": "https://attack.mitre.org/techniques/T1622",
-      "is_subtechnique": false
+      "is_subtechnique": false,
+      "platforms": [
+        "Linux",
+        "macOS",
+        "Windows"
+      ]
     },
     {
       "id": "T1678",
@@ -4515,7 +6115,12 @@
       ],
       "description": "Adversaries may employ various time-based methods to evade detection and analysis. These techniques often exploit system clocks, delays, or timing mechanisms to obscure malicious activity, blend in…",
       "url": "https://attack.mitre.org/techniques/T1678",
-      "is_subtechnique": false
+      "is_subtechnique": false,
+      "platforms": [
+        "Linux",
+        "macOS",
+        "Windows"
+      ]
     },
     {
       "id": "T1679",
@@ -4526,7 +6131,10 @@
       ],
       "description": "Adversaries may intentionally exclude certain files, folders, directories, file types, or system components from encryption or tampering during a ransomware or malicious payload execution. Some file…",
       "url": "https://attack.mitre.org/techniques/T1679",
-      "is_subtechnique": false
+      "is_subtechnique": false,
+      "platforms": [
+        "Windows"
+      ]
     },
     {
       "id": "T1684",
@@ -4537,7 +6145,14 @@
       ],
       "description": "Adversaries may use social engineering techniques to influence users to take actions that result in unauthorized access, approval of changes, disclosure of sensitive information, or execution of…",
       "url": "https://attack.mitre.org/techniques/T1684",
-      "is_subtechnique": false
+      "is_subtechnique": false,
+      "platforms": [
+        "Linux",
+        "macOS",
+        "Office Suite",
+        "SaaS",
+        "Windows"
+      ]
     },
     {
       "id": "T1684.001",
@@ -4548,7 +6163,14 @@
       ],
       "description": "Adversaries may impersonate a trusted person or organization in order to persuade and trick a target into performing some action on their behalf. For example, adversaries may communicate with victims…",
       "url": "https://attack.mitre.org/techniques/T1684/001",
-      "is_subtechnique": true
+      "is_subtechnique": true,
+      "platforms": [
+        "Linux",
+        "macOS",
+        "Office Suite",
+        "SaaS",
+        "Windows"
+      ]
     },
     {
       "id": "T1684.002",
@@ -4559,7 +6181,13 @@
       ],
       "description": "Adversaries may fake, or spoof, a sender’s identity by modifying the value of relevant email headers in order to establish contact with victims under false pretenses.(Citation: Proofpoint TA427 April…",
       "url": "https://attack.mitre.org/techniques/T1684/002",
-      "is_subtechnique": true
+      "is_subtechnique": true,
+      "platforms": [
+        "Linux",
+        "macOS",
+        "Office Suite",
+        "Windows"
+      ]
     },
     {
       "id": "T1112",
@@ -4571,7 +6199,10 @@
       ],
       "description": "Adversaries may interact with the Windows Registry as part of a variety of other techniques to aid in defense evasion, persistence, and execution.\n\nAccess to specific areas of the Registry depends on…",
       "url": "https://attack.mitre.org/techniques/T1112",
-      "is_subtechnique": false
+      "is_subtechnique": false,
+      "platforms": [
+        "Windows"
+      ]
     },
     {
       "id": "T1207",
@@ -4582,7 +6213,10 @@
       ],
       "description": "Adversaries may register a rogue Domain Controller to enable manipulation of Active Directory data. DCShadow may be used to create a rogue Domain Controller (DC). DCShadow is a method of manipulating…",
       "url": "https://attack.mitre.org/techniques/T1207",
-      "is_subtechnique": false
+      "is_subtechnique": false,
+      "platforms": [
+        "Windows"
+      ]
     },
     {
       "id": "T1222",
@@ -4593,7 +6227,13 @@
       ],
       "description": "Adversaries may modify file or directory permissions/attributes to evade access control lists (ACLs) and access protected files.(Citation: Hybrid Analysis Icacls1 June 2018)(Citation: Hybrid Analysis…",
       "url": "https://attack.mitre.org/techniques/T1222",
-      "is_subtechnique": false
+      "is_subtechnique": false,
+      "platforms": [
+        "ESXi",
+        "Linux",
+        "macOS",
+        "Windows"
+      ]
     },
     {
       "id": "T1222.001",
@@ -4604,7 +6244,10 @@
       ],
       "description": "Adversaries may modify file or directory permissions/attributes to evade access control lists (ACLs) and access protected files.(Citation: Hybrid Analysis Icacls1 June 2018)(Citation: Hybrid Analysis…",
       "url": "https://attack.mitre.org/techniques/T1222/001",
-      "is_subtechnique": true
+      "is_subtechnique": true,
+      "platforms": [
+        "Windows"
+      ]
     },
     {
       "id": "T1222.002",
@@ -4615,7 +6258,11 @@
       ],
       "description": "Adversaries may modify file or directory permissions/attributes to evade access control lists (ACLs) and access protected files.(Citation: Hybrid Analysis Icacls1 June 2018)(Citation: Hybrid Analysis…",
       "url": "https://attack.mitre.org/techniques/T1222/002",
-      "is_subtechnique": true
+      "is_subtechnique": true,
+      "platforms": [
+        "Linux",
+        "macOS"
+      ]
     },
     {
       "id": "T1484",
@@ -4627,7 +6274,11 @@
       ],
       "description": "Adversaries may modify the configuration settings of a domain or identity tenant to evade defenses and/or escalate privileges in centrally managed environments. Such services provide a centralized…",
       "url": "https://attack.mitre.org/techniques/T1484",
-      "is_subtechnique": false
+      "is_subtechnique": false,
+      "platforms": [
+        "Windows",
+        "Identity Provider"
+      ]
     },
     {
       "id": "T1484.001",
@@ -4639,7 +6290,10 @@
       ],
       "description": "Adversaries may modify Group Policy Objects (GPOs) to subvert the intended discretionary access controls for a domain, usually with the intention of escalating privileges on the domain. Group policy…",
       "url": "https://attack.mitre.org/techniques/T1484/001",
-      "is_subtechnique": true
+      "is_subtechnique": true,
+      "platforms": [
+        "Windows"
+      ]
     },
     {
       "id": "T1484.002",
@@ -4651,7 +6305,11 @@
       ],
       "description": "Adversaries may add new domain trusts, modify the properties of existing domain trusts, or otherwise change the configuration of trust relationships between domains and tenants to evade defenses…",
       "url": "https://attack.mitre.org/techniques/T1484/002",
-      "is_subtechnique": true
+      "is_subtechnique": true,
+      "platforms": [
+        "Identity Provider",
+        "Windows"
+      ]
     },
     {
       "id": "T1553",
@@ -4662,7 +6320,12 @@
       ],
       "description": "Adversaries may undermine security controls that will either warn users of untrusted activity or prevent execution of untrusted programs. Operating systems and security products may contain…",
       "url": "https://attack.mitre.org/techniques/T1553",
-      "is_subtechnique": false
+      "is_subtechnique": false,
+      "platforms": [
+        "Linux",
+        "macOS",
+        "Windows"
+      ]
     },
     {
       "id": "T1553.001",
@@ -4673,7 +6336,10 @@
       ],
       "description": "Adversaries may modify file attributes and subvert Gatekeeper functionality to evade user prompts and execute untrusted programs. Gatekeeper is a set of technologies that act as layer of Apple’s…",
       "url": "https://attack.mitre.org/techniques/T1553/001",
-      "is_subtechnique": true
+      "is_subtechnique": true,
+      "platforms": [
+        "macOS"
+      ]
     },
     {
       "id": "T1553.002",
@@ -4684,7 +6350,11 @@
       ],
       "description": "Adversaries may create, acquire, or steal code signing materials to sign their malware or tools. Code signing provides a level of authenticity on a binary from the developer and a guarantee that the…",
       "url": "https://attack.mitre.org/techniques/T1553/002",
-      "is_subtechnique": true
+      "is_subtechnique": true,
+      "platforms": [
+        "macOS",
+        "Windows"
+      ]
     },
     {
       "id": "T1553.003",
@@ -4695,7 +6365,10 @@
       ],
       "description": "Adversaries may tamper with SIP and trust provider components to mislead the operating system and application control tools when conducting signature validation checks. In user mode, Windows…",
       "url": "https://attack.mitre.org/techniques/T1553/003",
-      "is_subtechnique": true
+      "is_subtechnique": true,
+      "platforms": [
+        "Windows"
+      ]
     },
     {
       "id": "T1553.004",
@@ -4706,7 +6379,12 @@
       ],
       "description": "Adversaries may install a root certificate on a compromised system to avoid warnings when connecting to adversary controlled web servers. Root certificates are used in public key cryptography to…",
       "url": "https://attack.mitre.org/techniques/T1553/004",
-      "is_subtechnique": true
+      "is_subtechnique": true,
+      "platforms": [
+        "Linux",
+        "macOS",
+        "Windows"
+      ]
     },
     {
       "id": "T1553.005",
@@ -4717,7 +6395,10 @@
       ],
       "description": "Adversaries may abuse specific file formats to subvert Mark-of-the-Web (MOTW) controls. In Windows, when files are downloaded from the Internet, they are tagged with a hidden NTFS Alternate Data…",
       "url": "https://attack.mitre.org/techniques/T1553/005",
-      "is_subtechnique": true
+      "is_subtechnique": true,
+      "platforms": [
+        "Windows"
+      ]
     },
     {
       "id": "T1553.006",
@@ -4728,7 +6409,11 @@
       ],
       "description": "Adversaries may modify code signing policies to enable execution of unsigned or self-signed code. Code signing provides a level of authenticity on a program from a developer and a guarantee that the…",
       "url": "https://attack.mitre.org/techniques/T1553/006",
-      "is_subtechnique": true
+      "is_subtechnique": true,
+      "platforms": [
+        "macOS",
+        "Windows"
+      ]
     },
     {
       "id": "T1556",
@@ -4741,7 +6426,17 @@
       ],
       "description": "Adversaries may modify authentication mechanisms and processes to access user credentials or enable otherwise unwarranted access to accounts. The authentication process is handled by mechanisms, such…",
       "url": "https://attack.mitre.org/techniques/T1556",
-      "is_subtechnique": false
+      "is_subtechnique": false,
+      "platforms": [
+        "IaaS",
+        "Identity Provider",
+        "Linux",
+        "macOS",
+        "Network Devices",
+        "Office Suite",
+        "SaaS",
+        "Windows"
+      ]
     },
     {
       "id": "T1556.001",
@@ -4754,7 +6449,10 @@
       ],
       "description": "Adversaries may patch the authentication process on a domain controller to bypass the typical authentication mechanisms and enable access to accounts. \n\nMalware may be used to inject false…",
       "url": "https://attack.mitre.org/techniques/T1556/001",
-      "is_subtechnique": true
+      "is_subtechnique": true,
+      "platforms": [
+        "Windows"
+      ]
     },
     {
       "id": "T1556.002",
@@ -4767,7 +6465,10 @@
       ],
       "description": "Adversaries may register malicious password filter dynamic link libraries (DLLs) into the authentication process to acquire user credentials as they are validated. \n\nWindows password filters are…",
       "url": "https://attack.mitre.org/techniques/T1556/002",
-      "is_subtechnique": true
+      "is_subtechnique": true,
+      "platforms": [
+        "Windows"
+      ]
     },
     {
       "id": "T1556.003",
@@ -4780,7 +6481,11 @@
       ],
       "description": "Adversaries may modify pluggable authentication modules (PAM) to access user credentials or enable otherwise unwarranted access to accounts. PAM is a modular system of configuration files, libraries,…",
       "url": "https://attack.mitre.org/techniques/T1556/003",
-      "is_subtechnique": true
+      "is_subtechnique": true,
+      "platforms": [
+        "Linux",
+        "macOS"
+      ]
     },
     {
       "id": "T1556.004",
@@ -4793,7 +6498,10 @@
       ],
       "description": "Adversaries may use [Patch System Image](https://attack.mitre.org/techniques/T1601/001) to hard code a password in the operating system, thus bypassing of native authentication mechanisms for local…",
       "url": "https://attack.mitre.org/techniques/T1556/004",
-      "is_subtechnique": true
+      "is_subtechnique": true,
+      "platforms": [
+        "Network Devices"
+      ]
     },
     {
       "id": "T1556.005",
@@ -4806,7 +6514,10 @@
       ],
       "description": "An adversary may abuse Active Directory authentication encryption properties to gain access to credentials on Windows systems. The <code>AllowReversiblePasswordEncryption</code> property specifies…",
       "url": "https://attack.mitre.org/techniques/T1556/005",
-      "is_subtechnique": true
+      "is_subtechnique": true,
+      "platforms": [
+        "Windows"
+      ]
     },
     {
       "id": "T1556.006",
@@ -4819,7 +6530,16 @@
       ],
       "description": "Adversaries may disable or modify multi-factor authentication (MFA) mechanisms to enable persistent access to compromised accounts.\n\nOnce adversaries have gained access to a network by either…",
       "url": "https://attack.mitre.org/techniques/T1556/006",
-      "is_subtechnique": true
+      "is_subtechnique": true,
+      "platforms": [
+        "IaaS",
+        "Identity Provider",
+        "Linux",
+        "macOS",
+        "Office Suite",
+        "SaaS",
+        "Windows"
+      ]
     },
     {
       "id": "T1556.007",
@@ -4832,7 +6552,14 @@
       ],
       "description": "Adversaries may patch, modify, or otherwise backdoor cloud authentication processes that are tied to on-premises user identities in order to bypass typical authentication mechanisms, access…",
       "url": "https://attack.mitre.org/techniques/T1556/007",
-      "is_subtechnique": true
+      "is_subtechnique": true,
+      "platforms": [
+        "IaaS",
+        "Identity Provider",
+        "Office Suite",
+        "SaaS",
+        "Windows"
+      ]
     },
     {
       "id": "T1556.008",
@@ -4845,7 +6572,10 @@
       ],
       "description": "Adversaries may register malicious network provider dynamic link libraries (DLLs) to capture cleartext user credentials during the authentication process. Network provider DLLs allow Windows to…",
       "url": "https://attack.mitre.org/techniques/T1556/008",
-      "is_subtechnique": true
+      "is_subtechnique": true,
+      "platforms": [
+        "Windows"
+      ]
     },
     {
       "id": "T1556.009",
@@ -4858,7 +6588,11 @@
       ],
       "description": "Adversaries may disable or modify conditional access policies to enable persistent access to compromised accounts. Conditional access policies are additional verifications used by identity providers…",
       "url": "https://attack.mitre.org/techniques/T1556/009",
-      "is_subtechnique": true
+      "is_subtechnique": true,
+      "platforms": [
+        "IaaS",
+        "Identity Provider"
+      ]
     },
     {
       "id": "T1578",
@@ -4869,7 +6603,10 @@
       ],
       "description": "An adversary may attempt to modify a cloud account's compute service infrastructure to evade defenses. A modification to the compute service infrastructure can include the creation, deletion, or…",
       "url": "https://attack.mitre.org/techniques/T1578",
-      "is_subtechnique": false
+      "is_subtechnique": false,
+      "platforms": [
+        "IaaS"
+      ]
     },
     {
       "id": "T1578.001",
@@ -4880,7 +6617,10 @@
       ],
       "description": "An adversary may create a snapshot or data backup within a cloud account to evade defenses. A snapshot is a point-in-time copy of an existing cloud compute component such as a virtual machine (VM),…",
       "url": "https://attack.mitre.org/techniques/T1578/001",
-      "is_subtechnique": true
+      "is_subtechnique": true,
+      "platforms": [
+        "IaaS"
+      ]
     },
     {
       "id": "T1578.002",
@@ -4891,7 +6631,10 @@
       ],
       "description": "An adversary may create a new instance or virtual machine (VM) within the compute service of a cloud account to evade defenses. Creating a new instance may allow an adversary to bypass firewall rules…",
       "url": "https://attack.mitre.org/techniques/T1578/002",
-      "is_subtechnique": true
+      "is_subtechnique": true,
+      "platforms": [
+        "IaaS"
+      ]
     },
     {
       "id": "T1578.003",
@@ -4902,7 +6645,10 @@
       ],
       "description": "An adversary may delete a cloud instance after they have performed malicious activities in an attempt to evade detection and remove evidence of their presence.  Deleting an instance or virtual…",
       "url": "https://attack.mitre.org/techniques/T1578/003",
-      "is_subtechnique": true
+      "is_subtechnique": true,
+      "platforms": [
+        "IaaS"
+      ]
     },
     {
       "id": "T1578.004",
@@ -4913,7 +6659,10 @@
       ],
       "description": "An adversary may revert changes made to a cloud instance after they have performed malicious activities in attempt to evade detection and remove evidence of their presence. In highly virtualized…",
       "url": "https://attack.mitre.org/techniques/T1578/004",
-      "is_subtechnique": true
+      "is_subtechnique": true,
+      "platforms": [
+        "IaaS"
+      ]
     },
     {
       "id": "T1578.005",
@@ -4924,7 +6673,10 @@
       ],
       "description": "Adversaries may modify settings that directly affect the size, locations, and resources available to cloud compute infrastructure in order to evade defenses. These settings may include service…",
       "url": "https://attack.mitre.org/techniques/T1578/005",
-      "is_subtechnique": true
+      "is_subtechnique": true,
+      "platforms": [
+        "IaaS"
+      ]
     },
     {
       "id": "T1599",
@@ -4935,7 +6687,10 @@
       ],
       "description": "Adversaries may bridge network boundaries by compromising perimeter network devices or internal devices responsible for network segmentation. Breaching these devices may enable an adversary to bypass…",
       "url": "https://attack.mitre.org/techniques/T1599",
-      "is_subtechnique": false
+      "is_subtechnique": false,
+      "platforms": [
+        "Network Devices"
+      ]
     },
     {
       "id": "T1599.001",
@@ -4946,7 +6701,10 @@
       ],
       "description": "Adversaries may bridge network boundaries by modifying a network device’s Network Address Translation (NAT) configuration. Malicious modifications to NAT may enable an adversary to bypass…",
       "url": "https://attack.mitre.org/techniques/T1599/001",
-      "is_subtechnique": true
+      "is_subtechnique": true,
+      "platforms": [
+        "Network Devices"
+      ]
     },
     {
       "id": "T1600",
@@ -4957,7 +6715,10 @@
       ],
       "description": "Adversaries may compromise a network device’s encryption capability in order to bypass encryption that would otherwise protect data communications.(Citation: Cisco Synful Knock Evolution)\n\nEncryption…",
       "url": "https://attack.mitre.org/techniques/T1600",
-      "is_subtechnique": false
+      "is_subtechnique": false,
+      "platforms": [
+        "Network Devices"
+      ]
     },
     {
       "id": "T1600.001",
@@ -4968,7 +6729,10 @@
       ],
       "description": "Adversaries may reduce the level of effort required to decrypt data transmitted over the network by reducing the cipher strength of encrypted communications.(Citation: Cisco Synful Knock…",
       "url": "https://attack.mitre.org/techniques/T1600/001",
-      "is_subtechnique": true
+      "is_subtechnique": true,
+      "platforms": [
+        "Network Devices"
+      ]
     },
     {
       "id": "T1600.002",
@@ -4979,7 +6743,10 @@
       ],
       "description": "Adversaries disable a network device’s dedicated hardware encryption, which may enable them to leverage weaknesses in software encryption in order to reduce the effort involved in collecting,…",
       "url": "https://attack.mitre.org/techniques/T1600/002",
-      "is_subtechnique": true
+      "is_subtechnique": true,
+      "platforms": [
+        "Network Devices"
+      ]
     },
     {
       "id": "T1601",
@@ -4990,7 +6757,10 @@
       ],
       "description": "Adversaries may make changes to the operating system of embedded network devices to weaken defenses and provide new capabilities for themselves.  On such devices, the operating systems are typically…",
       "url": "https://attack.mitre.org/techniques/T1601",
-      "is_subtechnique": false
+      "is_subtechnique": false,
+      "platforms": [
+        "Network Devices"
+      ]
     },
     {
       "id": "T1601.001",
@@ -5001,7 +6771,10 @@
       ],
       "description": "Adversaries may modify the operating system of a network device to introduce new capabilities or weaken existing defenses.(Citation: Killing the myth of Cisco IOS rootkits) (Citation: Killing IOS…",
       "url": "https://attack.mitre.org/techniques/T1601/001",
-      "is_subtechnique": true
+      "is_subtechnique": true,
+      "platforms": [
+        "Network Devices"
+      ]
     },
     {
       "id": "T1601.002",
@@ -5012,7 +6785,10 @@
       ],
       "description": "Adversaries may install an older version of the operating system of a network device to weaken security.  Older operating system versions on network devices often have weaker encryption ciphers and,…",
       "url": "https://attack.mitre.org/techniques/T1601/002",
-      "is_subtechnique": true
+      "is_subtechnique": true,
+      "platforms": [
+        "Network Devices"
+      ]
     },
     {
       "id": "T1647",
@@ -5023,7 +6799,10 @@
       ],
       "description": "Adversaries may modify property list files (plist files) to enable other malicious activity, while also potentially evading and bypassing system defenses. macOS applications use plist files, such as…",
       "url": "https://attack.mitre.org/techniques/T1647",
-      "is_subtechnique": false
+      "is_subtechnique": false,
+      "platforms": [
+        "macOS"
+      ]
     },
     {
       "id": "T1666",
@@ -5034,7 +6813,10 @@
       ],
       "description": "Adversaries may attempt to modify hierarchical structures in infrastructure-as-a-service (IaaS) environments in order to evade defenses.  \n\nIaaS environments often group resources into a hierarchy,…",
       "url": "https://attack.mitre.org/techniques/T1666",
-      "is_subtechnique": false
+      "is_subtechnique": false,
+      "platforms": [
+        "IaaS"
+      ]
     },
     {
       "id": "T1685",
@@ -5045,7 +6827,16 @@
       ],
       "description": "Adversaries may disable, degrade, or tamper with security tools or applications (e.g., endpoint detection and response (EDR) tools, intrusion detection systems (IDS), antivirus, logging agents,…",
       "url": "https://attack.mitre.org/techniques/T1685",
-      "is_subtechnique": false
+      "is_subtechnique": false,
+      "platforms": [
+        "Containers",
+        "ESXi",
+        "IaaS",
+        "Linux",
+        "macOS",
+        "Network Devices",
+        "Windows"
+      ]
     },
     {
       "id": "T1685.001",
@@ -5056,7 +6847,10 @@
       ],
       "description": "Adversaries may disable or modify the Windows Event Log to limit data that can be leveraged for detections and audits. Windows Event Log records user and system activity such as login attempts and…",
       "url": "https://attack.mitre.org/techniques/T1685/001",
-      "is_subtechnique": true
+      "is_subtechnique": true,
+      "platforms": [
+        "Windows"
+      ]
     },
     {
       "id": "T1685.002",
@@ -5067,7 +6861,13 @@
       ],
       "description": "An adversary may disable or modify cloud logging capabilities and integrations to limit what data is collected on their activities and avoid detection. Cloud environments allow for collection and…",
       "url": "https://attack.mitre.org/techniques/T1685/002",
-      "is_subtechnique": true
+      "is_subtechnique": true,
+      "platforms": [
+        "IaaS",
+        "SaaS",
+        "Identity Provider",
+        "Office Suite"
+      ]
     },
     {
       "id": "T1685.003",
@@ -5078,7 +6878,12 @@
       ],
       "description": "Adversaries may spoof or manipulate security tool user interfaces (UIs) to falsely indicate tools are functioning normally and delay detection and response. \n\nAdversaries may present misleading or…",
       "url": "https://attack.mitre.org/techniques/T1685/003",
-      "is_subtechnique": true
+      "is_subtechnique": true,
+      "platforms": [
+        "Linux",
+        "macOS",
+        "Windows"
+      ]
     },
     {
       "id": "T1685.004",
@@ -5089,7 +6894,10 @@
       ],
       "description": "Adversaries may disable or modify the Linux Audit system to hide malicious activity and avoid detection. Linux admins use the Linux Audit system to track security-relevant information on a system.…",
       "url": "https://attack.mitre.org/techniques/T1685/004",
-      "is_subtechnique": true
+      "is_subtechnique": true,
+      "platforms": [
+        "Linux"
+      ]
     },
     {
       "id": "T1685.005",
@@ -5100,7 +6908,10 @@
       ],
       "description": "Adversaries may clear Windows Event Logs to hide the activity of an intrusion. Windows Event Logs are a record of a computer's alerts and notifications. There are three system-defined sources of…",
       "url": "https://attack.mitre.org/techniques/T1685/005",
-      "is_subtechnique": true
+      "is_subtechnique": true,
+      "platforms": [
+        "Windows"
+      ]
     },
     {
       "id": "T1685.006",
@@ -5111,7 +6922,11 @@
       ],
       "description": "Adversaries may clear system logs to hide evidence of an intrusion. macOS and Linux both keep track of system or user-initiated actions via system logs. The majority of native system logging is…",
       "url": "https://attack.mitre.org/techniques/T1685/006",
-      "is_subtechnique": true
+      "is_subtechnique": true,
+      "platforms": [
+        "Linux",
+        "macOS"
+      ]
     },
     {
       "id": "T1686",
@@ -5122,7 +6937,14 @@
       ],
       "description": "Adversaries may disable or modify host-based or network firewalls to impair defensive mechanisms and enable further action. Once an adversary has gathered sufficient privileges, they can tamper with…",
       "url": "https://attack.mitre.org/techniques/T1686",
-      "is_subtechnique": false
+      "is_subtechnique": false,
+      "platforms": [
+        "ESXi",
+        "Linux",
+        "macOS",
+        "Network Devices",
+        "Windows"
+      ]
     },
     {
       "id": "T1686.001",
@@ -5133,7 +6955,10 @@
       ],
       "description": "Adversaries may disable or modify a firewall within a cloud environment to bypass controls that limit access to cloud resources.\n\nCloud environments typically utilize restrictive security groups and…",
       "url": "https://attack.mitre.org/techniques/T1686/001",
-      "is_subtechnique": true
+      "is_subtechnique": true,
+      "platforms": [
+        "IaaS"
+      ]
     },
     {
       "id": "T1686.002",
@@ -5144,7 +6969,10 @@
       ],
       "description": "Adversaries may disable network device-based firewall mechanisms entirely or add, delete, or modify particular rules in order to bypass controls limiting network usage.  \n\nAdversaries may obtain…",
       "url": "https://attack.mitre.org/techniques/T1686/002",
-      "is_subtechnique": true
+      "is_subtechnique": true,
+      "platforms": [
+        "Network Devices"
+      ]
     },
     {
       "id": "T1686.003",
@@ -5155,7 +6983,10 @@
       ],
       "description": "Adversaries may disable or modify the Windows host firewall to bypass controls limiting network usage. This can include disabling the Windows host firewall entirely, suppressing specific profiles…",
       "url": "https://attack.mitre.org/techniques/T1686/003",
-      "is_subtechnique": true
+      "is_subtechnique": true,
+      "platforms": [
+        "Windows"
+      ]
     },
     {
       "id": "T1687",
@@ -5166,7 +6997,14 @@
       ],
       "description": "Adversaries may exploit vulnerabilities in security software, infrastructure, or defensive components to degrade, disable, or otherwise continue to impair their ability to prevent, detect, or respond…",
       "url": "https://attack.mitre.org/techniques/T1687",
-      "is_subtechnique": false
+      "is_subtechnique": false,
+      "platforms": [
+        "IaaS",
+        "Linux",
+        "macOS",
+        "SaaS",
+        "Windows"
+      ]
     },
     {
       "id": "T1688",
@@ -5177,7 +7015,10 @@
       ],
       "description": "Adversaries may abuse Windows safe mode to disable endpoint defenses. Safe mode starts up the Windows operating system with a limited set of drivers and services. Third-party security software such…",
       "url": "https://attack.mitre.org/techniques/T1688",
-      "is_subtechnique": false
+      "is_subtechnique": false,
+      "platforms": [
+        "Windows"
+      ]
     },
     {
       "id": "T1689",
@@ -5188,7 +7029,12 @@
       ],
       "description": "Adversaries may downgrade or use a version of system features that may be outdated, vulnerable, and/or does not support updated security controls. Downgrade attacks typically take advantage of a…",
       "url": "https://attack.mitre.org/techniques/T1689",
-      "is_subtechnique": false
+      "is_subtechnique": false,
+      "platforms": [
+        "macOS",
+        "Windows",
+        "Linux"
+      ]
     },
     {
       "id": "T1690",
@@ -5199,7 +7045,14 @@
       ],
       "description": "Adversaries may impair command history logging to hide commands they run on a compromised system. Various command interpreters keep track of the commands users type in their terminal so that users…",
       "url": "https://attack.mitre.org/techniques/T1690",
-      "is_subtechnique": false
+      "is_subtechnique": false,
+      "platforms": [
+        "ESXi",
+        "Linux",
+        "macOS",
+        "Network Devices",
+        "Windows"
+      ]
     },
     {
       "id": "T1003",
@@ -5210,7 +7063,12 @@
       ],
       "description": "Adversaries may attempt to dump credentials to obtain account login and credential material, normally in the form of a hash or a clear text password. Credentials can be obtained from OS caches,…",
       "url": "https://attack.mitre.org/techniques/T1003",
-      "is_subtechnique": false
+      "is_subtechnique": false,
+      "platforms": [
+        "Linux",
+        "macOS",
+        "Windows"
+      ]
     },
     {
       "id": "T1003.001",
@@ -5221,7 +7079,10 @@
       ],
       "description": "Adversaries may attempt to access credential material stored in the process memory of the Local Security Authority Subsystem Service (LSASS). After a user logs on, the system generates and stores a…",
       "url": "https://attack.mitre.org/techniques/T1003/001",
-      "is_subtechnique": true
+      "is_subtechnique": true,
+      "platforms": [
+        "Windows"
+      ]
     },
     {
       "id": "T1003.002",
@@ -5232,7 +7093,10 @@
       ],
       "description": "Adversaries may attempt to extract credential material from the Security Account Manager (SAM) database either through in-memory techniques or through the Windows Registry where the SAM database is…",
       "url": "https://attack.mitre.org/techniques/T1003/002",
-      "is_subtechnique": true
+      "is_subtechnique": true,
+      "platforms": [
+        "Windows"
+      ]
     },
     {
       "id": "T1003.003",
@@ -5243,7 +7107,10 @@
       ],
       "description": "Adversaries may attempt to access or create a copy of the Active Directory domain database in order to steal credential information, as well as obtain other information about domain members such as…",
       "url": "https://attack.mitre.org/techniques/T1003/003",
-      "is_subtechnique": true
+      "is_subtechnique": true,
+      "platforms": [
+        "Windows"
+      ]
     },
     {
       "id": "T1003.004",
@@ -5254,7 +7121,10 @@
       ],
       "description": "Adversaries with SYSTEM access to a host may attempt to access Local Security Authority (LSA) secrets, which can contain a variety of different credential materials, such as credentials for service…",
       "url": "https://attack.mitre.org/techniques/T1003/004",
-      "is_subtechnique": true
+      "is_subtechnique": true,
+      "platforms": [
+        "Windows"
+      ]
     },
     {
       "id": "T1003.005",
@@ -5265,7 +7135,11 @@
       ],
       "description": "Adversaries may attempt to access cached domain credentials used to allow authentication to occur in the event a domain controller is unavailable.(Citation: Microsoft - Cached Creds)\n\nOn Windows…",
       "url": "https://attack.mitre.org/techniques/T1003/005",
-      "is_subtechnique": true
+      "is_subtechnique": true,
+      "platforms": [
+        "Windows",
+        "Linux"
+      ]
     },
     {
       "id": "T1003.006",
@@ -5276,7 +7150,10 @@
       ],
       "description": "Adversaries may attempt to access credentials and other sensitive information by abusing a Windows Domain Controller's application programming interface (API)(Citation: Microsoft DRSR Dec 2017)…",
       "url": "https://attack.mitre.org/techniques/T1003/006",
-      "is_subtechnique": true
+      "is_subtechnique": true,
+      "platforms": [
+        "Windows"
+      ]
     },
     {
       "id": "T1003.007",
@@ -5287,7 +7164,10 @@
       ],
       "description": "Adversaries may gather credentials from the proc filesystem or `/proc`. The proc filesystem is a pseudo-filesystem used as an interface to kernel data structures for Linux based systems managing…",
       "url": "https://attack.mitre.org/techniques/T1003/007",
-      "is_subtechnique": true
+      "is_subtechnique": true,
+      "platforms": [
+        "Linux"
+      ]
     },
     {
       "id": "T1003.008",
@@ -5298,7 +7178,10 @@
       ],
       "description": "Adversaries may attempt to dump the contents of <code>/etc/passwd</code> and <code>/etc/shadow</code> to enable offline password cracking. Most modern Linux operating systems use a combination of…",
       "url": "https://attack.mitre.org/techniques/T1003/008",
-      "is_subtechnique": true
+      "is_subtechnique": true,
+      "platforms": [
+        "Linux"
+      ]
     },
     {
       "id": "T1040",
@@ -5310,7 +7193,14 @@
       ],
       "description": "Adversaries may passively sniff network traffic to capture information about an environment, including authentication material passed over the network. Network sniffing refers to using the network…",
       "url": "https://attack.mitre.org/techniques/T1040",
-      "is_subtechnique": false
+      "is_subtechnique": false,
+      "platforms": [
+        "IaaS",
+        "Linux",
+        "macOS",
+        "Network Devices",
+        "Windows"
+      ]
     },
     {
       "id": "T1110",
@@ -5321,7 +7211,19 @@
       ],
       "description": "Adversaries may use brute force techniques to gain access to accounts when passwords are unknown or when password hashes are obtained.(Citation: TrendMicro Pawn Storm Dec 2020) Without knowledge of…",
       "url": "https://attack.mitre.org/techniques/T1110",
-      "is_subtechnique": false
+      "is_subtechnique": false,
+      "platforms": [
+        "Containers",
+        "ESXi",
+        "IaaS",
+        "Identity Provider",
+        "Linux",
+        "macOS",
+        "Network Devices",
+        "Office Suite",
+        "SaaS",
+        "Windows"
+      ]
     },
     {
       "id": "T1110.001",
@@ -5332,7 +7234,19 @@
       ],
       "description": "Adversaries with no prior knowledge of legitimate credentials within the system or environment may guess passwords to attempt access to accounts. Without knowledge of the password for an account, an…",
       "url": "https://attack.mitre.org/techniques/T1110/001",
-      "is_subtechnique": true
+      "is_subtechnique": true,
+      "platforms": [
+        "Containers",
+        "ESXi",
+        "IaaS",
+        "Identity Provider",
+        "Linux",
+        "macOS",
+        "Network Devices",
+        "Office Suite",
+        "SaaS",
+        "Windows"
+      ]
     },
     {
       "id": "T1110.002",
@@ -5343,7 +7257,15 @@
       ],
       "description": "Adversaries may use password cracking to attempt to recover usable credentials, such as plaintext passwords, when credential material such as password hashes are obtained. [OS Credential…",
       "url": "https://attack.mitre.org/techniques/T1110/002",
-      "is_subtechnique": true
+      "is_subtechnique": true,
+      "platforms": [
+        "Identity Provider",
+        "Linux",
+        "macOS",
+        "Network Devices",
+        "Office Suite",
+        "Windows"
+      ]
     },
     {
       "id": "T1110.003",
@@ -5354,7 +7276,19 @@
       ],
       "description": "Adversaries may use a single or small list of commonly used passwords against many different accounts to attempt to acquire valid account credentials. Password spraying uses one password (e.g.…",
       "url": "https://attack.mitre.org/techniques/T1110/003",
-      "is_subtechnique": true
+      "is_subtechnique": true,
+      "platforms": [
+        "Containers",
+        "ESXi",
+        "IaaS",
+        "Identity Provider",
+        "Linux",
+        "Network Devices",
+        "Office Suite",
+        "SaaS",
+        "Windows",
+        "macOS"
+      ]
     },
     {
       "id": "T1110.004",
@@ -5365,7 +7299,19 @@
       ],
       "description": "Adversaries may use credentials obtained from breach dumps of unrelated accounts to gain access to target accounts through credential overlap. Occasionally, large numbers of username and password…",
       "url": "https://attack.mitre.org/techniques/T1110/004",
-      "is_subtechnique": true
+      "is_subtechnique": true,
+      "platforms": [
+        "Containers",
+        "ESXi",
+        "IaaS",
+        "Identity Provider",
+        "Linux",
+        "macOS",
+        "Network Devices",
+        "Office Suite",
+        "SaaS",
+        "Windows"
+      ]
     },
     {
       "id": "T1111",
@@ -5376,7 +7322,12 @@
       ],
       "description": "Adversaries may target multi-factor authentication (MFA) mechanisms, (i.e., smart cards, token generators, etc.) to gain access to credentials that can be used to access systems, services, and…",
       "url": "https://attack.mitre.org/techniques/T1111",
-      "is_subtechnique": false
+      "is_subtechnique": false,
+      "platforms": [
+        "Linux",
+        "macOS",
+        "Windows"
+      ]
     },
     {
       "id": "T1187",
@@ -5387,7 +7338,10 @@
       ],
       "description": "Adversaries may gather credential material by invoking or forcing a user to automatically provide authentication information through a mechanism in which they can intercept.\n\nThe Server Message Block…",
       "url": "https://attack.mitre.org/techniques/T1187",
-      "is_subtechnique": false
+      "is_subtechnique": false,
+      "platforms": [
+        "Windows"
+      ]
     },
     {
       "id": "T1212",
@@ -5398,7 +7352,13 @@
       ],
       "description": "Adversaries may exploit software vulnerabilities in an attempt to collect credentials. Exploitation of a software vulnerability occurs when an adversary takes advantage of a programming error in a…",
       "url": "https://attack.mitre.org/techniques/T1212",
-      "is_subtechnique": false
+      "is_subtechnique": false,
+      "platforms": [
+        "Linux",
+        "Windows",
+        "macOS",
+        "Identity Provider"
+      ]
     },
     {
       "id": "T1528",
@@ -5409,7 +7369,14 @@
       ],
       "description": "Adversaries can steal application access tokens as a means of acquiring credentials to access remote systems and resources.\n\nApplication access tokens are used to make authorized API requests on…",
       "url": "https://attack.mitre.org/techniques/T1528",
-      "is_subtechnique": false
+      "is_subtechnique": false,
+      "platforms": [
+        "Containers",
+        "IaaS",
+        "Identity Provider",
+        "Office Suite",
+        "SaaS"
+      ]
     },
     {
       "id": "T1539",
@@ -5420,7 +7387,14 @@
       ],
       "description": "An adversary may steal web application or service session cookies and use them to gain access to web applications or Internet services as an authenticated user without needing credentials. Web…",
       "url": "https://attack.mitre.org/techniques/T1539",
-      "is_subtechnique": false
+      "is_subtechnique": false,
+      "platforms": [
+        "Linux",
+        "macOS",
+        "Office Suite",
+        "SaaS",
+        "Windows"
+      ]
     },
     {
       "id": "T1552",
@@ -5431,7 +7405,18 @@
       ],
       "description": "Adversaries may search compromised systems to find and obtain insecurely stored credentials. These credentials can be stored and/or misplaced in many locations on a system, including plaintext files…",
       "url": "https://attack.mitre.org/techniques/T1552",
-      "is_subtechnique": false
+      "is_subtechnique": false,
+      "platforms": [
+        "Windows",
+        "SaaS",
+        "IaaS",
+        "Linux",
+        "macOS",
+        "Containers",
+        "Network Devices",
+        "Office Suite",
+        "Identity Provider"
+      ]
     },
     {
       "id": "T1552.001",
@@ -5442,7 +7427,14 @@
       ],
       "description": "Adversaries may search local file systems and remote file shares for files containing insecurely stored credentials. These can be files created by users to store their own credentials, shared…",
       "url": "https://attack.mitre.org/techniques/T1552/001",
-      "is_subtechnique": true
+      "is_subtechnique": true,
+      "platforms": [
+        "Containers",
+        "IaaS",
+        "Linux",
+        "macOS",
+        "Windows"
+      ]
     },
     {
       "id": "T1552.002",
@@ -5453,7 +7445,10 @@
       ],
       "description": "Adversaries may search the Registry on compromised systems for insecurely stored credentials. The Windows Registry stores configuration information that can be used by the system or other programs.…",
       "url": "https://attack.mitre.org/techniques/T1552/002",
-      "is_subtechnique": true
+      "is_subtechnique": true,
+      "platforms": [
+        "Windows"
+      ]
     },
     {
       "id": "T1552.003",
@@ -5464,7 +7459,12 @@
       ],
       "description": "Adversaries may search the command history on compromised systems for insecurely stored credentials.\n\nOn Linux and macOS systems, shells such as Bash and Zsh keep track of the commands users type on…",
       "url": "https://attack.mitre.org/techniques/T1552/003",
-      "is_subtechnique": true
+      "is_subtechnique": true,
+      "platforms": [
+        "Linux",
+        "macOS",
+        "Windows"
+      ]
     },
     {
       "id": "T1552.004",
@@ -5475,7 +7475,13 @@
       ],
       "description": "Adversaries may search for private key certificate files on compromised systems for insecurely stored credentials. Private cryptographic keys and certificates are used for authentication,…",
       "url": "https://attack.mitre.org/techniques/T1552/004",
-      "is_subtechnique": true
+      "is_subtechnique": true,
+      "platforms": [
+        "Linux",
+        "macOS",
+        "Network Devices",
+        "Windows"
+      ]
     },
     {
       "id": "T1552.005",
@@ -5486,7 +7492,10 @@
       ],
       "description": "Adversaries may attempt to access the Cloud Instance Metadata API to collect credentials and other sensitive data.\n\nMost cloud service providers support a Cloud Instance Metadata API which is a…",
       "url": "https://attack.mitre.org/techniques/T1552/005",
-      "is_subtechnique": true
+      "is_subtechnique": true,
+      "platforms": [
+        "IaaS"
+      ]
     },
     {
       "id": "T1552.006",
@@ -5497,7 +7506,10 @@
       ],
       "description": "Adversaries may attempt to find unsecured credentials in Group Policy Preferences (GPP). GPP are tools that allow administrators to create domain policies with embedded credentials. These policies…",
       "url": "https://attack.mitre.org/techniques/T1552/006",
-      "is_subtechnique": true
+      "is_subtechnique": true,
+      "platforms": [
+        "Windows"
+      ]
     },
     {
       "id": "T1552.007",
@@ -5508,7 +7520,10 @@
       ],
       "description": "Adversaries may gather credentials via APIs within a containers environment. APIs in these environments, such as the Docker API and Kubernetes APIs, allow a user to remotely manage their container…",
       "url": "https://attack.mitre.org/techniques/T1552/007",
-      "is_subtechnique": true
+      "is_subtechnique": true,
+      "platforms": [
+        "Containers"
+      ]
     },
     {
       "id": "T1552.008",
@@ -5519,7 +7534,11 @@
       ],
       "description": "Adversaries may directly collect unsecured credentials stored or passed through user communication services. Credentials may be sent and stored in user chat communication applications such as email,…",
       "url": "https://attack.mitre.org/techniques/T1552/008",
-      "is_subtechnique": true
+      "is_subtechnique": true,
+      "platforms": [
+        "SaaS",
+        "Office Suite"
+      ]
     },
     {
       "id": "T1555",
@@ -5530,7 +7549,13 @@
       ],
       "description": "Adversaries may search for common password storage locations to obtain user credentials.(Citation: F-Secure The Dukes) Passwords are stored in several places on a system, depending on the operating…",
       "url": "https://attack.mitre.org/techniques/T1555",
-      "is_subtechnique": false
+      "is_subtechnique": false,
+      "platforms": [
+        "IaaS",
+        "Linux",
+        "macOS",
+        "Windows"
+      ]
     },
     {
       "id": "T1555.001",
@@ -5541,7 +7566,10 @@
       ],
       "description": "Adversaries may acquire credentials from Keychain. Keychain (or Keychain Services) is the macOS credential management system that stores account names, passwords, private keys, certificates,…",
       "url": "https://attack.mitre.org/techniques/T1555/001",
-      "is_subtechnique": true
+      "is_subtechnique": true,
+      "platforms": [
+        "macOS"
+      ]
     },
     {
       "id": "T1555.002",
@@ -5552,7 +7580,11 @@
       ],
       "description": "An adversary with root access may gather credentials by reading `securityd`’s memory. `securityd` is a service/daemon responsible for implementing security protocols such as encryption and…",
       "url": "https://attack.mitre.org/techniques/T1555/002",
-      "is_subtechnique": true
+      "is_subtechnique": true,
+      "platforms": [
+        "Linux",
+        "macOS"
+      ]
     },
     {
       "id": "T1555.003",
@@ -5563,7 +7595,12 @@
       ],
       "description": "Adversaries may acquire credentials from web browsers by reading files specific to the target browser.(Citation: Talos Olympic Destroyer 2018) Web browsers commonly save credentials such as website…",
       "url": "https://attack.mitre.org/techniques/T1555/003",
-      "is_subtechnique": true
+      "is_subtechnique": true,
+      "platforms": [
+        "Linux",
+        "macOS",
+        "Windows"
+      ]
     },
     {
       "id": "T1555.004",
@@ -5574,7 +7611,10 @@
       ],
       "description": "Adversaries may acquire credentials from the Windows Credential Manager. The Credential Manager stores credentials for signing into websites, applications, and/or devices that request authentication…",
       "url": "https://attack.mitre.org/techniques/T1555/004",
-      "is_subtechnique": true
+      "is_subtechnique": true,
+      "platforms": [
+        "Windows"
+      ]
     },
     {
       "id": "T1555.005",
@@ -5585,7 +7625,12 @@
       ],
       "description": "Adversaries may acquire user credentials from third-party password managers.(Citation: ise Password Manager February 2019) Password managers are applications designed to store user credentials,…",
       "url": "https://attack.mitre.org/techniques/T1555/005",
-      "is_subtechnique": true
+      "is_subtechnique": true,
+      "platforms": [
+        "Linux",
+        "macOS",
+        "Windows"
+      ]
     },
     {
       "id": "T1555.006",
@@ -5596,7 +7641,10 @@
       ],
       "description": "Adversaries may acquire credentials from cloud-native secret management solutions such as AWS Secrets Manager, GCP Secret Manager, Azure Key Vault, and Terraform Vault.  \n\nSecrets managers support…",
       "url": "https://attack.mitre.org/techniques/T1555/006",
-      "is_subtechnique": true
+      "is_subtechnique": true,
+      "platforms": [
+        "IaaS"
+      ]
     },
     {
       "id": "T1557",
@@ -5608,7 +7656,13 @@
       ],
       "description": "Adversaries may attempt to position themselves between two or more networked devices using an adversary-in-the-middle (AiTM) technique to support follow-on behaviors such as [Network…",
       "url": "https://attack.mitre.org/techniques/T1557",
-      "is_subtechnique": false
+      "is_subtechnique": false,
+      "platforms": [
+        "Linux",
+        "macOS",
+        "Network Devices",
+        "Windows"
+      ]
     },
     {
       "id": "T1557.001",
@@ -5620,7 +7674,10 @@
       ],
       "description": "By responding to LLMNR/NBT-NS/mDNS network traffic, adversaries may spoof an authoritative source for name resolution to force communication with an adversary controlled system.(Citation: BlackCat…",
       "url": "https://attack.mitre.org/techniques/T1557/001",
-      "is_subtechnique": true
+      "is_subtechnique": true,
+      "platforms": [
+        "Windows"
+      ]
     },
     {
       "id": "T1557.002",
@@ -5632,7 +7689,12 @@
       ],
       "description": "Adversaries may poison Address Resolution Protocol (ARP) caches to position themselves between the communication of two or more networked devices. This activity may be used to enable follow-on…",
       "url": "https://attack.mitre.org/techniques/T1557/002",
-      "is_subtechnique": true
+      "is_subtechnique": true,
+      "platforms": [
+        "Linux",
+        "Windows",
+        "macOS"
+      ]
     },
     {
       "id": "T1557.003",
@@ -5644,7 +7706,12 @@
       ],
       "description": "Adversaries may redirect network traffic to adversary-owned systems by spoofing Dynamic Host Configuration Protocol (DHCP) traffic and acting as a malicious DHCP server on the victim network. By…",
       "url": "https://attack.mitre.org/techniques/T1557/003",
-      "is_subtechnique": true
+      "is_subtechnique": true,
+      "platforms": [
+        "Linux",
+        "Windows",
+        "macOS"
+      ]
     },
     {
       "id": "T1557.004",
@@ -5656,7 +7723,10 @@
       ],
       "description": "Adversaries may host seemingly genuine Wi-Fi access points to deceive users into connecting to malicious networks as a way of supporting follow-on behaviors such as [Network…",
       "url": "https://attack.mitre.org/techniques/T1557/004",
-      "is_subtechnique": true
+      "is_subtechnique": true,
+      "platforms": [
+        "Network Devices"
+      ]
     },
     {
       "id": "T1558",
@@ -5667,7 +7737,12 @@
       ],
       "description": "Adversaries may attempt to subvert Kerberos authentication by stealing or forging Kerberos tickets to enable [Pass the Ticket](https://attack.mitre.org/techniques/T1550/003). Kerberos is an…",
       "url": "https://attack.mitre.org/techniques/T1558",
-      "is_subtechnique": false
+      "is_subtechnique": false,
+      "platforms": [
+        "Linux",
+        "macOS",
+        "Windows"
+      ]
     },
     {
       "id": "T1558.001",
@@ -5678,7 +7753,10 @@
       ],
       "description": "Adversaries who have the KRBTGT account password hash may forge Kerberos ticket-granting tickets (TGT), also known as a golden ticket.(Citation: AdSecurity Kerberos GT Aug 2015) Golden tickets enable…",
       "url": "https://attack.mitre.org/techniques/T1558/001",
-      "is_subtechnique": true
+      "is_subtechnique": true,
+      "platforms": [
+        "Windows"
+      ]
     },
     {
       "id": "T1558.002",
@@ -5689,7 +7767,10 @@
       ],
       "description": "Adversaries who have the password hash of a target service account (e.g. SharePoint, MSSQL) may forge Kerberos ticket granting service (TGS) tickets, also known as silver tickets. Kerberos TGS…",
       "url": "https://attack.mitre.org/techniques/T1558/002",
-      "is_subtechnique": true
+      "is_subtechnique": true,
+      "platforms": [
+        "Windows"
+      ]
     },
     {
       "id": "T1558.003",
@@ -5700,7 +7781,10 @@
       ],
       "description": "Adversaries may abuse a valid Kerberos ticket-granting ticket (TGT) or sniff network traffic to obtain a ticket-granting service (TGS) ticket that may be vulnerable to [Brute…",
       "url": "https://attack.mitre.org/techniques/T1558/003",
-      "is_subtechnique": true
+      "is_subtechnique": true,
+      "platforms": [
+        "Windows"
+      ]
     },
     {
       "id": "T1558.004",
@@ -5711,7 +7795,10 @@
       ],
       "description": "Adversaries may reveal credentials of accounts that have disabled Kerberos preauthentication by [Password Cracking](https://attack.mitre.org/techniques/T1110/002) Kerberos messages.(Citation: Harmj0y…",
       "url": "https://attack.mitre.org/techniques/T1558/004",
-      "is_subtechnique": true
+      "is_subtechnique": true,
+      "platforms": [
+        "Windows"
+      ]
     },
     {
       "id": "T1558.005",
@@ -5722,7 +7809,11 @@
       ],
       "description": "Adversaries may attempt to steal Kerberos tickets stored in credential cache files (or ccache). These files are used for short term storage of a user's active session credentials. The ccache file is…",
       "url": "https://attack.mitre.org/techniques/T1558/005",
-      "is_subtechnique": true
+      "is_subtechnique": true,
+      "platforms": [
+        "Linux",
+        "macOS"
+      ]
     },
     {
       "id": "T1606",
@@ -5733,7 +7824,16 @@
       ],
       "description": "Adversaries may forge credential materials that can be used to gain access to web applications or Internet services. Web applications and services (hosted in cloud SaaS environments or on-premise…",
       "url": "https://attack.mitre.org/techniques/T1606",
-      "is_subtechnique": false
+      "is_subtechnique": false,
+      "platforms": [
+        "SaaS",
+        "Windows",
+        "macOS",
+        "Linux",
+        "IaaS",
+        "Office Suite",
+        "Identity Provider"
+      ]
     },
     {
       "id": "T1606.001",
@@ -5744,7 +7844,14 @@
       ],
       "description": "Adversaries may forge web cookies that can be used to gain access to web applications or Internet services. Web applications and services (hosted in cloud SaaS environments or on-premise servers)…",
       "url": "https://attack.mitre.org/techniques/T1606/001",
-      "is_subtechnique": true
+      "is_subtechnique": true,
+      "platforms": [
+        "Linux",
+        "macOS",
+        "Windows",
+        "SaaS",
+        "IaaS"
+      ]
     },
     {
       "id": "T1606.002",
@@ -5755,7 +7862,14 @@
       ],
       "description": "An adversary may forge SAML tokens with any permissions claims and lifetimes if they possess a valid SAML token-signing certificate.(Citation: Microsoft SolarWinds Steps) The default lifetime of a…",
       "url": "https://attack.mitre.org/techniques/T1606/002",
-      "is_subtechnique": true
+      "is_subtechnique": true,
+      "platforms": [
+        "SaaS",
+        "Windows",
+        "IaaS",
+        "Office Suite",
+        "Identity Provider"
+      ]
     },
     {
       "id": "T1621",
@@ -5766,7 +7880,16 @@
       ],
       "description": "Adversaries may attempt to bypass multi-factor authentication (MFA) mechanisms and gain access to accounts by generating MFA requests sent to users.\n\nAdversaries in possession of credentials to…",
       "url": "https://attack.mitre.org/techniques/T1621",
-      "is_subtechnique": false
+      "is_subtechnique": false,
+      "platforms": [
+        "Windows",
+        "Linux",
+        "macOS",
+        "IaaS",
+        "SaaS",
+        "Office Suite",
+        "Identity Provider"
+      ]
     },
     {
       "id": "T1649",
@@ -5777,7 +7900,13 @@
       ],
       "description": "Adversaries may steal or forge certificates used for authentication to access remote systems or resources. Digital certificates are often used to sign and encrypt messages and/or files. Certificates…",
       "url": "https://attack.mitre.org/techniques/T1649",
-      "is_subtechnique": false
+      "is_subtechnique": false,
+      "platforms": [
+        "Windows",
+        "Linux",
+        "macOS",
+        "Identity Provider"
+      ]
     },
     {
       "id": "T1007",
@@ -5788,7 +7917,12 @@
       ],
       "description": "Adversaries may try to gather information about registered local system services. Adversaries may obtain information about services using tools as well as OS utility commands such as <code>sc…",
       "url": "https://attack.mitre.org/techniques/T1007",
-      "is_subtechnique": false
+      "is_subtechnique": false,
+      "platforms": [
+        "Linux",
+        "macOS",
+        "Windows"
+      ]
     },
     {
       "id": "T1010",
@@ -5799,7 +7933,12 @@
       ],
       "description": "Adversaries may attempt to get a listing of open application windows. Window listings could convey information about how the system is used.(Citation: Prevailion DarkWatchman 2021) For example,…",
       "url": "https://attack.mitre.org/techniques/T1010",
-      "is_subtechnique": false
+      "is_subtechnique": false,
+      "platforms": [
+        "Linux",
+        "macOS",
+        "Windows"
+      ]
     },
     {
       "id": "T1012",
@@ -5810,7 +7949,10 @@
       ],
       "description": "Adversaries may interact with the Windows Registry to gather information about the system, configuration, and installed software.\n\nThe Registry contains a significant amount of information about the…",
       "url": "https://attack.mitre.org/techniques/T1012",
-      "is_subtechnique": false
+      "is_subtechnique": false,
+      "platforms": [
+        "Windows"
+      ]
     },
     {
       "id": "T1016",
@@ -5821,7 +7963,14 @@
       ],
       "description": "Adversaries may look for details about the network configuration and settings, such as IP and/or MAC addresses, of systems they access or through information discovery of remote systems. Several…",
       "url": "https://attack.mitre.org/techniques/T1016",
-      "is_subtechnique": false
+      "is_subtechnique": false,
+      "platforms": [
+        "ESXi",
+        "Linux",
+        "macOS",
+        "Network Devices",
+        "Windows"
+      ]
     },
     {
       "id": "T1016.001",
@@ -5832,7 +7981,13 @@
       ],
       "description": "Adversaries may check for Internet connectivity on compromised systems. This may be performed during automated discovery and can be accomplished in numerous ways such as using…",
       "url": "https://attack.mitre.org/techniques/T1016/001",
-      "is_subtechnique": true
+      "is_subtechnique": true,
+      "platforms": [
+        "Windows",
+        "Linux",
+        "macOS",
+        "ESXi"
+      ]
     },
     {
       "id": "T1016.002",
@@ -5843,7 +7998,12 @@
       ],
       "description": "Adversaries may search for information about Wi-Fi networks, such as network names and passwords, on compromised systems. Adversaries may use Wi-Fi information as part of [Account…",
       "url": "https://attack.mitre.org/techniques/T1016/002",
-      "is_subtechnique": true
+      "is_subtechnique": true,
+      "platforms": [
+        "Linux",
+        "Windows",
+        "macOS"
+      ]
     },
     {
       "id": "T1018",
@@ -5854,7 +8014,14 @@
       ],
       "description": "Adversaries may attempt to get a listing of other systems by IP address, hostname, or other logical identifier on a network that may be used for Lateral Movement from the current system.…",
       "url": "https://attack.mitre.org/techniques/T1018",
-      "is_subtechnique": false
+      "is_subtechnique": false,
+      "platforms": [
+        "ESXi",
+        "Linux",
+        "macOS",
+        "Network Devices",
+        "Windows"
+      ]
     },
     {
       "id": "T1033",
@@ -5865,7 +8032,13 @@
       ],
       "description": "Adversaries may attempt to identify the primary user, currently logged in user, set of users that commonly uses a system, or whether a user is actively using the system. They may do this, for…",
       "url": "https://attack.mitre.org/techniques/T1033",
-      "is_subtechnique": false
+      "is_subtechnique": false,
+      "platforms": [
+        "Linux",
+        "macOS",
+        "Network Devices",
+        "Windows"
+      ]
     },
     {
       "id": "T1046",
@@ -5876,7 +8049,15 @@
       ],
       "description": "Adversaries may attempt to get a listing of services running on remote hosts and local network infrastructure devices, including those that may be vulnerable to remote software exploitation. Common…",
       "url": "https://attack.mitre.org/techniques/T1046",
-      "is_subtechnique": false
+      "is_subtechnique": false,
+      "platforms": [
+        "Containers",
+        "IaaS",
+        "Linux",
+        "macOS",
+        "Network Devices",
+        "Windows"
+      ]
     },
     {
       "id": "T1049",
@@ -5887,7 +8068,15 @@
       ],
       "description": "Adversaries may attempt to get a listing of network connections to or from the compromised system they are currently accessing or from remote systems by querying for information over the network.…",
       "url": "https://attack.mitre.org/techniques/T1049",
-      "is_subtechnique": false
+      "is_subtechnique": false,
+      "platforms": [
+        "ESXi",
+        "IaaS",
+        "Linux",
+        "macOS",
+        "Network Devices",
+        "Windows"
+      ]
     },
     {
       "id": "T1057",
@@ -5898,7 +8087,14 @@
       ],
       "description": "Adversaries may attempt to get information about running processes on a system. Information obtained could be used to gain an understanding of common software/applications running on systems within…",
       "url": "https://attack.mitre.org/techniques/T1057",
-      "is_subtechnique": false
+      "is_subtechnique": false,
+      "platforms": [
+        "ESXi",
+        "Linux",
+        "macOS",
+        "Network Devices",
+        "Windows"
+      ]
     },
     {
       "id": "T1069",
@@ -5909,7 +8105,17 @@
       ],
       "description": "Adversaries may attempt to discover group and permission settings. This information can help adversaries determine which user accounts and groups are available, the membership of users in particular…",
       "url": "https://attack.mitre.org/techniques/T1069",
-      "is_subtechnique": false
+      "is_subtechnique": false,
+      "platforms": [
+        "Containers",
+        "IaaS",
+        "Identity Provider",
+        "Linux",
+        "macOS",
+        "Office Suite",
+        "SaaS",
+        "Windows"
+      ]
     },
     {
       "id": "T1069.001",
@@ -5920,7 +8126,12 @@
       ],
       "description": "Adversaries may attempt to find local system groups and permission settings. The knowledge of local system permission groups can help adversaries determine which groups exist and which users belong…",
       "url": "https://attack.mitre.org/techniques/T1069/001",
-      "is_subtechnique": true
+      "is_subtechnique": true,
+      "platforms": [
+        "Linux",
+        "macOS",
+        "Windows"
+      ]
     },
     {
       "id": "T1069.002",
@@ -5931,7 +8142,12 @@
       ],
       "description": "Adversaries may attempt to find domain-level groups and permission settings. The knowledge of domain-level permission groups can help adversaries determine which groups exist and which users belong…",
       "url": "https://attack.mitre.org/techniques/T1069/002",
-      "is_subtechnique": true
+      "is_subtechnique": true,
+      "platforms": [
+        "Linux",
+        "macOS",
+        "Windows"
+      ]
     },
     {
       "id": "T1069.003",
@@ -5942,7 +8158,13 @@
       ],
       "description": "Adversaries may attempt to find cloud groups and permission settings. The knowledge of cloud permission groups can help adversaries determine the particular roles of users and groups within an…",
       "url": "https://attack.mitre.org/techniques/T1069/003",
-      "is_subtechnique": true
+      "is_subtechnique": true,
+      "platforms": [
+        "SaaS",
+        "IaaS",
+        "Office Suite",
+        "Identity Provider"
+      ]
     },
     {
       "id": "T1082",
@@ -5953,7 +8175,15 @@
       ],
       "description": "An adversary may attempt to get detailed information about the operating system and hardware, including version, patches, hotfixes, service packs, and architecture. Adversaries may use this…",
       "url": "https://attack.mitre.org/techniques/T1082",
-      "is_subtechnique": false
+      "is_subtechnique": false,
+      "platforms": [
+        "ESXi",
+        "IaaS",
+        "Linux",
+        "macOS",
+        "Network Devices",
+        "Windows"
+      ]
     },
     {
       "id": "T1083",
@@ -5964,7 +8194,14 @@
       ],
       "description": "Adversaries may enumerate files and directories or may search in specific locations of a host or network share for certain information within a file system. Adversaries may use the information from…",
       "url": "https://attack.mitre.org/techniques/T1083",
-      "is_subtechnique": false
+      "is_subtechnique": false,
+      "platforms": [
+        "ESXi",
+        "Linux",
+        "macOS",
+        "Network Devices",
+        "Windows"
+      ]
     },
     {
       "id": "T1087",
@@ -5975,7 +8212,17 @@
       ],
       "description": "Adversaries may attempt to get a listing of valid accounts, usernames, or email addresses on a system or within a compromised environment. This information can help adversaries determine which…",
       "url": "https://attack.mitre.org/techniques/T1087",
-      "is_subtechnique": false
+      "is_subtechnique": false,
+      "platforms": [
+        "ESXi",
+        "IaaS",
+        "Identity Provider",
+        "Linux",
+        "macOS",
+        "Office Suite",
+        "SaaS",
+        "Windows"
+      ]
     },
     {
       "id": "T1087.001",
@@ -5986,7 +8233,13 @@
       ],
       "description": "Adversaries may attempt to get a listing of local system accounts. This information can help adversaries determine which local accounts exist on a system to aid in follow-on behavior.\n\nCommands such…",
       "url": "https://attack.mitre.org/techniques/T1087/001",
-      "is_subtechnique": true
+      "is_subtechnique": true,
+      "platforms": [
+        "ESXi",
+        "Linux",
+        "macOS",
+        "Windows"
+      ]
     },
     {
       "id": "T1087.002",
@@ -5997,7 +8250,12 @@
       ],
       "description": "Adversaries may attempt to get a listing of domain accounts. This information can help adversaries determine which domain accounts exist to aid in follow-on behavior such as targeting specific…",
       "url": "https://attack.mitre.org/techniques/T1087/002",
-      "is_subtechnique": true
+      "is_subtechnique": true,
+      "platforms": [
+        "Linux",
+        "macOS",
+        "Windows"
+      ]
     },
     {
       "id": "T1087.003",
@@ -6008,7 +8266,11 @@
       ],
       "description": "Adversaries may attempt to get a listing of email addresses and accounts. Adversaries may try to dump Exchange address lists such as global address lists (GALs).(Citation: Microsoft Exchange Address…",
       "url": "https://attack.mitre.org/techniques/T1087/003",
-      "is_subtechnique": true
+      "is_subtechnique": true,
+      "platforms": [
+        "Windows",
+        "Office Suite"
+      ]
     },
     {
       "id": "T1087.004",
@@ -6019,7 +8281,13 @@
       ],
       "description": "Adversaries may attempt to get a listing of cloud accounts. Cloud accounts are those created and configured by an organization for use by users, remote support, services, or for administration of…",
       "url": "https://attack.mitre.org/techniques/T1087/004",
-      "is_subtechnique": true
+      "is_subtechnique": true,
+      "platforms": [
+        "IaaS",
+        "Identity Provider",
+        "Office Suite",
+        "SaaS"
+      ]
     },
     {
       "id": "T1120",
@@ -6030,7 +8298,12 @@
       ],
       "description": "Adversaries may attempt to gather information about attached peripheral devices and components connected to a computer system.(Citation: Peripheral Discovery Linux)(Citation: Peripheral Discovery…",
       "url": "https://attack.mitre.org/techniques/T1120",
-      "is_subtechnique": false
+      "is_subtechnique": false,
+      "platforms": [
+        "Linux",
+        "macOS",
+        "Windows"
+      ]
     },
     {
       "id": "T1124",
@@ -6041,7 +8314,14 @@
       ],
       "description": "An adversary may gather the system time and/or time zone settings from a local or remote system. The system time is set and stored by services, such as the Windows Time Service on Windows or…",
       "url": "https://attack.mitre.org/techniques/T1124",
-      "is_subtechnique": false
+      "is_subtechnique": false,
+      "platforms": [
+        "ESXi",
+        "Linux",
+        "macOS",
+        "Network Devices",
+        "Windows"
+      ]
     },
     {
       "id": "T1135",
@@ -6052,7 +8332,12 @@
       ],
       "description": "Adversaries may look for folders and drives shared on remote systems as a means of identifying sources of information to gather as a precursor for Collection and to identify potential systems of…",
       "url": "https://attack.mitre.org/techniques/T1135",
-      "is_subtechnique": false
+      "is_subtechnique": false,
+      "platforms": [
+        "Linux",
+        "macOS",
+        "Windows"
+      ]
     },
     {
       "id": "T1201",
@@ -6063,7 +8348,17 @@
       ],
       "description": "Adversaries may attempt to access detailed information about the password policy used within an enterprise network or cloud environment. Password policies are a way to enforce complex passwords that…",
       "url": "https://attack.mitre.org/techniques/T1201",
-      "is_subtechnique": false
+      "is_subtechnique": false,
+      "platforms": [
+        "Windows",
+        "Linux",
+        "macOS",
+        "IaaS",
+        "Network Devices",
+        "Identity Provider",
+        "SaaS",
+        "Office Suite"
+      ]
     },
     {
       "id": "T1217",
@@ -6074,7 +8369,12 @@
       ],
       "description": "Adversaries may enumerate information about browsers to learn more about compromised environments. Data saved by browsers (such as bookmarks, accounts, and browsing history) may reveal a variety of…",
       "url": "https://attack.mitre.org/techniques/T1217",
-      "is_subtechnique": false
+      "is_subtechnique": false,
+      "platforms": [
+        "Linux",
+        "macOS",
+        "Windows"
+      ]
     },
     {
       "id": "T1482",
@@ -6085,7 +8385,10 @@
       ],
       "description": "Adversaries may attempt to gather information on domain trust relationships that may be used to identify lateral movement opportunities in Windows multi-domain/forest environments. Domain trusts…",
       "url": "https://attack.mitre.org/techniques/T1482",
-      "is_subtechnique": false
+      "is_subtechnique": false,
+      "platforms": [
+        "Windows"
+      ]
     },
     {
       "id": "T1518",
@@ -6096,7 +8399,14 @@
       ],
       "description": "Adversaries may attempt to get a listing of software and software versions that are installed on a system or in a cloud environment. Adversaries may use the information from [Software…",
       "url": "https://attack.mitre.org/techniques/T1518",
-      "is_subtechnique": false
+      "is_subtechnique": false,
+      "platforms": [
+        "ESXi",
+        "IaaS",
+        "Linux",
+        "macOS",
+        "Windows"
+      ]
     },
     {
       "id": "T1518.001",
@@ -6107,7 +8417,13 @@
       ],
       "description": "Adversaries may attempt to get a listing of security software, configurations, defensive tools, and sensors that are installed on a system or in a cloud environment. This may include things such as…",
       "url": "https://attack.mitre.org/techniques/T1518/001",
-      "is_subtechnique": true
+      "is_subtechnique": true,
+      "platforms": [
+        "IaaS",
+        "Linux",
+        "macOS",
+        "Windows"
+      ]
     },
     {
       "id": "T1518.002",
@@ -6118,7 +8434,12 @@
       ],
       "description": "Adversaries may attempt to get a listing of backup software or configurations that are installed on a system. Adversaries may use this information to shape follow-on behaviors, such as [Data…",
       "url": "https://attack.mitre.org/techniques/T1518/002",
-      "is_subtechnique": true
+      "is_subtechnique": true,
+      "platforms": [
+        "Windows",
+        "macOS",
+        "Linux"
+      ]
     },
     {
       "id": "T1526",
@@ -6129,7 +8450,13 @@
       ],
       "description": "An adversary may attempt to enumerate the cloud services running on a system after gaining access. These methods can differ from platform-as-a-service (PaaS), to infrastructure-as-a-service (IaaS),…",
       "url": "https://attack.mitre.org/techniques/T1526",
-      "is_subtechnique": false
+      "is_subtechnique": false,
+      "platforms": [
+        "IaaS",
+        "Identity Provider",
+        "Office Suite",
+        "SaaS"
+      ]
     },
     {
       "id": "T1538",
@@ -6140,7 +8467,13 @@
       ],
       "description": "An adversary may use a cloud service dashboard GUI with stolen credentials to gain useful information from an operational cloud environment, such as specific services, resources, and features. For…",
       "url": "https://attack.mitre.org/techniques/T1538",
-      "is_subtechnique": false
+      "is_subtechnique": false,
+      "platforms": [
+        "IaaS",
+        "SaaS",
+        "Office Suite",
+        "Identity Provider"
+      ]
     },
     {
       "id": "T1580",
@@ -6151,7 +8484,10 @@
       ],
       "description": "An adversary may attempt to discover infrastructure and resources that are available within an infrastructure-as-a-service (IaaS) environment. This includes compute service resources such as…",
       "url": "https://attack.mitre.org/techniques/T1580",
-      "is_subtechnique": false
+      "is_subtechnique": false,
+      "platforms": [
+        "IaaS"
+      ]
     },
     {
       "id": "T1613",
@@ -6162,7 +8498,10 @@
       ],
       "description": "Adversaries may attempt to discover containers and other resources that are available within a containers environment. Other resources may include images, deployments, pods, nodes, and other…",
       "url": "https://attack.mitre.org/techniques/T1613",
-      "is_subtechnique": false
+      "is_subtechnique": false,
+      "platforms": [
+        "Containers"
+      ]
     },
     {
       "id": "T1614",
@@ -6173,7 +8512,13 @@
       ],
       "description": "Adversaries may gather information in an attempt to calculate the geographical location of a victim host. Adversaries may use the information from [System Location…",
       "url": "https://attack.mitre.org/techniques/T1614",
-      "is_subtechnique": false
+      "is_subtechnique": false,
+      "platforms": [
+        "IaaS",
+        "Linux",
+        "macOS",
+        "Windows"
+      ]
     },
     {
       "id": "T1614.001",
@@ -6184,7 +8529,12 @@
       ],
       "description": "Adversaries may attempt to gather information about the system language of a victim in order to infer the geographical location of that host. This information may be used to shape follow-on…",
       "url": "https://attack.mitre.org/techniques/T1614/001",
-      "is_subtechnique": true
+      "is_subtechnique": true,
+      "platforms": [
+        "Linux",
+        "macOS",
+        "Windows"
+      ]
     },
     {
       "id": "T1615",
@@ -6195,7 +8545,10 @@
       ],
       "description": "Adversaries may gather information on Group Policy settings to identify paths for privilege escalation, security measures applied within a domain, and to discover patterns in domain objects that can…",
       "url": "https://attack.mitre.org/techniques/T1615",
-      "is_subtechnique": false
+      "is_subtechnique": false,
+      "platforms": [
+        "Windows"
+      ]
     },
     {
       "id": "T1619",
@@ -6206,7 +8559,10 @@
       ],
       "description": "Adversaries may enumerate objects in cloud storage infrastructure. Adversaries may use this information during automated discovery to shape follow-on behaviors, including requesting all or specific…",
       "url": "https://attack.mitre.org/techniques/T1619",
-      "is_subtechnique": false
+      "is_subtechnique": false,
+      "platforms": [
+        "IaaS"
+      ]
     },
     {
       "id": "T1652",
@@ -6217,7 +8573,12 @@
       ],
       "description": "Adversaries may attempt to enumerate local device drivers on a victim host. Information about device drivers may highlight various insights that shape follow-on behaviors, such as the…",
       "url": "https://attack.mitre.org/techniques/T1652",
-      "is_subtechnique": false
+      "is_subtechnique": false,
+      "platforms": [
+        "Linux",
+        "macOS",
+        "Windows"
+      ]
     },
     {
       "id": "T1654",
@@ -6228,7 +8589,14 @@
       ],
       "description": "Adversaries may enumerate system and service logs to find useful data. These logs may highlight various types of valuable insights for an adversary, such as user authentication records ([Account…",
       "url": "https://attack.mitre.org/techniques/T1654",
-      "is_subtechnique": false
+      "is_subtechnique": false,
+      "platforms": [
+        "ESXi",
+        "IaaS",
+        "Linux",
+        "macOS",
+        "Windows"
+      ]
     },
     {
       "id": "T1673",
@@ -6239,7 +8607,13 @@
       ],
       "description": "An adversary may attempt to enumerate running virtual machines (VMs) after gaining access to a host or hypervisor. For example, adversaries may enumerate a list of VMs on an ESXi hypervisor using a…",
       "url": "https://attack.mitre.org/techniques/T1673",
-      "is_subtechnique": false
+      "is_subtechnique": false,
+      "platforms": [
+        "ESXi",
+        "Linux",
+        "macOS",
+        "Windows"
+      ]
     },
     {
       "id": "T1680",
@@ -6250,7 +8624,14 @@
       ],
       "description": "Adversaries may enumerate local drives, disks, and/or volumes and their attributes like total or free space and volume serial number. This can be done to prepare for ransomware-related encryption, to…",
       "url": "https://attack.mitre.org/techniques/T1680",
-      "is_subtechnique": false
+      "is_subtechnique": false,
+      "platforms": [
+        "ESXi",
+        "IaaS",
+        "Linux",
+        "macOS",
+        "Windows"
+      ]
     },
     {
       "id": "T1021",
@@ -6261,7 +8642,14 @@
       ],
       "description": "Adversaries may use [Valid Accounts](https://attack.mitre.org/techniques/T1078) to log into a service that accepts remote connections, such as telnet, SSH, and VNC. The adversary may then perform…",
       "url": "https://attack.mitre.org/techniques/T1021",
-      "is_subtechnique": false
+      "is_subtechnique": false,
+      "platforms": [
+        "Linux",
+        "macOS",
+        "Windows",
+        "IaaS",
+        "ESXi"
+      ]
     },
     {
       "id": "T1021.001",
@@ -6272,7 +8660,10 @@
       ],
       "description": "Adversaries may use [Valid Accounts](https://attack.mitre.org/techniques/T1078) to log into a computer using the Remote Desktop Protocol (RDP). The adversary may then perform actions as the logged-on…",
       "url": "https://attack.mitre.org/techniques/T1021/001",
-      "is_subtechnique": true
+      "is_subtechnique": true,
+      "platforms": [
+        "Windows"
+      ]
     },
     {
       "id": "T1021.002",
@@ -6283,7 +8674,10 @@
       ],
       "description": "Adversaries may use [Valid Accounts](https://attack.mitre.org/techniques/T1078) to interact with a remote network share using Server Message Block (SMB). The adversary may then perform actions as the…",
       "url": "https://attack.mitre.org/techniques/T1021/002",
-      "is_subtechnique": true
+      "is_subtechnique": true,
+      "platforms": [
+        "Windows"
+      ]
     },
     {
       "id": "T1021.003",
@@ -6294,7 +8688,10 @@
       ],
       "description": "Adversaries may use [Valid Accounts](https://attack.mitre.org/techniques/T1078) to interact with remote machines by taking advantage of Distributed Component Object Model (DCOM). The adversary may…",
       "url": "https://attack.mitre.org/techniques/T1021/003",
-      "is_subtechnique": true
+      "is_subtechnique": true,
+      "platforms": [
+        "Windows"
+      ]
     },
     {
       "id": "T1021.004",
@@ -6305,7 +8702,12 @@
       ],
       "description": "Adversaries may use [Valid Accounts](https://attack.mitre.org/techniques/T1078) to log into remote machines using Secure Shell (SSH). The adversary may then perform actions as the logged-on…",
       "url": "https://attack.mitre.org/techniques/T1021/004",
-      "is_subtechnique": true
+      "is_subtechnique": true,
+      "platforms": [
+        "ESXi",
+        "Linux",
+        "macOS"
+      ]
     },
     {
       "id": "T1021.005",
@@ -6316,7 +8718,12 @@
       ],
       "description": "Adversaries may use [Valid Accounts](https://attack.mitre.org/techniques/T1078) to remotely control machines using Virtual Network Computing (VNC).  VNC is a platform-independent desktop sharing…",
       "url": "https://attack.mitre.org/techniques/T1021/005",
-      "is_subtechnique": true
+      "is_subtechnique": true,
+      "platforms": [
+        "Linux",
+        "Windows",
+        "macOS"
+      ]
     },
     {
       "id": "T1021.006",
@@ -6327,7 +8734,10 @@
       ],
       "description": "Adversaries may use [Valid Accounts](https://attack.mitre.org/techniques/T1078) to interact with remote systems using Windows Remote Management (WinRM). The adversary may then perform actions as the…",
       "url": "https://attack.mitre.org/techniques/T1021/006",
-      "is_subtechnique": true
+      "is_subtechnique": true,
+      "platforms": [
+        "Windows"
+      ]
     },
     {
       "id": "T1021.007",
@@ -6338,7 +8748,13 @@
       ],
       "description": "Adversaries may log into accessible cloud services within a compromised environment using [Valid Accounts](https://attack.mitre.org/techniques/T1078) that are synchronized with or federated to…",
       "url": "https://attack.mitre.org/techniques/T1021/007",
-      "is_subtechnique": true
+      "is_subtechnique": true,
+      "platforms": [
+        "IaaS",
+        "Identity Provider",
+        "Office Suite",
+        "SaaS"
+      ]
     },
     {
       "id": "T1021.008",
@@ -6349,7 +8765,10 @@
       ],
       "description": "Adversaries may leverage [Valid Accounts](https://attack.mitre.org/techniques/T1078) to log directly into accessible cloud hosted compute infrastructure through cloud native methods. Many cloud…",
       "url": "https://attack.mitre.org/techniques/T1021/008",
-      "is_subtechnique": true
+      "is_subtechnique": true,
+      "platforms": [
+        "IaaS"
+      ]
     },
     {
       "id": "T1080",
@@ -6360,7 +8779,14 @@
       ],
       "description": "Adversaries may deliver payloads to remote systems by adding content to shared storage locations, such as network drives or internal code repositories. Content stored on network drives or in other…",
       "url": "https://attack.mitre.org/techniques/T1080",
-      "is_subtechnique": false
+      "is_subtechnique": false,
+      "platforms": [
+        "Windows",
+        "SaaS",
+        "Linux",
+        "macOS",
+        "Office Suite"
+      ]
     },
     {
       "id": "T1091",
@@ -6372,7 +8798,10 @@
       ],
       "description": "Adversaries may move onto systems, possibly those on disconnected or air-gapped networks, by copying malware to removable media and taking advantage of Autorun features when the media is inserted…",
       "url": "https://attack.mitre.org/techniques/T1091",
-      "is_subtechnique": false
+      "is_subtechnique": false,
+      "platforms": [
+        "Windows"
+      ]
     },
     {
       "id": "T1210",
@@ -6383,7 +8812,13 @@
       ],
       "description": "Adversaries may exploit remote services to gain unauthorized access to internal systems once inside of a network. Exploitation of a software vulnerability occurs when an adversary takes advantage of…",
       "url": "https://attack.mitre.org/techniques/T1210",
-      "is_subtechnique": false
+      "is_subtechnique": false,
+      "platforms": [
+        "Linux",
+        "Windows",
+        "macOS",
+        "ESXi"
+      ]
     },
     {
       "id": "T1534",
@@ -6394,7 +8829,14 @@
       ],
       "description": "After they already have access to accounts or systems within the environment, adversaries may use internal spearphishing to gain access to additional information or compromise other users within the…",
       "url": "https://attack.mitre.org/techniques/T1534",
-      "is_subtechnique": false
+      "is_subtechnique": false,
+      "platforms": [
+        "Linux",
+        "macOS",
+        "Office Suite",
+        "SaaS",
+        "Windows"
+      ]
     },
     {
       "id": "T1550",
@@ -6405,7 +8847,16 @@
       ],
       "description": "Adversaries may use alternate authentication material, such as password hashes, Kerberos tickets, and application access tokens, in order to move laterally within an environment and bypass normal…",
       "url": "https://attack.mitre.org/techniques/T1550",
-      "is_subtechnique": false
+      "is_subtechnique": false,
+      "platforms": [
+        "Containers",
+        "IaaS",
+        "Identity Provider",
+        "Linux",
+        "Office Suite",
+        "SaaS",
+        "Windows"
+      ]
     },
     {
       "id": "T1550.001",
@@ -6416,7 +8867,14 @@
       ],
       "description": "Adversaries may use stolen application access tokens to bypass the typical authentication process and access restricted accounts, information, or services on remote systems. These tokens are…",
       "url": "https://attack.mitre.org/techniques/T1550/001",
-      "is_subtechnique": true
+      "is_subtechnique": true,
+      "platforms": [
+        "Containers",
+        "IaaS",
+        "Identity Provider",
+        "Office Suite",
+        "SaaS"
+      ]
     },
     {
       "id": "T1550.002",
@@ -6427,7 +8885,10 @@
       ],
       "description": "Adversaries may “pass the hash” using stolen password hashes to move laterally within an environment, bypassing normal system access controls. Pass the hash (PtH) is a method of authenticating as a…",
       "url": "https://attack.mitre.org/techniques/T1550/002",
-      "is_subtechnique": true
+      "is_subtechnique": true,
+      "platforms": [
+        "Windows"
+      ]
     },
     {
       "id": "T1550.003",
@@ -6438,7 +8899,10 @@
       ],
       "description": "Adversaries may “pass the ticket” using stolen Kerberos tickets to move laterally within an environment, bypassing normal system access controls. Pass the ticket (PtT) is a method of authenticating…",
       "url": "https://attack.mitre.org/techniques/T1550/003",
-      "is_subtechnique": true
+      "is_subtechnique": true,
+      "platforms": [
+        "Windows"
+      ]
     },
     {
       "id": "T1550.004",
@@ -6449,7 +8913,12 @@
       ],
       "description": "Adversaries can use stolen session cookies to authenticate to web applications and services. This technique bypasses some multi-factor authentication protocols since the session is already…",
       "url": "https://attack.mitre.org/techniques/T1550/004",
-      "is_subtechnique": true
+      "is_subtechnique": true,
+      "platforms": [
+        "IaaS",
+        "Office Suite",
+        "SaaS"
+      ]
     },
     {
       "id": "T1563",
@@ -6460,7 +8929,12 @@
       ],
       "description": "Adversaries may take control of preexisting sessions with remote services to move laterally in an environment. Users may use valid credentials to log into a service specifically designed to accept…",
       "url": "https://attack.mitre.org/techniques/T1563",
-      "is_subtechnique": false
+      "is_subtechnique": false,
+      "platforms": [
+        "Linux",
+        "macOS",
+        "Windows"
+      ]
     },
     {
       "id": "T1563.001",
@@ -6471,7 +8945,11 @@
       ],
       "description": "Adversaries may hijack a legitimate user's SSH session to move laterally within an environment. Secure Shell (SSH) is a standard means of remote access on Linux and macOS systems. It allows a user to…",
       "url": "https://attack.mitre.org/techniques/T1563/001",
-      "is_subtechnique": true
+      "is_subtechnique": true,
+      "platforms": [
+        "Linux",
+        "macOS"
+      ]
     },
     {
       "id": "T1563.002",
@@ -6482,7 +8960,10 @@
       ],
       "description": "Adversaries may hijack a legitimate user’s remote desktop session to move laterally within an environment. Remote desktop is a common feature in operating systems. It allows a user to log into an…",
       "url": "https://attack.mitre.org/techniques/T1563/002",
-      "is_subtechnique": true
+      "is_subtechnique": true,
+      "platforms": [
+        "Windows"
+      ]
     },
     {
       "id": "T1570",
@@ -6493,7 +8974,13 @@
       ],
       "description": "Adversaries may transfer tools or other files between systems in a compromised environment. Once brought into the victim environment (i.e., [Ingress Tool…",
       "url": "https://attack.mitre.org/techniques/T1570",
-      "is_subtechnique": false
+      "is_subtechnique": false,
+      "platforms": [
+        "ESXi",
+        "Linux",
+        "macOS",
+        "Windows"
+      ]
     },
     {
       "id": "T1005",
@@ -6504,7 +8991,14 @@
       ],
       "description": "Adversaries may search local system sources, such as file systems, configuration files, local databases, virtual machine files, or process memory, to find files of interest and sensitive data prior…",
       "url": "https://attack.mitre.org/techniques/T1005",
-      "is_subtechnique": false
+      "is_subtechnique": false,
+      "platforms": [
+        "ESXi",
+        "Linux",
+        "macOS",
+        "Network Devices",
+        "Windows"
+      ]
     },
     {
       "id": "T1025",
@@ -6515,7 +9009,12 @@
       ],
       "description": "Adversaries may search connected removable media on computers they have compromised to find files of interest. Sensitive data can be collected from any removable media (optical disk drive, USB…",
       "url": "https://attack.mitre.org/techniques/T1025",
-      "is_subtechnique": false
+      "is_subtechnique": false,
+      "platforms": [
+        "Linux",
+        "macOS",
+        "Windows"
+      ]
     },
     {
       "id": "T1039",
@@ -6526,7 +9025,12 @@
       ],
       "description": "Adversaries may search network shares on computers they have compromised to find files of interest. Sensitive data can be collected from remote systems via shared network drives (host shared…",
       "url": "https://attack.mitre.org/techniques/T1039",
-      "is_subtechnique": false
+      "is_subtechnique": false,
+      "platforms": [
+        "Linux",
+        "macOS",
+        "Windows"
+      ]
     },
     {
       "id": "T1056",
@@ -6538,7 +9042,13 @@
       ],
       "description": "Adversaries may use methods of capturing user input to obtain credentials or collect information. During normal system usage, users often provide credentials to various different locations, such as…",
       "url": "https://attack.mitre.org/techniques/T1056",
-      "is_subtechnique": false
+      "is_subtechnique": false,
+      "platforms": [
+        "Linux",
+        "macOS",
+        "Network Devices",
+        "Windows"
+      ]
     },
     {
       "id": "T1056.001",
@@ -6550,7 +9060,13 @@
       ],
       "description": "Adversaries may log user keystrokes to intercept credentials as the user types them. Keylogging is likely to be used to acquire credentials for new access opportunities when [OS Credential…",
       "url": "https://attack.mitre.org/techniques/T1056/001",
-      "is_subtechnique": true
+      "is_subtechnique": true,
+      "platforms": [
+        "Linux",
+        "macOS",
+        "Network Devices",
+        "Windows"
+      ]
     },
     {
       "id": "T1056.002",
@@ -6562,7 +9078,12 @@
       ],
       "description": "Adversaries may mimic common operating system GUI components to prompt users for credentials with a seemingly legitimate prompt. When programs are executed that need additional privileges than are…",
       "url": "https://attack.mitre.org/techniques/T1056/002",
-      "is_subtechnique": true
+      "is_subtechnique": true,
+      "platforms": [
+        "Linux",
+        "macOS",
+        "Windows"
+      ]
     },
     {
       "id": "T1056.003",
@@ -6574,7 +9095,12 @@
       ],
       "description": "Adversaries may install code on externally facing portals, such as a VPN login page, to capture and transmit credentials of users who attempt to log into the service. For example, a compromised login…",
       "url": "https://attack.mitre.org/techniques/T1056/003",
-      "is_subtechnique": true
+      "is_subtechnique": true,
+      "platforms": [
+        "Linux",
+        "macOS",
+        "Windows"
+      ]
     },
     {
       "id": "T1056.004",
@@ -6586,7 +9112,12 @@
       ],
       "description": "Adversaries may hook into Windows application programming interface (API) functions and Linux system functions to collect user credentials. Malicious hooking mechanisms may capture API or function…",
       "url": "https://attack.mitre.org/techniques/T1056/004",
-      "is_subtechnique": true
+      "is_subtechnique": true,
+      "platforms": [
+        "Windows",
+        "Linux",
+        "macOS"
+      ]
     },
     {
       "id": "T1074",
@@ -6597,7 +9128,14 @@
       ],
       "description": "Adversaries may stage collected data in a central location or directory prior to Exfiltration. Data may be kept in separate files or combined into one file through techniques such as [Archive…",
       "url": "https://attack.mitre.org/techniques/T1074",
-      "is_subtechnique": false
+      "is_subtechnique": false,
+      "platforms": [
+        "ESXi",
+        "IaaS",
+        "Linux",
+        "macOS",
+        "Windows"
+      ]
     },
     {
       "id": "T1074.001",
@@ -6608,7 +9146,13 @@
       ],
       "description": "Adversaries may stage collected data in a central location or directory on the local system prior to Exfiltration. Data may be kept in separate files or combined into one file through techniques such…",
       "url": "https://attack.mitre.org/techniques/T1074/001",
-      "is_subtechnique": true
+      "is_subtechnique": true,
+      "platforms": [
+        "ESXi",
+        "Linux",
+        "macOS",
+        "Windows"
+      ]
     },
     {
       "id": "T1074.002",
@@ -6619,7 +9163,14 @@
       ],
       "description": "Adversaries may stage data collected from multiple systems in a central location or directory on one system prior to Exfiltration. Data may be kept in separate files or combined into one file through…",
       "url": "https://attack.mitre.org/techniques/T1074/002",
-      "is_subtechnique": true
+      "is_subtechnique": true,
+      "platforms": [
+        "ESXi",
+        "IaaS",
+        "Linux",
+        "macOS",
+        "Windows"
+      ]
     },
     {
       "id": "T1113",
@@ -6630,7 +9181,12 @@
       ],
       "description": "Adversaries may attempt to take screen captures of the desktop to gather information over the course of an operation. Screen capturing functionality may be included as a feature of a remote access…",
       "url": "https://attack.mitre.org/techniques/T1113",
-      "is_subtechnique": false
+      "is_subtechnique": false,
+      "platforms": [
+        "Linux",
+        "macOS",
+        "Windows"
+      ]
     },
     {
       "id": "T1114",
@@ -6641,7 +9197,13 @@
       ],
       "description": "Adversaries may target user email to collect sensitive information. Emails may contain sensitive data, including trade secrets or personal information, that can prove valuable to adversaries. Emails…",
       "url": "https://attack.mitre.org/techniques/T1114",
-      "is_subtechnique": false
+      "is_subtechnique": false,
+      "platforms": [
+        "Windows",
+        "macOS",
+        "Linux",
+        "Office Suite"
+      ]
     },
     {
       "id": "T1114.001",
@@ -6652,7 +9214,10 @@
       ],
       "description": "Adversaries may target user email on local systems to collect sensitive information. Files containing email data can be acquired from a user’s local system, such as Outlook storage or cache…",
       "url": "https://attack.mitre.org/techniques/T1114/001",
-      "is_subtechnique": true
+      "is_subtechnique": true,
+      "platforms": [
+        "Windows"
+      ]
     },
     {
       "id": "T1114.002",
@@ -6663,7 +9228,11 @@
       ],
       "description": "Adversaries may target an Exchange server, Office 365, or Google Workspace to collect sensitive information. Adversaries may leverage a user's credentials and interact directly with the Exchange…",
       "url": "https://attack.mitre.org/techniques/T1114/002",
-      "is_subtechnique": true
+      "is_subtechnique": true,
+      "platforms": [
+        "Office Suite",
+        "Windows"
+      ]
     },
     {
       "id": "T1114.003",
@@ -6674,7 +9243,13 @@
       ],
       "description": "Adversaries may setup email forwarding rules to collect sensitive information. Adversaries may abuse email forwarding rules to monitor the activities of a victim, steal information, and further gain…",
       "url": "https://attack.mitre.org/techniques/T1114/003",
-      "is_subtechnique": true
+      "is_subtechnique": true,
+      "platforms": [
+        "Linux",
+        "macOS",
+        "Office Suite",
+        "Windows"
+      ]
     },
     {
       "id": "T1115",
@@ -6685,7 +9260,12 @@
       ],
       "description": "Adversaries may collect data stored in the clipboard from users copying information within or between applications. \n\nFor example, on Windows adversaries can access clipboard data by using…",
       "url": "https://attack.mitre.org/techniques/T1115",
-      "is_subtechnique": false
+      "is_subtechnique": false,
+      "platforms": [
+        "Linux",
+        "macOS",
+        "Windows"
+      ]
     },
     {
       "id": "T1119",
@@ -6696,7 +9276,15 @@
       ],
       "description": "Once established within a system or network, an adversary may use automated techniques for collecting internal data. Methods for performing this technique could include use of a [Command and…",
       "url": "https://attack.mitre.org/techniques/T1119",
-      "is_subtechnique": false
+      "is_subtechnique": false,
+      "platforms": [
+        "IaaS",
+        "Linux",
+        "macOS",
+        "Office Suite",
+        "SaaS",
+        "Windows"
+      ]
     },
     {
       "id": "T1123",
@@ -6707,7 +9295,12 @@
       ],
       "description": "An adversary can leverage a computer's peripheral devices (e.g., microphones and webcams) or applications (e.g., voice and video call services) to capture audio recordings for the purpose of…",
       "url": "https://attack.mitre.org/techniques/T1123",
-      "is_subtechnique": false
+      "is_subtechnique": false,
+      "platforms": [
+        "Linux",
+        "macOS",
+        "Windows"
+      ]
     },
     {
       "id": "T1125",
@@ -6718,7 +9311,12 @@
       ],
       "description": "An adversary can leverage a computer's peripheral devices (e.g., integrated cameras or webcams) or applications (e.g., video call services) to capture video recordings for the purpose of gathering…",
       "url": "https://attack.mitre.org/techniques/T1125",
-      "is_subtechnique": false
+      "is_subtechnique": false,
+      "platforms": [
+        "Linux",
+        "macOS",
+        "Windows"
+      ]
     },
     {
       "id": "T1185",
@@ -6729,7 +9327,10 @@
       ],
       "description": "Adversaries may take advantage of security vulnerabilities and inherent functionality in browser software to change content, modify user-behaviors, and intercept information as part of various…",
       "url": "https://attack.mitre.org/techniques/T1185",
-      "is_subtechnique": false
+      "is_subtechnique": false,
+      "platforms": [
+        "Windows"
+      ]
     },
     {
       "id": "T1213",
@@ -6740,7 +9341,15 @@
       ],
       "description": "Adversaries may leverage information repositories to mine valuable information. Information repositories are tools that allow for storage of information, typically to facilitate collaboration or…",
       "url": "https://attack.mitre.org/techniques/T1213",
-      "is_subtechnique": false
+      "is_subtechnique": false,
+      "platforms": [
+        "Linux",
+        "Windows",
+        "macOS",
+        "SaaS",
+        "IaaS",
+        "Office Suite"
+      ]
     },
     {
       "id": "T1213.001",
@@ -6751,7 +9360,10 @@
       ],
       "description": "Adversaries may leverage Confluence repositories to mine valuable information. Often found in development environments alongside Atlassian JIRA, Confluence is generally used to store…",
       "url": "https://attack.mitre.org/techniques/T1213/001",
-      "is_subtechnique": true
+      "is_subtechnique": true,
+      "platforms": [
+        "SaaS"
+      ]
     },
     {
       "id": "T1213.002",
@@ -6762,7 +9374,11 @@
       ],
       "description": "Adversaries may leverage the SharePoint repository as a source to mine valuable information. SharePoint will often contain useful information for an adversary to learn about the structure and…",
       "url": "https://attack.mitre.org/techniques/T1213/002",
-      "is_subtechnique": true
+      "is_subtechnique": true,
+      "platforms": [
+        "Office Suite",
+        "Windows"
+      ]
     },
     {
       "id": "T1213.003",
@@ -6773,7 +9389,10 @@
       ],
       "description": "Adversaries may leverage code repositories to collect valuable information. Code repositories are tools/services that store source code and automate software builds. They may be hosted internally or…",
       "url": "https://attack.mitre.org/techniques/T1213/003",
-      "is_subtechnique": true
+      "is_subtechnique": true,
+      "platforms": [
+        "SaaS"
+      ]
     },
     {
       "id": "T1213.004",
@@ -6784,7 +9403,10 @@
       ],
       "description": "Adversaries may leverage Customer Relationship Management (CRM) software to mine valuable information. CRM software is used to assist organizations in tracking and managing customer interactions, as…",
       "url": "https://attack.mitre.org/techniques/T1213/004",
-      "is_subtechnique": true
+      "is_subtechnique": true,
+      "platforms": [
+        "SaaS"
+      ]
     },
     {
       "id": "T1213.005",
@@ -6795,7 +9417,11 @@
       ],
       "description": "Adversaries may leverage chat and messaging applications, such as Microsoft Teams, Google Chat, and Slack, to mine valuable information.  \n\nThe following is a brief list of example information that…",
       "url": "https://attack.mitre.org/techniques/T1213/005",
-      "is_subtechnique": true
+      "is_subtechnique": true,
+      "platforms": [
+        "Office Suite",
+        "SaaS"
+      ]
     },
     {
       "id": "T1213.006",
@@ -6806,7 +9432,14 @@
       ],
       "description": "Adversaries may leverage databases to mine valuable information. These databases may be hosted on-premises or in the cloud (both in platform-as-a-service and software-as-a-service environments).…",
       "url": "https://attack.mitre.org/techniques/T1213/006",
-      "is_subtechnique": true
+      "is_subtechnique": true,
+      "platforms": [
+        "IaaS",
+        "Linux",
+        "macOS",
+        "SaaS",
+        "Windows"
+      ]
     },
     {
       "id": "T1530",
@@ -6817,7 +9450,12 @@
       ],
       "description": "Adversaries may access data from cloud storage.\n\nMany IaaS providers offer solutions for online data object storage such as Amazon S3, Azure Storage, and Google Cloud Storage. Similarly, SaaS…",
       "url": "https://attack.mitre.org/techniques/T1530",
-      "is_subtechnique": false
+      "is_subtechnique": false,
+      "platforms": [
+        "IaaS",
+        "Office Suite",
+        "SaaS"
+      ]
     },
     {
       "id": "T1560",
@@ -6828,7 +9466,12 @@
       ],
       "description": "An adversary may compress and/or encrypt data that is collected prior to exfiltration. Compressing the data can help to obfuscate the collected data and minimize the amount of data sent over the…",
       "url": "https://attack.mitre.org/techniques/T1560",
-      "is_subtechnique": false
+      "is_subtechnique": false,
+      "platforms": [
+        "Linux",
+        "macOS",
+        "Windows"
+      ]
     },
     {
       "id": "T1560.001",
@@ -6839,7 +9482,12 @@
       ],
       "description": "Adversaries may use utilities to compress and/or encrypt collected data prior to exfiltration. Many utilities include functionalities to compress, encrypt, or otherwise package data into a format…",
       "url": "https://attack.mitre.org/techniques/T1560/001",
-      "is_subtechnique": true
+      "is_subtechnique": true,
+      "platforms": [
+        "Linux",
+        "macOS",
+        "Windows"
+      ]
     },
     {
       "id": "T1560.002",
@@ -6850,7 +9498,12 @@
       ],
       "description": "An adversary may compress or encrypt data that is collected prior to exfiltration using 3rd party libraries. Many libraries exist that can archive data, including…",
       "url": "https://attack.mitre.org/techniques/T1560/002",
-      "is_subtechnique": true
+      "is_subtechnique": true,
+      "platforms": [
+        "Linux",
+        "macOS",
+        "Windows"
+      ]
     },
     {
       "id": "T1560.003",
@@ -6861,7 +9514,12 @@
       ],
       "description": "An adversary may compress or encrypt data that is collected prior to exfiltration using a custom method. Adversaries may choose to use custom archival methods, such as encryption with XOR or stream…",
       "url": "https://attack.mitre.org/techniques/T1560/003",
-      "is_subtechnique": true
+      "is_subtechnique": true,
+      "platforms": [
+        "Linux",
+        "macOS",
+        "Windows"
+      ]
     },
     {
       "id": "T1602",
@@ -6872,7 +9530,10 @@
       ],
       "description": "Adversaries may collect data related to managed devices from configuration repositories. Configuration repositories are used by management systems in order to configure, manage, and control data on…",
       "url": "https://attack.mitre.org/techniques/T1602",
-      "is_subtechnique": false
+      "is_subtechnique": false,
+      "platforms": [
+        "Network Devices"
+      ]
     },
     {
       "id": "T1602.001",
@@ -6883,7 +9544,10 @@
       ],
       "description": "Adversaries may target the Management Information Base (MIB) to collect and/or mine valuable information in a network managed using Simple Network Management Protocol (SNMP).\n\nThe MIB is a…",
       "url": "https://attack.mitre.org/techniques/T1602/001",
-      "is_subtechnique": true
+      "is_subtechnique": true,
+      "platforms": [
+        "Network Devices"
+      ]
     },
     {
       "id": "T1602.002",
@@ -6894,7 +9558,10 @@
       ],
       "description": "Adversaries may access network configuration files to collect sensitive data about the device and the network. The network configuration is a file containing parameters that determine the operation…",
       "url": "https://attack.mitre.org/techniques/T1602/002",
-      "is_subtechnique": true
+      "is_subtechnique": true,
+      "platforms": [
+        "Network Devices"
+      ]
     },
     {
       "id": "T1001",
@@ -6905,7 +9572,13 @@
       ],
       "description": "Adversaries may obfuscate command and control traffic to make it more difficult to detect.(Citation: Bitdefender FunnyDream Campaign November 2020) Command and control (C2) communications are hidden…",
       "url": "https://attack.mitre.org/techniques/T1001",
-      "is_subtechnique": false
+      "is_subtechnique": false,
+      "platforms": [
+        "ESXi",
+        "Linux",
+        "macOS",
+        "Windows"
+      ]
     },
     {
       "id": "T1001.001",
@@ -6916,7 +9589,13 @@
       ],
       "description": "Adversaries may add junk data to protocols used for command and control to make detection more difficult.(Citation: FireEye SUNBURST Backdoor December 2020) By adding random or meaningless data to…",
       "url": "https://attack.mitre.org/techniques/T1001/001",
-      "is_subtechnique": true
+      "is_subtechnique": true,
+      "platforms": [
+        "ESXi",
+        "Linux",
+        "macOS",
+        "Windows"
+      ]
     },
     {
       "id": "T1001.002",
@@ -6927,7 +9606,13 @@
       ],
       "description": "Adversaries may use steganographic techniques to hide command and control traffic to make detection efforts more difficult. Steganographic techniques can be used to hide data in digital messages that…",
       "url": "https://attack.mitre.org/techniques/T1001/002",
-      "is_subtechnique": true
+      "is_subtechnique": true,
+      "platforms": [
+        "Linux",
+        "macOS",
+        "Windows",
+        "ESXi"
+      ]
     },
     {
       "id": "T1001.003",
@@ -6938,7 +9623,13 @@
       ],
       "description": "Adversaries may impersonate legitimate protocols or web service traffic to disguise command and control activity and thwart analysis efforts. By impersonating legitimate protocols or web services,…",
       "url": "https://attack.mitre.org/techniques/T1001/003",
-      "is_subtechnique": true
+      "is_subtechnique": true,
+      "platforms": [
+        "ESXi",
+        "Linux",
+        "macOS",
+        "Windows"
+      ]
     },
     {
       "id": "T1008",
@@ -6949,7 +9640,13 @@
       ],
       "description": "Adversaries may use fallback or alternate communication channels if the primary channel is compromised or inaccessible in order to maintain reliable command and control and to avoid data transfer…",
       "url": "https://attack.mitre.org/techniques/T1008",
-      "is_subtechnique": false
+      "is_subtechnique": false,
+      "platforms": [
+        "ESXi",
+        "Linux",
+        "macOS",
+        "Windows"
+      ]
     },
     {
       "id": "T1071",
@@ -6960,7 +9657,14 @@
       ],
       "description": "Adversaries may communicate using OSI application layer protocols to avoid detection/network filtering by blending in with existing traffic. Commands to the remote system, and often the results of…",
       "url": "https://attack.mitre.org/techniques/T1071",
-      "is_subtechnique": false
+      "is_subtechnique": false,
+      "platforms": [
+        "Linux",
+        "macOS",
+        "Windows",
+        "Network Devices",
+        "ESXi"
+      ]
     },
     {
       "id": "T1071.001",
@@ -6971,7 +9675,14 @@
       ],
       "description": "Adversaries may communicate using application layer protocols associated with web traffic to avoid detection/network filtering by blending in with existing traffic. Commands to the remote system, and…",
       "url": "https://attack.mitre.org/techniques/T1071/001",
-      "is_subtechnique": true
+      "is_subtechnique": true,
+      "platforms": [
+        "ESXi",
+        "Linux",
+        "macOS",
+        "Network Devices",
+        "Windows"
+      ]
     },
     {
       "id": "T1071.002",
@@ -6982,7 +9693,14 @@
       ],
       "description": "Adversaries may communicate using application layer protocols associated with transferring files to avoid detection/network filtering by blending in with existing traffic. Commands to the remote…",
       "url": "https://attack.mitre.org/techniques/T1071/002",
-      "is_subtechnique": true
+      "is_subtechnique": true,
+      "platforms": [
+        "ESXi",
+        "Linux",
+        "macOS",
+        "Network Devices",
+        "Windows"
+      ]
     },
     {
       "id": "T1071.003",
@@ -6993,7 +9711,13 @@
       ],
       "description": "Adversaries may communicate using application layer protocols associated with electronic mail delivery to avoid detection/network filtering by blending in with existing traffic. Commands to the…",
       "url": "https://attack.mitre.org/techniques/T1071/003",
-      "is_subtechnique": true
+      "is_subtechnique": true,
+      "platforms": [
+        "Linux",
+        "macOS",
+        "Network Devices",
+        "Windows"
+      ]
     },
     {
       "id": "T1071.004",
@@ -7004,7 +9728,14 @@
       ],
       "description": "Adversaries may communicate using the Domain Name System (DNS) application layer protocol to avoid detection/network filtering by blending in with existing traffic. Commands to the remote system, and…",
       "url": "https://attack.mitre.org/techniques/T1071/004",
-      "is_subtechnique": true
+      "is_subtechnique": true,
+      "platforms": [
+        "ESXi",
+        "Linux",
+        "macOS",
+        "Network Devices",
+        "Windows"
+      ]
     },
     {
       "id": "T1071.005",
@@ -7015,7 +9746,13 @@
       ],
       "description": "Adversaries may communicate using publish/subscribe (pub/sub) application layer protocols to avoid detection/network filtering by blending in with existing traffic. Commands to the remote system, and…",
       "url": "https://attack.mitre.org/techniques/T1071/005",
-      "is_subtechnique": true
+      "is_subtechnique": true,
+      "platforms": [
+        "macOS",
+        "Linux",
+        "Windows",
+        "Network Devices"
+      ]
     },
     {
       "id": "T1090",
@@ -7026,7 +9763,14 @@
       ],
       "description": "Adversaries may use a connection proxy to direct network traffic between systems or act as an intermediary for network communications to a command and control server to avoid direct connections to…",
       "url": "https://attack.mitre.org/techniques/T1090",
-      "is_subtechnique": false
+      "is_subtechnique": false,
+      "platforms": [
+        "ESXi",
+        "Linux",
+        "macOS",
+        "Network Devices",
+        "Windows"
+      ]
     },
     {
       "id": "T1090.001",
@@ -7037,7 +9781,14 @@
       ],
       "description": "Adversaries may use an internal proxy to direct command and control traffic between two or more systems in a compromised environment. Many tools exist that enable traffic redirection through proxies…",
       "url": "https://attack.mitre.org/techniques/T1090/001",
-      "is_subtechnique": true
+      "is_subtechnique": true,
+      "platforms": [
+        "ESXi",
+        "Linux",
+        "macOS",
+        "Network Devices",
+        "Windows"
+      ]
     },
     {
       "id": "T1090.002",
@@ -7048,7 +9799,14 @@
       ],
       "description": "Adversaries may use an external proxy to act as an intermediary for network communications to a command and control server to avoid direct connections to their infrastructure. Many tools exist that…",
       "url": "https://attack.mitre.org/techniques/T1090/002",
-      "is_subtechnique": true
+      "is_subtechnique": true,
+      "platforms": [
+        "ESXi",
+        "Linux",
+        "macOS",
+        "Network Devices",
+        "Windows"
+      ]
     },
     {
       "id": "T1090.003",
@@ -7059,7 +9817,14 @@
       ],
       "description": "Adversaries may chain together multiple proxies to disguise the source of malicious traffic. Typically, a defender will be able to identify the last proxy traffic traversed before it enters their…",
       "url": "https://attack.mitre.org/techniques/T1090/003",
-      "is_subtechnique": true
+      "is_subtechnique": true,
+      "platforms": [
+        "ESXi",
+        "Linux",
+        "macOS",
+        "Network Devices",
+        "Windows"
+      ]
     },
     {
       "id": "T1090.004",
@@ -7070,7 +9835,13 @@
       ],
       "description": "Adversaries may take advantage of routing schemes in Content Delivery Networks (CDNs) and other services which host multiple domains to obfuscate the intended destination of HTTPS traffic or traffic…",
       "url": "https://attack.mitre.org/techniques/T1090/004",
-      "is_subtechnique": true
+      "is_subtechnique": true,
+      "platforms": [
+        "Linux",
+        "macOS",
+        "Windows",
+        "ESXi"
+      ]
     },
     {
       "id": "T1092",
@@ -7081,7 +9852,12 @@
       ],
       "description": "Adversaries can perform command and control between compromised hosts on potentially disconnected networks using removable media to transfer commands from system to system.(Citation: ESET Sednit…",
       "url": "https://attack.mitre.org/techniques/T1092",
-      "is_subtechnique": false
+      "is_subtechnique": false,
+      "platforms": [
+        "Linux",
+        "macOS",
+        "Windows"
+      ]
     },
     {
       "id": "T1095",
@@ -7092,7 +9868,14 @@
       ],
       "description": "Adversaries may use an OSI non-application layer protocol for communication between host and C2 server or among infected hosts within a network. The list of possible protocols is extensive.(Citation:…",
       "url": "https://attack.mitre.org/techniques/T1095",
-      "is_subtechnique": false
+      "is_subtechnique": false,
+      "platforms": [
+        "ESXi",
+        "Linux",
+        "macOS",
+        "Network Devices",
+        "Windows"
+      ]
     },
     {
       "id": "T1102",
@@ -7103,7 +9886,13 @@
       ],
       "description": "Adversaries may use an existing, legitimate external Web service as a means for relaying data to/from a compromised system. Popular websites, cloud services, and social media acting as a mechanism…",
       "url": "https://attack.mitre.org/techniques/T1102",
-      "is_subtechnique": false
+      "is_subtechnique": false,
+      "platforms": [
+        "ESXi",
+        "Linux",
+        "macOS",
+        "Windows"
+      ]
     },
     {
       "id": "T1102.001",
@@ -7114,7 +9903,13 @@
       ],
       "description": "Adversaries may use an existing, legitimate external Web service to host information that points to additional command and control (C2) infrastructure. Adversaries may post content, known as a dead…",
       "url": "https://attack.mitre.org/techniques/T1102/001",
-      "is_subtechnique": true
+      "is_subtechnique": true,
+      "platforms": [
+        "ESXi",
+        "Linux",
+        "macOS",
+        "Windows"
+      ]
     },
     {
       "id": "T1102.002",
@@ -7125,7 +9920,13 @@
       ],
       "description": "Adversaries may use an existing, legitimate external Web service as a means for sending commands to and receiving output from a compromised system over the Web service channel. Compromised systems…",
       "url": "https://attack.mitre.org/techniques/T1102/002",
-      "is_subtechnique": true
+      "is_subtechnique": true,
+      "platforms": [
+        "ESXi",
+        "Linux",
+        "macOS",
+        "Windows"
+      ]
     },
     {
       "id": "T1102.003",
@@ -7136,7 +9937,13 @@
       ],
       "description": "Adversaries may use an existing, legitimate external Web service as a means for sending commands to a compromised system without receiving return output over the Web service channel. Compromised…",
       "url": "https://attack.mitre.org/techniques/T1102/003",
-      "is_subtechnique": true
+      "is_subtechnique": true,
+      "platforms": [
+        "Linux",
+        "macOS",
+        "Windows",
+        "ESXi"
+      ]
     },
     {
       "id": "T1104",
@@ -7147,7 +9954,13 @@
       ],
       "description": "Adversaries may create multiple stages for command and control that are employed under different conditions or for certain functions. Use of multiple stages may obfuscate the command and control…",
       "url": "https://attack.mitre.org/techniques/T1104",
-      "is_subtechnique": false
+      "is_subtechnique": false,
+      "platforms": [
+        "Linux",
+        "macOS",
+        "Windows",
+        "ESXi"
+      ]
     },
     {
       "id": "T1105",
@@ -7158,7 +9971,14 @@
       ],
       "description": "Adversaries may transfer tools or other files from an external system into a compromised environment. Tools or files may be copied from an external adversary-controlled system to the victim network…",
       "url": "https://attack.mitre.org/techniques/T1105",
-      "is_subtechnique": false
+      "is_subtechnique": false,
+      "platforms": [
+        "ESXi",
+        "Linux",
+        "macOS",
+        "Network Devices",
+        "Windows"
+      ]
     },
     {
       "id": "T1132",
@@ -7169,7 +9989,13 @@
       ],
       "description": "Adversaries may encode data to make the content of command and control traffic more difficult to detect. Command and control (C2) information can be encoded using a standard data encoding system. Use…",
       "url": "https://attack.mitre.org/techniques/T1132",
-      "is_subtechnique": false
+      "is_subtechnique": false,
+      "platforms": [
+        "ESXi",
+        "Linux",
+        "macOS",
+        "Windows"
+      ]
     },
     {
       "id": "T1132.001",
@@ -7180,7 +10006,13 @@
       ],
       "description": "Adversaries may encode data with a standard data encoding system to make the content of command and control traffic more difficult to detect. Command and control (C2) information can be encoded using…",
       "url": "https://attack.mitre.org/techniques/T1132/001",
-      "is_subtechnique": true
+      "is_subtechnique": true,
+      "platforms": [
+        "ESXi",
+        "Linux",
+        "macOS",
+        "Windows"
+      ]
     },
     {
       "id": "T1132.002",
@@ -7191,7 +10023,13 @@
       ],
       "description": "Adversaries may encode data with a non-standard data encoding system to make the content of command and control traffic more difficult to detect. Command and control (C2) information can be encoded…",
       "url": "https://attack.mitre.org/techniques/T1132/002",
-      "is_subtechnique": true
+      "is_subtechnique": true,
+      "platforms": [
+        "ESXi",
+        "Linux",
+        "macOS",
+        "Windows"
+      ]
     },
     {
       "id": "T1219",
@@ -7202,7 +10040,12 @@
       ],
       "description": "An adversary may use legitimate remote access tools to establish an interactive command and control channel within a network. Remote access tools create a session between two trusted hosts through a…",
       "url": "https://attack.mitre.org/techniques/T1219",
-      "is_subtechnique": false
+      "is_subtechnique": false,
+      "platforms": [
+        "Linux",
+        "macOS",
+        "Windows"
+      ]
     },
     {
       "id": "T1219.001",
@@ -7213,7 +10056,12 @@
       ],
       "description": "Adversaries may abuse Integrated Development Environment (IDE) software with remote development features to establish an interactive command and control channel on target systems within a network.…",
       "url": "https://attack.mitre.org/techniques/T1219/001",
-      "is_subtechnique": true
+      "is_subtechnique": true,
+      "platforms": [
+        "Linux",
+        "macOS",
+        "Windows"
+      ]
     },
     {
       "id": "T1219.002",
@@ -7224,7 +10072,12 @@
       ],
       "description": "An adversary may use legitimate desktop support software to establish an interactive command and control channel to target systems within networks. Desktop support software provides a graphical…",
       "url": "https://attack.mitre.org/techniques/T1219/002",
-      "is_subtechnique": true
+      "is_subtechnique": true,
+      "platforms": [
+        "Linux",
+        "macOS",
+        "Windows"
+      ]
     },
     {
       "id": "T1219.003",
@@ -7235,7 +10088,12 @@
       ],
       "description": "An adversary may use legitimate remote access hardware to establish an interactive command and control channel to target systems within networks. These services, including IP-based keyboard, video,…",
       "url": "https://attack.mitre.org/techniques/T1219/003",
-      "is_subtechnique": true
+      "is_subtechnique": true,
+      "platforms": [
+        "Linux",
+        "macOS",
+        "Windows"
+      ]
     },
     {
       "id": "T1568",
@@ -7246,7 +10104,13 @@
       ],
       "description": "Adversaries may dynamically establish connections to command and control infrastructure to evade common detections and remediations. This may be achieved by using malware that shares a common…",
       "url": "https://attack.mitre.org/techniques/T1568",
-      "is_subtechnique": false
+      "is_subtechnique": false,
+      "platforms": [
+        "ESXi",
+        "Linux",
+        "macOS",
+        "Windows"
+      ]
     },
     {
       "id": "T1568.001",
@@ -7257,7 +10121,13 @@
       ],
       "description": "Adversaries may use Fast Flux DNS to hide a command and control channel behind an array of rapidly changing IP addresses linked to a single domain resolution. This technique uses a fully qualified…",
       "url": "https://attack.mitre.org/techniques/T1568/001",
-      "is_subtechnique": true
+      "is_subtechnique": true,
+      "platforms": [
+        "Linux",
+        "macOS",
+        "Windows",
+        "ESXi"
+      ]
     },
     {
       "id": "T1568.002",
@@ -7268,7 +10138,13 @@
       ],
       "description": "Adversaries may make use of Domain Generation Algorithms (DGAs) to dynamically identify a destination domain for command and control traffic rather than relying on a list of static IP addresses or…",
       "url": "https://attack.mitre.org/techniques/T1568/002",
-      "is_subtechnique": true
+      "is_subtechnique": true,
+      "platforms": [
+        "ESXi",
+        "Linux",
+        "macOS",
+        "Windows"
+      ]
     },
     {
       "id": "T1568.003",
@@ -7279,7 +10155,13 @@
       ],
       "description": "Adversaries may perform calculations on addresses returned in DNS results to determine which port and IP address to use for command and control, rather than relying on a predetermined port number or…",
       "url": "https://attack.mitre.org/techniques/T1568/003",
-      "is_subtechnique": true
+      "is_subtechnique": true,
+      "platforms": [
+        "ESXi",
+        "Linux",
+        "macOS",
+        "Windows"
+      ]
     },
     {
       "id": "T1571",
@@ -7290,7 +10172,13 @@
       ],
       "description": "Adversaries may communicate using a protocol and port pairing that are typically not associated. For example, HTTPS over port 8088(Citation: Symantec Elfin Mar 2019) or port 587(Citation: Fortinet…",
       "url": "https://attack.mitre.org/techniques/T1571",
-      "is_subtechnique": false
+      "is_subtechnique": false,
+      "platforms": [
+        "ESXi",
+        "Linux",
+        "macOS",
+        "Windows"
+      ]
     },
     {
       "id": "T1572",
@@ -7301,7 +10189,13 @@
       ],
       "description": "Adversaries may tunnel network communications to and from a victim system within a separate protocol to avoid detection/network filtering and/or enable access to otherwise unreachable systems.…",
       "url": "https://attack.mitre.org/techniques/T1572",
-      "is_subtechnique": false
+      "is_subtechnique": false,
+      "platforms": [
+        "ESXi",
+        "Linux",
+        "macOS",
+        "Windows"
+      ]
     },
     {
       "id": "T1573",
@@ -7312,7 +10206,14 @@
       ],
       "description": "Adversaries may employ an encryption algorithm to conceal command and control traffic rather than relying on any inherent protections provided by a communication protocol. Despite the use of a secure…",
       "url": "https://attack.mitre.org/techniques/T1573",
-      "is_subtechnique": false
+      "is_subtechnique": false,
+      "platforms": [
+        "ESXi",
+        "Linux",
+        "macOS",
+        "Network Devices",
+        "Windows"
+      ]
     },
     {
       "id": "T1573.001",
@@ -7323,7 +10224,14 @@
       ],
       "description": "Adversaries may employ a known symmetric encryption algorithm to conceal command and control traffic rather than relying on any inherent protections provided by a communication protocol. Symmetric…",
       "url": "https://attack.mitre.org/techniques/T1573/001",
-      "is_subtechnique": true
+      "is_subtechnique": true,
+      "platforms": [
+        "ESXi",
+        "Linux",
+        "macOS",
+        "Network Devices",
+        "Windows"
+      ]
     },
     {
       "id": "T1573.002",
@@ -7334,7 +10242,14 @@
       ],
       "description": "Adversaries may employ a known asymmetric encryption algorithm to conceal command and control traffic rather than relying on any inherent protections provided by a communication protocol. Asymmetric…",
       "url": "https://attack.mitre.org/techniques/T1573/002",
-      "is_subtechnique": true
+      "is_subtechnique": true,
+      "platforms": [
+        "ESXi",
+        "Linux",
+        "macOS",
+        "Network Devices",
+        "Windows"
+      ]
     },
     {
       "id": "T1665",
@@ -7345,7 +10260,14 @@
       ],
       "description": "Adversaries may manipulate network traffic in order to hide and evade detection of their C2 infrastructure. This can be accomplished by identifying and filtering traffic from defensive…",
       "url": "https://attack.mitre.org/techniques/T1665",
-      "is_subtechnique": false
+      "is_subtechnique": false,
+      "platforms": [
+        "ESXi",
+        "Linux",
+        "macOS",
+        "Network Devices",
+        "Windows"
+      ]
     },
     {
       "id": "T1011",
@@ -7356,7 +10278,12 @@
       ],
       "description": "Adversaries may attempt to exfiltrate data over a different network medium than the command and control channel. If the command and control network is a wired Internet connection, the exfiltration…",
       "url": "https://attack.mitre.org/techniques/T1011",
-      "is_subtechnique": false
+      "is_subtechnique": false,
+      "platforms": [
+        "Linux",
+        "macOS",
+        "Windows"
+      ]
     },
     {
       "id": "T1011.001",
@@ -7367,7 +10294,12 @@
       ],
       "description": "Adversaries may attempt to exfiltrate data over Bluetooth rather than the command and control channel. If the command and control network is a wired Internet connection, an adversary may opt to…",
       "url": "https://attack.mitre.org/techniques/T1011/001",
-      "is_subtechnique": true
+      "is_subtechnique": true,
+      "platforms": [
+        "Linux",
+        "macOS",
+        "Windows"
+      ]
     },
     {
       "id": "T1020",
@@ -7378,7 +10310,13 @@
       ],
       "description": "Adversaries may exfiltrate data, such as sensitive documents, through the use of automated processing after being gathered during Collection.(Citation: ESET Gamaredon June 2020) \n\nWhen automated…",
       "url": "https://attack.mitre.org/techniques/T1020",
-      "is_subtechnique": false
+      "is_subtechnique": false,
+      "platforms": [
+        "Linux",
+        "macOS",
+        "Network Devices",
+        "Windows"
+      ]
     },
     {
       "id": "T1020.001",
@@ -7389,7 +10327,11 @@
       ],
       "description": "Adversaries may leverage traffic mirroring in order to automate data exfiltration over compromised infrastructure. Traffic mirroring is a native feature for some devices, often used for network…",
       "url": "https://attack.mitre.org/techniques/T1020/001",
-      "is_subtechnique": true
+      "is_subtechnique": true,
+      "platforms": [
+        "Network Devices",
+        "IaaS"
+      ]
     },
     {
       "id": "T1029",
@@ -7400,7 +10342,12 @@
       ],
       "description": "Adversaries may schedule data exfiltration to be performed only at certain times of day or at certain intervals. This could be done to blend traffic patterns with normal activity or…",
       "url": "https://attack.mitre.org/techniques/T1029",
-      "is_subtechnique": false
+      "is_subtechnique": false,
+      "platforms": [
+        "Linux",
+        "macOS",
+        "Windows"
+      ]
     },
     {
       "id": "T1030",
@@ -7411,7 +10358,13 @@
       ],
       "description": "An adversary may exfiltrate data in fixed size chunks instead of whole files or limit packet sizes below certain thresholds. This approach may be used to avoid triggering network data transfer…",
       "url": "https://attack.mitre.org/techniques/T1030",
-      "is_subtechnique": false
+      "is_subtechnique": false,
+      "platforms": [
+        "Linux",
+        "macOS",
+        "Windows",
+        "ESXi"
+      ]
     },
     {
       "id": "T1041",
@@ -7422,7 +10375,13 @@
       ],
       "description": "Adversaries may steal data by exfiltrating it over an existing command and control channel. Stolen data is encoded into the normal communications channel using the same protocol as command and…",
       "url": "https://attack.mitre.org/techniques/T1041",
-      "is_subtechnique": false
+      "is_subtechnique": false,
+      "platforms": [
+        "ESXi",
+        "Linux",
+        "macOS",
+        "Windows"
+      ]
     },
     {
       "id": "T1048",
@@ -7433,7 +10392,17 @@
       ],
       "description": "Adversaries may steal data by exfiltrating it over a different protocol than that of the existing command and control channel. The data may also be sent to an alternate network location from the main…",
       "url": "https://attack.mitre.org/techniques/T1048",
-      "is_subtechnique": false
+      "is_subtechnique": false,
+      "platforms": [
+        "ESXi",
+        "IaaS",
+        "Linux",
+        "macOS",
+        "Network Devices",
+        "Office Suite",
+        "SaaS",
+        "Windows"
+      ]
     },
     {
       "id": "T1048.001",
@@ -7444,7 +10413,13 @@
       ],
       "description": "Adversaries may steal data by exfiltrating it over a symmetrically encrypted network protocol other than that of the existing command and control channel. The data may also be sent to an alternate…",
       "url": "https://attack.mitre.org/techniques/T1048/001",
-      "is_subtechnique": true
+      "is_subtechnique": true,
+      "platforms": [
+        "Linux",
+        "macOS",
+        "Windows",
+        "ESXi"
+      ]
     },
     {
       "id": "T1048.002",
@@ -7455,7 +10430,13 @@
       ],
       "description": "Adversaries may steal data by exfiltrating it over an asymmetrically encrypted network protocol other than that of the existing command and control channel. The data may also be sent to an alternate…",
       "url": "https://attack.mitre.org/techniques/T1048/002",
-      "is_subtechnique": true
+      "is_subtechnique": true,
+      "platforms": [
+        "ESXi",
+        "Linux",
+        "macOS",
+        "Windows"
+      ]
     },
     {
       "id": "T1048.003",
@@ -7466,7 +10447,14 @@
       ],
       "description": "Adversaries may steal data by exfiltrating it over an un-encrypted network protocol other than that of the existing command and control channel. The data may also be sent to an alternate network…",
       "url": "https://attack.mitre.org/techniques/T1048/003",
-      "is_subtechnique": true
+      "is_subtechnique": true,
+      "platforms": [
+        "ESXi",
+        "Linux",
+        "macOS",
+        "Network Devices",
+        "Windows"
+      ]
     },
     {
       "id": "T1052",
@@ -7477,7 +10465,12 @@
       ],
       "description": "Adversaries may attempt to exfiltrate data via a physical medium, such as a removable drive. In certain circumstances, such as an air-gapped network compromise, exfiltration could occur via a…",
       "url": "https://attack.mitre.org/techniques/T1052",
-      "is_subtechnique": false
+      "is_subtechnique": false,
+      "platforms": [
+        "Linux",
+        "macOS",
+        "Windows"
+      ]
     },
     {
       "id": "T1052.001",
@@ -7488,7 +10481,12 @@
       ],
       "description": "Adversaries may attempt to exfiltrate data over a USB connected physical device. In certain circumstances, such as an air-gapped network compromise, exfiltration could occur via a USB device…",
       "url": "https://attack.mitre.org/techniques/T1052/001",
-      "is_subtechnique": true
+      "is_subtechnique": true,
+      "platforms": [
+        "Linux",
+        "Windows",
+        "macOS"
+      ]
     },
     {
       "id": "T1537",
@@ -7499,7 +10497,12 @@
       ],
       "description": "Adversaries may exfiltrate data by transferring the data, including through sharing/syncing and creating backups of cloud environments, to another cloud account they control on the same service.\n\nA…",
       "url": "https://attack.mitre.org/techniques/T1537",
-      "is_subtechnique": false
+      "is_subtechnique": false,
+      "platforms": [
+        "IaaS",
+        "Office Suite",
+        "SaaS"
+      ]
     },
     {
       "id": "T1567",
@@ -7510,7 +10513,15 @@
       ],
       "description": "Adversaries may use an existing, legitimate external Web service to exfiltrate data rather than their primary command and control channel. Popular Web services acting as an exfiltration mechanism may…",
       "url": "https://attack.mitre.org/techniques/T1567",
-      "is_subtechnique": false
+      "is_subtechnique": false,
+      "platforms": [
+        "ESXi",
+        "Linux",
+        "macOS",
+        "Office Suite",
+        "SaaS",
+        "Windows"
+      ]
     },
     {
       "id": "T1567.001",
@@ -7521,7 +10532,13 @@
       ],
       "description": "Adversaries may exfiltrate data to a code repository rather than over their primary command and control channel. Code repositories are often accessible via an API (ex: https://api.github.com). Access…",
       "url": "https://attack.mitre.org/techniques/T1567/001",
-      "is_subtechnique": true
+      "is_subtechnique": true,
+      "platforms": [
+        "ESXi",
+        "Linux",
+        "macOS",
+        "Windows"
+      ]
     },
     {
       "id": "T1567.002",
@@ -7532,7 +10549,13 @@
       ],
       "description": "Adversaries may exfiltrate data to a cloud storage service rather than over their primary command and control channel. Cloud storage services allow for the storage, edit, and retrieval of data from a…",
       "url": "https://attack.mitre.org/techniques/T1567/002",
-      "is_subtechnique": true
+      "is_subtechnique": true,
+      "platforms": [
+        "ESXi",
+        "Linux",
+        "macOS",
+        "Windows"
+      ]
     },
     {
       "id": "T1567.003",
@@ -7543,7 +10566,13 @@
       ],
       "description": "Adversaries may exfiltrate data to text storage sites instead of their primary command and control channel. Text storage sites, such as <code>pastebin[.]com</code>, are commonly used by developers to…",
       "url": "https://attack.mitre.org/techniques/T1567/003",
-      "is_subtechnique": true
+      "is_subtechnique": true,
+      "platforms": [
+        "Linux",
+        "macOS",
+        "Windows",
+        "ESXi"
+      ]
     },
     {
       "id": "T1567.004",
@@ -7554,7 +10583,15 @@
       ],
       "description": "Adversaries may exfiltrate data to a webhook endpoint rather than over their primary command and control channel. Webhooks are simple mechanisms for allowing a server to push data over HTTP/S to a…",
       "url": "https://attack.mitre.org/techniques/T1567/004",
-      "is_subtechnique": true
+      "is_subtechnique": true,
+      "platforms": [
+        "ESXi",
+        "Linux",
+        "macOS",
+        "Office Suite",
+        "SaaS",
+        "Windows"
+      ]
     },
     {
       "id": "T1485",
@@ -7565,7 +10602,15 @@
       ],
       "description": "Adversaries may destroy data and files on specific systems or in large numbers on a network to interrupt availability to systems, services, and network resources. Data destruction is likely to render…",
       "url": "https://attack.mitre.org/techniques/T1485",
-      "is_subtechnique": false
+      "is_subtechnique": false,
+      "platforms": [
+        "Containers",
+        "ESXi",
+        "IaaS",
+        "Linux",
+        "macOS",
+        "Windows"
+      ]
     },
     {
       "id": "T1485.001",
@@ -7576,7 +10621,10 @@
       ],
       "description": "Adversaries may modify the lifecycle policies of a cloud storage bucket to destroy all objects stored within.  \n\nCloud storage buckets often allow users to set lifecycle policies to automate the…",
       "url": "https://attack.mitre.org/techniques/T1485/001",
-      "is_subtechnique": true
+      "is_subtechnique": true,
+      "platforms": [
+        "IaaS"
+      ]
     },
     {
       "id": "T1486",
@@ -7587,7 +10635,14 @@
       ],
       "description": "Adversaries may encrypt data on target systems or on large numbers of systems in a network to interrupt availability to system and network resources. They can attempt to render stored data…",
       "url": "https://attack.mitre.org/techniques/T1486",
-      "is_subtechnique": false
+      "is_subtechnique": false,
+      "platforms": [
+        "ESXi",
+        "IaaS",
+        "Linux",
+        "macOS",
+        "Windows"
+      ]
     },
     {
       "id": "T1489",
@@ -7598,7 +10653,14 @@
       ],
       "description": "Adversaries may stop or disable services on a system to render those services unavailable to legitimate users. Stopping critical services or processes can inhibit or stop response to an incident or…",
       "url": "https://attack.mitre.org/techniques/T1489",
-      "is_subtechnique": false
+      "is_subtechnique": false,
+      "platforms": [
+        "ESXi",
+        "IaaS",
+        "Linux",
+        "macOS",
+        "Windows"
+      ]
     },
     {
       "id": "T1490",
@@ -7609,7 +10671,16 @@
       ],
       "description": "Adversaries may delete or remove built-in data and turn off services designed to aid in the recovery of a corrupted system to prevent recovery.(Citation: Talos Olympic Destroyer 2018)(Citation:…",
       "url": "https://attack.mitre.org/techniques/T1490",
-      "is_subtechnique": false
+      "is_subtechnique": false,
+      "platforms": [
+        "Containers",
+        "ESXi",
+        "IaaS",
+        "Linux",
+        "macOS",
+        "Network Devices",
+        "Windows"
+      ]
     },
     {
       "id": "T1491",
@@ -7620,7 +10691,14 @@
       ],
       "description": "Adversaries may modify visual content available internally or externally to an enterprise network, thus affecting the integrity of the original content. Reasons for…",
       "url": "https://attack.mitre.org/techniques/T1491",
-      "is_subtechnique": false
+      "is_subtechnique": false,
+      "platforms": [
+        "Windows",
+        "IaaS",
+        "Linux",
+        "macOS",
+        "ESXi"
+      ]
     },
     {
       "id": "T1491.001",
@@ -7631,7 +10709,13 @@
       ],
       "description": "An adversary may deface systems internal to an organization in an attempt to intimidate or mislead users, thus discrediting the integrity of the systems. This may take the form of modifications to…",
       "url": "https://attack.mitre.org/techniques/T1491/001",
-      "is_subtechnique": true
+      "is_subtechnique": true,
+      "platforms": [
+        "ESXi",
+        "Linux",
+        "macOS",
+        "Windows"
+      ]
     },
     {
       "id": "T1491.002",
@@ -7642,7 +10726,13 @@
       ],
       "description": "An adversary may deface systems external to an organization in an attempt to deliver messaging, intimidate, or otherwise mislead an organization or users. [External…",
       "url": "https://attack.mitre.org/techniques/T1491/002",
-      "is_subtechnique": true
+      "is_subtechnique": true,
+      "platforms": [
+        "Windows",
+        "IaaS",
+        "Linux",
+        "macOS"
+      ]
     },
     {
       "id": "T1495",
@@ -7653,7 +10743,13 @@
       ],
       "description": "Adversaries may overwrite or corrupt the flash memory contents of system BIOS or other firmware in devices attached to a system in order to render them inoperable or unable to boot, thus denying the…",
       "url": "https://attack.mitre.org/techniques/T1495",
-      "is_subtechnique": false
+      "is_subtechnique": false,
+      "platforms": [
+        "Linux",
+        "macOS",
+        "Network Devices",
+        "Windows"
+      ]
     },
     {
       "id": "T1496",
@@ -7664,7 +10760,15 @@
       ],
       "description": "Adversaries may leverage the resources of co-opted systems to complete resource-intensive tasks, which may impact system and/or hosted service availability. \n\nResource hijacking may take a number of…",
       "url": "https://attack.mitre.org/techniques/T1496",
-      "is_subtechnique": false
+      "is_subtechnique": false,
+      "platforms": [
+        "Windows",
+        "IaaS",
+        "Linux",
+        "macOS",
+        "Containers",
+        "SaaS"
+      ]
     },
     {
       "id": "T1496.001",
@@ -7675,7 +10779,14 @@
       ],
       "description": "Adversaries may leverage the compute resources of co-opted systems to complete resource-intensive tasks, which may impact system and/or hosted service availability. \n\nOne common purpose for [Compute…",
       "url": "https://attack.mitre.org/techniques/T1496/001",
-      "is_subtechnique": true
+      "is_subtechnique": true,
+      "platforms": [
+        "Windows",
+        "IaaS",
+        "Linux",
+        "macOS",
+        "Containers"
+      ]
     },
     {
       "id": "T1496.002",
@@ -7686,7 +10797,14 @@
       ],
       "description": "Adversaries may leverage the network bandwidth resources of co-opted systems to complete resource-intensive tasks, which may impact system and/or hosted service availability. \n\nAdversaries may also…",
       "url": "https://attack.mitre.org/techniques/T1496/002",
-      "is_subtechnique": true
+      "is_subtechnique": true,
+      "platforms": [
+        "Linux",
+        "Windows",
+        "macOS",
+        "IaaS",
+        "Containers"
+      ]
     },
     {
       "id": "T1496.003",
@@ -7697,7 +10815,10 @@
       ],
       "description": "Adversaries may leverage messaging services for SMS pumping, which may impact system and/or hosted service availability.(Citation: Twilio SMS Pumping) SMS pumping is a type of telecommunications…",
       "url": "https://attack.mitre.org/techniques/T1496/003",
-      "is_subtechnique": true
+      "is_subtechnique": true,
+      "platforms": [
+        "SaaS"
+      ]
     },
     {
       "id": "T1496.004",
@@ -7708,7 +10829,10 @@
       ],
       "description": "Adversaries may leverage compromised software-as-a-service (SaaS) applications to complete resource-intensive tasks, which may impact hosted service availability. \n\nFor example, adversaries may…",
       "url": "https://attack.mitre.org/techniques/T1496/004",
-      "is_subtechnique": true
+      "is_subtechnique": true,
+      "platforms": [
+        "SaaS"
+      ]
     },
     {
       "id": "T1498",
@@ -7719,7 +10843,14 @@
       ],
       "description": "Adversaries may perform Network Denial of Service (DoS) attacks to degrade or block the availability of targeted resources to users. Network DoS can be performed by exhausting the network bandwidth…",
       "url": "https://attack.mitre.org/techniques/T1498",
-      "is_subtechnique": false
+      "is_subtechnique": false,
+      "platforms": [
+        "Windows",
+        "IaaS",
+        "Linux",
+        "macOS",
+        "Containers"
+      ]
     },
     {
       "id": "T1498.001",
@@ -7730,7 +10861,13 @@
       ],
       "description": "Adversaries may attempt to cause a denial of service (DoS) by directly sending a high-volume of network traffic to a target. This DoS attack may also reduce the availability and functionality of the…",
       "url": "https://attack.mitre.org/techniques/T1498/001",
-      "is_subtechnique": true
+      "is_subtechnique": true,
+      "platforms": [
+        "Windows",
+        "IaaS",
+        "Linux",
+        "macOS"
+      ]
     },
     {
       "id": "T1498.002",
@@ -7741,7 +10878,13 @@
       ],
       "description": "Adversaries may attempt to cause a denial of service (DoS) by reflecting a high-volume of network traffic to a target. This type of Network DoS takes advantage of a third-party server intermediary…",
       "url": "https://attack.mitre.org/techniques/T1498/002",
-      "is_subtechnique": true
+      "is_subtechnique": true,
+      "platforms": [
+        "Windows",
+        "IaaS",
+        "Linux",
+        "macOS"
+      ]
     },
     {
       "id": "T1499",
@@ -7752,7 +10895,14 @@
       ],
       "description": "Adversaries may perform Endpoint Denial of Service (DoS) attacks to degrade or block the availability of services to users. Endpoint DoS can be performed by exhausting the system resources those…",
       "url": "https://attack.mitre.org/techniques/T1499",
-      "is_subtechnique": false
+      "is_subtechnique": false,
+      "platforms": [
+        "Windows",
+        "Linux",
+        "macOS",
+        "Containers",
+        "IaaS"
+      ]
     },
     {
       "id": "T1499.001",
@@ -7763,7 +10913,12 @@
       ],
       "description": "Adversaries may launch a denial of service (DoS) attack targeting an endpoint's operating system (OS). A system's OS is responsible for managing the finite resources as well as preventing the entire…",
       "url": "https://attack.mitre.org/techniques/T1499/001",
-      "is_subtechnique": true
+      "is_subtechnique": true,
+      "platforms": [
+        "Linux",
+        "macOS",
+        "Windows"
+      ]
     },
     {
       "id": "T1499.002",
@@ -7774,7 +10929,13 @@
       ],
       "description": "Adversaries may target the different network services provided by systems to conduct a denial of service (DoS). Adversaries often target the availability of DNS and web services, however others have…",
       "url": "https://attack.mitre.org/techniques/T1499/002",
-      "is_subtechnique": true
+      "is_subtechnique": true,
+      "platforms": [
+        "Windows",
+        "IaaS",
+        "Linux",
+        "macOS"
+      ]
     },
     {
       "id": "T1499.003",
@@ -7785,7 +10946,13 @@
       ],
       "description": "Adversaries may target resource intensive features of applications to cause a denial of service (DoS), denying availability to those applications. For example, specific features in web applications…",
       "url": "https://attack.mitre.org/techniques/T1499/003",
-      "is_subtechnique": true
+      "is_subtechnique": true,
+      "platforms": [
+        "Windows",
+        "IaaS",
+        "Linux",
+        "macOS"
+      ]
     },
     {
       "id": "T1499.004",
@@ -7796,7 +10963,13 @@
       ],
       "description": "Adversaries may exploit software vulnerabilities that can cause an application or system to crash and deny availability to users. (Citation: Sucuri BIND9 August 2015) Some systems may automatically…",
       "url": "https://attack.mitre.org/techniques/T1499/004",
-      "is_subtechnique": true
+      "is_subtechnique": true,
+      "platforms": [
+        "Windows",
+        "IaaS",
+        "Linux",
+        "macOS"
+      ]
     },
     {
       "id": "T1529",
@@ -7807,7 +10980,14 @@
       ],
       "description": "Adversaries may shutdown/reboot systems to interrupt access to, or aid in the destruction of, those systems. Operating systems may contain commands to initiate a shutdown/reboot of a machine or…",
       "url": "https://attack.mitre.org/techniques/T1529",
-      "is_subtechnique": false
+      "is_subtechnique": false,
+      "platforms": [
+        "ESXi",
+        "Linux",
+        "macOS",
+        "Network Devices",
+        "Windows"
+      ]
     },
     {
       "id": "T1531",
@@ -7818,7 +10998,16 @@
       ],
       "description": "Adversaries may interrupt availability of system and network resources by inhibiting access to accounts utilized by legitimate users. Accounts may be deleted, locked, or manipulated (ex: changed…",
       "url": "https://attack.mitre.org/techniques/T1531",
-      "is_subtechnique": false
+      "is_subtechnique": false,
+      "platforms": [
+        "Linux",
+        "macOS",
+        "Windows",
+        "SaaS",
+        "IaaS",
+        "Office Suite",
+        "ESXi"
+      ]
     },
     {
       "id": "T1561",
@@ -7829,7 +11018,13 @@
       ],
       "description": "Adversaries may wipe or corrupt raw disk data on specific systems or in large numbers in a network to interrupt availability to system and network resources. With direct write access to a disk,…",
       "url": "https://attack.mitre.org/techniques/T1561",
-      "is_subtechnique": false
+      "is_subtechnique": false,
+      "platforms": [
+        "Linux",
+        "macOS",
+        "Windows",
+        "Network Devices"
+      ]
     },
     {
       "id": "T1561.001",
@@ -7840,7 +11035,13 @@
       ],
       "description": "Adversaries may erase the contents of storage devices on specific systems or in large numbers in a network to interrupt availability to system and network resources.\n\nAdversaries may partially or…",
       "url": "https://attack.mitre.org/techniques/T1561/001",
-      "is_subtechnique": true
+      "is_subtechnique": true,
+      "platforms": [
+        "Linux",
+        "macOS",
+        "Network Devices",
+        "Windows"
+      ]
     },
     {
       "id": "T1561.002",
@@ -7851,7 +11052,13 @@
       ],
       "description": "Adversaries may corrupt or wipe the disk data structures on a hard drive necessary to boot a system; targeting specific critical systems or in large numbers in a network to interrupt availability to…",
       "url": "https://attack.mitre.org/techniques/T1561/002",
-      "is_subtechnique": true
+      "is_subtechnique": true,
+      "platforms": [
+        "Linux",
+        "macOS",
+        "Network Devices",
+        "Windows"
+      ]
     },
     {
       "id": "T1565",
@@ -7862,7 +11069,12 @@
       ],
       "description": "Adversaries may insert, delete, or manipulate data in order to influence external outcomes or hide activity, thus threatening the integrity of the data.(Citation: Sygnia Elephant Beetle Jan 2022) By…",
       "url": "https://attack.mitre.org/techniques/T1565",
-      "is_subtechnique": false
+      "is_subtechnique": false,
+      "platforms": [
+        "Linux",
+        "macOS",
+        "Windows"
+      ]
     },
     {
       "id": "T1565.001",
@@ -7873,7 +11085,12 @@
       ],
       "description": "Adversaries may insert, delete, or manipulate data at rest in order to influence external outcomes or hide activity, thus threatening the integrity of the data.(Citation: FireEye APT38 Oct…",
       "url": "https://attack.mitre.org/techniques/T1565/001",
-      "is_subtechnique": true
+      "is_subtechnique": true,
+      "platforms": [
+        "Linux",
+        "macOS",
+        "Windows"
+      ]
     },
     {
       "id": "T1565.002",
@@ -7884,7 +11101,12 @@
       ],
       "description": "Adversaries may alter data en route to storage or other systems in order to manipulate external outcomes or hide activity, thus threatening the integrity of the data.(Citation: FireEye APT38 Oct…",
       "url": "https://attack.mitre.org/techniques/T1565/002",
-      "is_subtechnique": true
+      "is_subtechnique": true,
+      "platforms": [
+        "Linux",
+        "macOS",
+        "Windows"
+      ]
     },
     {
       "id": "T1565.003",
@@ -7895,7 +11117,12 @@
       ],
       "description": "Adversaries may modify systems in order to manipulate the data as it is accessed and displayed to an end user, thus threatening the integrity of the data.(Citation: FireEye APT38 Oct 2018)(Citation:…",
       "url": "https://attack.mitre.org/techniques/T1565/003",
-      "is_subtechnique": true
+      "is_subtechnique": true,
+      "platforms": [
+        "Linux",
+        "macOS",
+        "Windows"
+      ]
     },
     {
       "id": "T1657",
@@ -7906,7 +11133,14 @@
       ],
       "description": "Adversaries may steal monetary resources from targets through extortion, social engineering, technical theft, or other methods aimed at their own financial gain at the expense of the availability of…",
       "url": "https://attack.mitre.org/techniques/T1657",
-      "is_subtechnique": false
+      "is_subtechnique": false,
+      "platforms": [
+        "Linux",
+        "macOS",
+        "Office Suite",
+        "SaaS",
+        "Windows"
+      ]
     },
     {
       "id": "T1667",
@@ -7917,7 +11151,820 @@
       ],
       "description": "Adversaries may flood targeted email addresses with an overwhelming volume of messages. This may bury legitimate emails in a flood of spam and disrupt business operations.(Citation:…",
       "url": "https://attack.mitre.org/techniques/T1667",
-      "is_subtechnique": false
+      "is_subtechnique": false,
+      "platforms": [
+        "Linux",
+        "Office Suite",
+        "Windows",
+        "macOS"
+      ]
     }
-  ]
+  ],
+  "deprecated": {
+    "T1066": {
+      "name": "Indicator Removal from Tools",
+      "revoked": true,
+      "revoked_by": "T1027.005"
+    },
+    "T1156": {
+      "name": "Malicious Shell Modification",
+      "revoked": true,
+      "revoked_by": "T1546.004"
+    },
+    "T1067": {
+      "name": "Bootkit",
+      "revoked": true,
+      "revoked_by": "T1542.003"
+    },
+    "T1143": {
+      "name": "Hidden Window",
+      "revoked": true,
+      "revoked_by": "T1564.003"
+    },
+    "T1161": {
+      "name": "LC_LOAD_DYLIB Addition",
+      "revoked": true,
+      "revoked_by": "T1546.006"
+    },
+    "T1150": {
+      "name": "Plist Modification",
+      "revoked": true,
+      "revoked_by": "T1547.011"
+    },
+    "T1148": {
+      "name": "HISTCONTROL",
+      "revoked": true,
+      "revoked_by": "T1690"
+    },
+    "T1492": {
+      "name": "Stored Data Manipulation",
+      "revoked": true,
+      "revoked_by": "T1565.001"
+    },
+    "T1044": {
+      "name": "File System Permissions Weakness",
+      "revoked": true,
+      "revoked_by": "T1574.010"
+    },
+    "T1171": {
+      "name": "LLMNR/NBT-NS Poisoning and Relay",
+      "revoked": true,
+      "revoked_by": "T1557.001"
+    },
+    "T1501": {
+      "name": "Systemd Service",
+      "revoked": true,
+      "revoked_by": "T1543.002"
+    },
+    "T1514": {
+      "name": "Elevated Execution with Prompt",
+      "revoked": true,
+      "revoked_by": "T1548.004"
+    },
+    "T1109": {
+      "name": "Component Firmware",
+      "revoked": true,
+      "revoked_by": "T1542.002"
+    },
+    "T1099": {
+      "name": "Timestomp",
+      "revoked": true,
+      "revoked_by": "T1070.006"
+    },
+    "T1163": {
+      "name": "Rc.common",
+      "revoked": true,
+      "revoked_by": "T1037.004"
+    },
+    "T1116": {
+      "name": "Code Signing",
+      "revoked": true,
+      "revoked_by": "T1553.002"
+    },
+    "T1522": {
+      "name": "Cloud Instance Metadata API",
+      "revoked": true,
+      "revoked_by": "T1552.005"
+    },
+    "T1093": {
+      "name": "Process Hollowing",
+      "revoked": true,
+      "revoked_by": "T1055.012"
+    },
+    "T1172": {
+      "name": "Domain Fronting",
+      "revoked": true,
+      "revoked_by": "T1090.004"
+    },
+    "T1178": {
+      "name": "SID-History Injection",
+      "revoked": true,
+      "revoked_by": "T1134.005"
+    },
+    "T1013": {
+      "name": "Port Monitors",
+      "revoked": true,
+      "revoked_by": "T1547.010"
+    },
+    "T1192": {
+      "name": "Spearphishing Link",
+      "revoked": true,
+      "revoked_by": "T1566.002"
+    },
+    "T1121": {
+      "name": "Regsvcs/Regasm",
+      "revoked": true,
+      "revoked_by": "T1218.009"
+    },
+    "T1206": {
+      "name": "Sudo Caching",
+      "revoked": true,
+      "revoked_by": "T1548.003"
+    },
+    "T1063": {
+      "name": "Security Software Discovery",
+      "revoked": true,
+      "revoked_by": "T1518.001"
+    },
+    "T1167": {
+      "name": "Securityd Memory",
+      "revoked": true,
+      "revoked_by": "T1555.002"
+    },
+    "T1527": {
+      "name": "Application Access Token",
+      "revoked": true,
+      "revoked_by": "T1550.001"
+    },
+    "T1562.009": {
+      "name": "Safe Mode Boot",
+      "revoked": true,
+      "revoked_by": "T1688"
+    },
+    "T1180": {
+      "name": "Screensaver",
+      "revoked": true,
+      "revoked_by": "T1546.002"
+    },
+    "T1165": {
+      "name": "Startup Items",
+      "revoked": true,
+      "revoked_by": "T1037.005"
+    },
+    "T1070.002": {
+      "name": "Clear Linux or Mac System Logs",
+      "revoked": true,
+      "revoked_by": "T1685.006"
+    },
+    "T1089": {
+      "name": "Disabling Security Tools",
+      "revoked": true,
+      "revoked_by": "T1685"
+    },
+    "T1487": {
+      "name": "Disk Structure Wipe",
+      "revoked": true,
+      "revoked_by": "T1561.002"
+    },
+    "T1214": {
+      "name": "Credentials in Registry",
+      "revoked": true,
+      "revoked_by": "T1552.002"
+    },
+    "T1103": {
+      "name": "AppInit DLLs",
+      "revoked": true,
+      "revoked_by": "T1546.010"
+    },
+    "T1017": {
+      "name": "Application Deployment Software",
+      "revoked": true,
+      "revoked_by": "T1072"
+    },
+    "T1162": {
+      "name": "Login Item",
+      "revoked": true,
+      "revoked_by": "T1547.011"
+    },
+    "T1058": {
+      "name": "Service Registry Permissions Weakness",
+      "revoked": true,
+      "revoked_by": "T1574.011"
+    },
+    "T1024": {
+      "name": "Custom Cryptographic Protocol",
+      "revoked": true,
+      "revoked_by": "T1573"
+    },
+    "T1536": {
+      "name": "Revert Cloud Instance",
+      "revoked": true,
+      "revoked_by": "T1578.004"
+    },
+    "T1562": {
+      "name": "Impair Defenses",
+      "revoked": true,
+      "revoked_by": "T1685"
+    },
+    "T1079": {
+      "name": "Multilayer Encryption",
+      "revoked": true,
+      "revoked_by": "T1573"
+    },
+    "T1139": {
+      "name": "Bash History",
+      "revoked": true,
+      "revoked_by": "T1552.003"
+    },
+    "T1503": {
+      "name": "Credentials from Web Browsers",
+      "revoked": true,
+      "revoked_by": "T1555.003"
+    },
+    "T1153": {
+      "name": "Source",
+      "revoked": false,
+      "revoked_by": null
+    },
+    "T1038": {
+      "name": "DLL Search Order Hijacking",
+      "revoked": true,
+      "revoked_by": "T1574.001"
+    },
+    "T1050": {
+      "name": "New Service",
+      "revoked": true,
+      "revoked_by": "T1543.003"
+    },
+    "T1032": {
+      "name": "Standard Cryptographic Protocol",
+      "revoked": true,
+      "revoked_by": "T1573"
+    },
+    "T1062": {
+      "name": "Hypervisor",
+      "revoked": false,
+      "revoked_by": null
+    },
+    "T1182": {
+      "name": "AppCert DLLs",
+      "revoked": true,
+      "revoked_by": "T1546.009"
+    },
+    "T1562.002": {
+      "name": "Disable Windows Event Logging",
+      "revoked": true,
+      "revoked_by": "T1685.001"
+    },
+    "T1004": {
+      "name": "Winlogon Helper DLL",
+      "revoked": true,
+      "revoked_by": "T1547.004"
+    },
+    "T1009": {
+      "name": "Binary Padding",
+      "revoked": true,
+      "revoked_by": "T1027.001"
+    },
+    "T1076": {
+      "name": "Remote Desktop Protocol",
+      "revoked": true,
+      "revoked_by": "T1021.001"
+    },
+    "T1131": {
+      "name": "Authentication Package",
+      "revoked": true,
+      "revoked_by": "T1547.002"
+    },
+    "T1181": {
+      "name": "Extra Window Memory Injection",
+      "revoked": true,
+      "revoked_by": "T1055.011"
+    },
+    "T1562.004": {
+      "name": "Disable or Modify System Firewall",
+      "revoked": true,
+      "revoked_by": "T1686"
+    },
+    "T1152": {
+      "name": "Launchctl",
+      "revoked": true,
+      "revoked_by": "T1569.001"
+    },
+    "T1483": {
+      "name": "Domain Generation Algorithms",
+      "revoked": true,
+      "revoked_by": "T1568.002"
+    },
+    "T1562.012": {
+      "name": "Disable or Modify Linux Audit System",
+      "revoked": true,
+      "revoked_by": "T1685.004"
+    },
+    "T1107": {
+      "name": "File Deletion",
+      "revoked": true,
+      "revoked_by": "T1070.004"
+    },
+    "T1145": {
+      "name": "Private Keys",
+      "revoked": true,
+      "revoked_by": "T1552.004"
+    },
+    "T1155": {
+      "name": "AppleScript",
+      "revoked": true,
+      "revoked_by": "T1059.002"
+    },
+    "T1183": {
+      "name": "Image File Execution Options Injection",
+      "revoked": true,
+      "revoked_by": "T1546.012"
+    },
+    "T1085": {
+      "name": "Rundll32",
+      "revoked": true,
+      "revoked_by": "T1218.011"
+    },
+    "T1031": {
+      "name": "Modify Existing Service",
+      "revoked": true,
+      "revoked_by": "T1543.003"
+    },
+    "T1070.001": {
+      "name": "Clear Windows Event Logs",
+      "revoked": true,
+      "revoked_by": "T1685.005"
+    },
+    "T1053.001": {
+      "name": "At (Linux)",
+      "revoked": true,
+      "revoked_by": "T1053.002"
+    },
+    "T1179": {
+      "name": "Hooking",
+      "revoked": true,
+      "revoked_by": "T1056.004"
+    },
+    "T1547.011": {
+      "name": "Plist Modification",
+      "revoked": true,
+      "revoked_by": "T1647"
+    },
+    "T1019": {
+      "name": "System Firmware",
+      "revoked": true,
+      "revoked_by": "T1542.001"
+    },
+    "T1042": {
+      "name": "Change Default File Association",
+      "revoked": true,
+      "revoked_by": "T1546.001"
+    },
+    "T1117": {
+      "name": "Regsvr32",
+      "revoked": true,
+      "revoked_by": "T1218.010"
+    },
+    "T1164": {
+      "name": "Re-opened Applications",
+      "revoked": true,
+      "revoked_by": "T1547.007"
+    },
+    "T1054": {
+      "name": "Indicator Blocking",
+      "revoked": true,
+      "revoked_by": "T1685"
+    },
+    "T1108": {
+      "name": "Redundant Access",
+      "revoked": false,
+      "revoked_by": null
+    },
+    "T1193": {
+      "name": "Spearphishing Attachment",
+      "revoked": true,
+      "revoked_by": "T1566.001"
+    },
+    "T1215": {
+      "name": "Kernel Modules and Extensions",
+      "revoked": true,
+      "revoked_by": "T1547.006"
+    },
+    "T1101": {
+      "name": "Security Support Provider",
+      "revoked": true,
+      "revoked_by": "T1547.005"
+    },
+    "T1177": {
+      "name": "LSASS Driver",
+      "revoked": true,
+      "revoked_by": "T1547.008"
+    },
+    "T1144": {
+      "name": "Gatekeeper Bypass",
+      "revoked": true,
+      "revoked_by": "T1553.001"
+    },
+    "T1045": {
+      "name": "Software Packing",
+      "revoked": true,
+      "revoked_by": "T1027.002"
+    },
+    "T1504": {
+      "name": "PowerShell Profile",
+      "revoked": true,
+      "revoked_by": "T1546.013"
+    },
+    "T1198": {
+      "name": "SIP and Trust Provider Hijacking",
+      "revoked": true,
+      "revoked_by": "T1553.003"
+    },
+    "T1562.006": {
+      "name": "Indicator Blocking",
+      "revoked": true,
+      "revoked_by": "T1685"
+    },
+    "T1175": {
+      "name": "Component Object Model and Distributed COM",
+      "revoked": false,
+      "revoked_by": null
+    },
+    "T1562.007": {
+      "name": "Disable or Modify Cloud Firewall",
+      "revoked": true,
+      "revoked_by": "T1686.001"
+    },
+    "T1138": {
+      "name": "Application Shimming",
+      "revoked": true,
+      "revoked_by": "T1546.011"
+    },
+    "T1191": {
+      "name": "CMSTP",
+      "revoked": true,
+      "revoked_by": "T1218.003"
+    },
+    "T1188": {
+      "name": "Multi-hop Proxy",
+      "revoked": true,
+      "revoked_by": "T1090.003"
+    },
+    "T1064": {
+      "name": "Scripting",
+      "revoked": false,
+      "revoked_by": null
+    },
+    "T1051": {
+      "name": "Shared Webroot",
+      "revoked": false,
+      "revoked_by": null
+    },
+    "T1562.010": {
+      "name": "Downgrade Attack",
+      "revoked": true,
+      "revoked_by": "T1689"
+    },
+    "T1196": {
+      "name": "Control Panel Items",
+      "revoked": true,
+      "revoked_by": "T1218.002"
+    },
+    "T1562.003": {
+      "name": "Impair Command History Logging",
+      "revoked": true,
+      "revoked_by": "T1690"
+    },
+    "T1053.004": {
+      "name": "Launchd",
+      "revoked": false,
+      "revoked_by": null
+    },
+    "T1141": {
+      "name": "Input Prompt",
+      "revoked": true,
+      "revoked_by": "T1056.002"
+    },
+    "T1060": {
+      "name": "Registry Run Keys / Startup Folder",
+      "revoked": true,
+      "revoked_by": "T1547.001"
+    },
+    "T1023": {
+      "name": "Shortcut Modification",
+      "revoked": true,
+      "revoked_by": "T1547.009"
+    },
+    "T1026": {
+      "name": "Multiband Communication",
+      "revoked": false,
+      "revoked_by": null
+    },
+    "T1122": {
+      "name": "Component Object Model Hijacking",
+      "revoked": true,
+      "revoked_by": "T1546.015"
+    },
+    "T1015": {
+      "name": "Accessibility Features",
+      "revoked": true,
+      "revoked_by": "T1546.008"
+    },
+    "T1502": {
+      "name": "Parent PID Spoofing",
+      "revoked": true,
+      "revoked_by": "T1134.004"
+    },
+    "T1142": {
+      "name": "Keychain",
+      "revoked": true,
+      "revoked_by": "T1555.001"
+    },
+    "T1169": {
+      "name": "Sudo",
+      "revoked": true,
+      "revoked_by": "T1548.003"
+    },
+    "T1149": {
+      "name": "LC_MAIN Hijacking",
+      "revoked": false,
+      "revoked_by": null
+    },
+    "T1562.013": {
+      "name": "Disable or Modify Network Device Firewall",
+      "revoked": true,
+      "revoked_by": "T1686.002"
+    },
+    "T1170": {
+      "name": "Mshta",
+      "revoked": true,
+      "revoked_by": "T1218.005"
+    },
+    "T1097": {
+      "name": "Pass the Ticket",
+      "revoked": true,
+      "revoked_by": "T1550.003"
+    },
+    "T1061": {
+      "name": "Graphical User Interface",
+      "revoked": false,
+      "revoked_by": null
+    },
+    "T1157": {
+      "name": "Dylib Hijacking",
+      "revoked": true,
+      "revoked_by": "T1574.004"
+    },
+    "T1562.001": {
+      "name": "Disable or Modify Tools",
+      "revoked": true,
+      "revoked_by": "T1685"
+    },
+    "T1073": {
+      "name": "DLL Side-Loading",
+      "revoked": true,
+      "revoked_by": "T1574.002"
+    },
+    "T1208": {
+      "name": "Kerberoasting",
+      "revoked": true,
+      "revoked_by": "T1558.003"
+    },
+    "T1154": {
+      "name": "Trap",
+      "revoked": true,
+      "revoked_by": "T1546.005"
+    },
+    "T1488": {
+      "name": "Disk Content Wipe",
+      "revoked": true,
+      "revoked_by": "T1561.001"
+    },
+    "T1174": {
+      "name": "Password Filter DLL",
+      "revoked": true,
+      "revoked_by": "T1556.002"
+    },
+    "T1002": {
+      "name": "Data Compressed",
+      "revoked": true,
+      "revoked_by": "T1560"
+    },
+    "T1081": {
+      "name": "Credentials in Files",
+      "revoked": true,
+      "revoked_by": "T1552.001"
+    },
+    "T1128": {
+      "name": "Netsh Helper DLL",
+      "revoked": true,
+      "revoked_by": "T1546.007"
+    },
+    "T1562.011": {
+      "name": "Spoof Security Alerting",
+      "revoked": true,
+      "revoked_by": "T1685.003"
+    },
+    "T1168": {
+      "name": "Local Job Scheduling",
+      "revoked": true,
+      "revoked_by": "T1053"
+    },
+    "T1166": {
+      "name": "Setuid and Setgid",
+      "revoked": true,
+      "revoked_by": "T1548.001"
+    },
+    "T1100": {
+      "name": "Web Shell",
+      "revoked": true,
+      "revoked_by": "T1505.003"
+    },
+    "T1186": {
+      "name": "Process Doppelgänging",
+      "revoked": true,
+      "revoked_by": "T1055.013"
+    },
+    "T1184": {
+      "name": "SSH Hijacking",
+      "revoked": true,
+      "revoked_by": "T1563.001"
+    },
+    "T1075": {
+      "name": "Pass the Hash",
+      "revoked": true,
+      "revoked_by": "T1550.002"
+    },
+    "T1028": {
+      "name": "Windows Remote Management",
+      "revoked": true,
+      "revoked_by": "T1021.006"
+    },
+    "T1034": {
+      "name": "Path Interception",
+      "revoked": false,
+      "revoked_by": null
+    },
+    "T1506": {
+      "name": "Web Session Cookie",
+      "revoked": true,
+      "revoked_by": "T1550.004"
+    },
+    "T1065": {
+      "name": "Uncommonly Used Port",
+      "revoked": true,
+      "revoked_by": "T1571"
+    },
+    "T1656": {
+      "name": "Impersonation",
+      "revoked": true,
+      "revoked_by": "T1684.001"
+    },
+    "T1088": {
+      "name": "Bypass User Account Control",
+      "revoked": true,
+      "revoked_by": "T1548.002"
+    },
+    "T1494": {
+      "name": "Runtime Data Manipulation",
+      "revoked": true,
+      "revoked_by": "T1565.003"
+    },
+    "T1562.008": {
+      "name": "Disable or Modify Cloud Logs",
+      "revoked": true,
+      "revoked_by": "T1685.002"
+    },
+    "T1493": {
+      "name": "Transmitted Data Manipulation",
+      "revoked": true,
+      "revoked_by": "T1565.002"
+    },
+    "T1147": {
+      "name": "Hidden Users",
+      "revoked": true,
+      "revoked_by": "T1564.002"
+    },
+    "T1500": {
+      "name": "Compile After Delivery",
+      "revoked": true,
+      "revoked_by": "T1027.004"
+    },
+    "T1223": {
+      "name": "Compiled HTML File",
+      "revoked": true,
+      "revoked_by": "T1218.001"
+    },
+    "T1146": {
+      "name": "Clear Command History",
+      "revoked": true,
+      "revoked_by": "T1070.003"
+    },
+    "T1519": {
+      "name": "Emond",
+      "revoked": true,
+      "revoked_by": "T1546.014"
+    },
+    "T1194": {
+      "name": "Spearphishing via Service",
+      "revoked": true,
+      "revoked_by": "T1566.003"
+    },
+    "T1130": {
+      "name": "Install Root Certificate",
+      "revoked": true,
+      "revoked_by": "T1553.004"
+    },
+    "T1022": {
+      "name": "Data Encrypted",
+      "revoked": true,
+      "revoked_by": "T1560"
+    },
+    "T1158": {
+      "name": "Hidden Files and Directories",
+      "revoked": true,
+      "revoked_by": "T1564.001"
+    },
+    "T1209": {
+      "name": "Time Providers",
+      "revoked": true,
+      "revoked_by": "T1547.003"
+    },
+    "T1159": {
+      "name": "Launch Agent",
+      "revoked": true,
+      "revoked_by": "T1543.001"
+    },
+    "T1672": {
+      "name": "Email Spoofing",
+      "revoked": true,
+      "revoked_by": "T1684.002"
+    },
+    "T1151": {
+      "name": "Space after Filename",
+      "revoked": true,
+      "revoked_by": "T1036.006"
+    },
+    "T1574.002": {
+      "name": "DLL Side-Loading",
+      "revoked": true,
+      "revoked_by": "T1574.001"
+    },
+    "T1126": {
+      "name": "Network Share Connection Removal",
+      "revoked": true,
+      "revoked_by": "T1070.005"
+    },
+    "T1084": {
+      "name": "Windows Management Instrumentation Event Subscription",
+      "revoked": true,
+      "revoked_by": "T1546.003"
+    },
+    "T1160": {
+      "name": "Launch Daemon",
+      "revoked": true,
+      "revoked_by": "T1543.004"
+    },
+    "T1173": {
+      "name": "Dynamic Data Exchange",
+      "revoked": true,
+      "revoked_by": "T1559.002"
+    },
+    "T1096": {
+      "name": "NTFS File Attributes",
+      "revoked": true,
+      "revoked_by": "T1564.004"
+    },
+    "T1035": {
+      "name": "Service Execution",
+      "revoked": true,
+      "revoked_by": "T1569.002"
+    },
+    "T1086": {
+      "name": "PowerShell",
+      "revoked": true,
+      "revoked_by": "T1059.001"
+    },
+    "T1094": {
+      "name": "Custom Command and Control Protocol",
+      "revoked": true,
+      "revoked_by": "T1095"
+    },
+    "T1118": {
+      "name": "InstallUtil",
+      "revoked": true,
+      "revoked_by": "T1218.004"
+    },
+    "T1043": {
+      "name": "Commonly Used Port",
+      "revoked": false,
+      "revoked_by": null
+    },
+    "T1077": {
+      "name": "Windows Admin Shares",
+      "revoked": true,
+      "revoked_by": "T1021.002"
+    }
+  }
 }

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,6 +14,8 @@ readability-lxml>=0.8.0
 lxml>=5.0.0
 # Headless-browser fallback for JS bot-challenged sources (needs: playwright install chromium)
 playwright>=1.40.0
+# Hardened XML parsing for CTI feed ingestion (billion-laughs/XXE defense)
+defusedxml>=0.7.1
 
 # Document Processing
 pypdf>=4.0.0

--- a/scripts/build_mitre_matrix.py
+++ b/scripts/build_mitre_matrix.py
@@ -2,7 +2,10 @@
 """Build a slim MITRE ATT&CK matrix JSON for the Coverage Heatmap page.
 
 Reads data/enterprise-attack.json (downloaded from mitre/cti) and writes
-public/mitre-matrix.json with just the tactics + techniques the frontend needs.
+public/mitre-matrix.json with the tactics + techniques the frontend needs, plus:
+  - `platforms` on each technique (for local OS validation by the CTI pipeline)
+  - a top-level `deprecated` map of retired ID → replacement (revoked-by)
+Both are additive; existing consumers that read `tactics`/`techniques` are unaffected.
 """
 import json
 import sys
@@ -57,7 +60,18 @@ def main() -> int:
             "description": desc,
             "url": _ext_url(obj),
             "is_subtechnique": bool(obj.get("x_mitre_is_subtechnique")),
+            # Platforms let downstream consumers (e.g. the CTI pipeline's hunt
+            # generator) validate a technique's OS locally instead of WebFetching
+            # its ATT&CK page. Empty list if ATT&CK doesn't scope the technique.
+            "platforms": obj.get("x_mitre_platforms", []),
         })
+
+    # Deprecated/revoked redirect map. Active techniques above deliberately exclude
+    # these, but the CTI pipeline needs them: a CTI report may cite an ID that ATT&CK
+    # has since retired (e.g. T1158 → T1564.001), and the generator should follow the
+    # redirect rather than WebFetch to discover it. Keyed by the retired ID; value
+    # carries the replacement (revoked-by) when ATT&CK provides one.
+    deprecated = _build_deprecated_map(objects)
 
     order = _tactic_order(objects)
     tactics.sort(key=lambda t: order.get(t["shortname"], 999))
@@ -68,13 +82,50 @@ def main() -> int:
 
     techniques.sort(key=tech_key)
 
-    payload = {"tactics": tactics, "techniques": techniques}
+    payload = {"tactics": tactics, "techniques": techniques, "deprecated": deprecated}
     TARGET.parent.mkdir(parents=True, exist_ok=True)
     TARGET.write_text(json.dumps(payload, indent=2, ensure_ascii=False) + "\n")
 
     size_kb = TARGET.stat().st_size / 1024
-    print(f"Wrote {TARGET} — {len(tactics)} tactics, {len(techniques)} techniques, {size_kb:.1f} KB")
+    print(f"Wrote {TARGET} — {len(tactics)} tactics, {len(techniques)} techniques, "
+          f"{len(deprecated)} deprecated, {size_kb:.1f} KB")
     return 0
+
+
+def _build_deprecated_map(objects: list[dict]) -> dict[str, dict]:
+    """Map each retired (revoked or deprecated) technique ID to its replacement.
+
+    `revoked_by` resolves the STIX `revoked-by` relationship to the successor's
+    external technique ID (or None when ATT&CK deprecated a technique without a
+    direct replacement). Lets consumers follow a retired ID → current ID locally
+    instead of discovering the redirect via a live ATT&CK page fetch.
+    """
+    stix_to_ext = {
+        o["id"]: _ext_id(o)
+        for o in objects
+        if o.get("type") == "attack-pattern" and _ext_id(o)
+    }
+    revoked_by = {
+        r["source_ref"]: r["target_ref"]
+        for r in objects
+        if r.get("type") == "relationship" and r.get("relationship_type") == "revoked-by"
+    }
+    deprecated: dict[str, dict] = {}
+    for obj in objects:
+        if obj.get("type") != "attack-pattern":
+            continue
+        if not (obj.get("revoked") or obj.get("x_mitre_deprecated")):
+            continue
+        ext_id = _ext_id(obj)
+        if not ext_id:
+            continue
+        successor = stix_to_ext.get(revoked_by.get(obj["id"], ""), "") or None
+        deprecated[ext_id] = {
+            "name": obj.get("name", ""),
+            "revoked": bool(obj.get("revoked")),
+            "revoked_by": successor,
+        }
+    return deprecated
 
 
 def _ext_id(obj: dict) -> str:

--- a/src/types/Mitre.ts
+++ b/src/types/Mitre.ts
@@ -12,9 +12,19 @@ export interface MitreTechnique {
   description: string;
   url: string;
   is_subtechnique: boolean;
+  /** ATT&CK platform list (e.g. ["Windows", "macOS"]); may be empty. */
+  platforms?: string[];
+}
+
+/** Retired technique ID → replacement, from the matrix's `deprecated` map. */
+export interface MitreDeprecatedEntry {
+  name: string;
+  revoked: boolean;
+  revoked_by: string | null;
 }
 
 export interface MitreMatrix {
   tactics: MitreTactic[];
   techniques: MitreTechnique[];
+  deprecated?: Record<string, MitreDeprecatedEntry>;
 }


### PR DESCRIPTION
## What

`scripts/build_mitre_matrix.py` now emits, **additively**:
- `platforms` on each technique (ATT&CK OS list)
- a top-level `deprecated` map of retired ID → `{name, revoked, revoked_by}`

## Why

Lets the CTI pipeline validate technique OS/deprecation and follow retired-ID redirects **locally**, instead of a live WebFetch per technique.

## Safety

Regenerated `public/mitre-matrix.json` is purely additive — identical tactics and the same **697 techniques in the same order**. Existing consumers (Coverage Heatmap, etc.) that read tactics/techniques are unaffected. `Mitre.ts` gains optional `platforms?` / `deprecated?` fields; `requirements.txt` adds `defusedxml`.

## ⚠️ Reviewer note
This branch was cut from a local `main` that was ~85 commits behind origin. The three core files (`mitre-matrix.json`, `build_mitre_matrix.py`, `Mitre.ts`) are byte-identical upstream so they merge clean, but **`requirements.txt` diverged upstream** (PyPDF2→pypdf) — watch for a conflict there and take upstream's version plus the `defusedxml` line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)