### PR TITLE
Ignore local screenshot/social-card generation artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -61,3 +61,12 @@ scripts/cti_pipeline.py
 
 # CI-generated at deploy time (home page Recent activity feed)
 public/activity.json
+
+# Local screenshot / social-card generation artifacts (root-level)
+/.playwright-mcp/
+/.superpowers/
+/social/
+/smoke-*.png
+/social-*.png
+/hero-*.png
+/profile-hero-*.png


### PR DESCRIPTION
Adds root-anchored `.gitignore` entries for local-only artifacts produced when running Playwright smoke tests and social-card generation locally (`.playwright-mcp/`, `.superpowers/`, `social/`, and root-level `smoke-*.png` / `social-*.png` / `hero-*.png` / `profile-hero-*.png`).

Root-anchored (`/…`) so real tracked assets in subdirectories are unaffected. No code or data changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)