### PR TITLE
Add H222: ConsentFix OAuth callback token replay into Microsoft 365 resource access

### DIFF
--- a/Flames/H227.md
+++ b/Flames/H227.md
@@ -1,0 +1,56 @@
+---
+id: H227
+category: Flames
+title: ConsentFix OAuth callback token replay into Microsoft 365 resource access
+hypothesis: >-
+  An adversary tricks a user into moving a localhost OAuth callback URL into the browser, captures the authorization code, exchanges it for Microsoft 365 tokens, and replays them from a new ASN to read mail or files.
+tactics:
+  - Credential Access
+  - Stealth
+  - Collection
+techniques:
+  - T1528
+  - T1550.001
+  - T1114.002
+  - T1213
+tags:
+  - entra_id
+  - oauth
+  - token_replay
+  - microsoft_365
+  - consentfix
+submitter:
+  name: Joshua Strickland
+  link: https://novasky.io
+required_data_sources:
+  - Entra interactive sign-in logs
+  - Entra non-interactive sign-in logs
+  - Microsoft 365 audit logs
+  - Microsoft Graph activity logs
+  - OAuth and app consent audit logs
+false_positive_notes: |
+  Azure CLI, Azure PowerShell, Visual Studio Code, and other first-party clients can use localhost OAuth callbacks for legitimate admin and developer work. Treat the initial callback as context. Escalate when the same user and app move into non-interactive token use from a new ASN or user agent, then read mail, SharePoint, OneDrive, or Graph resources without a fresh interactive sign-in from that network.
+notes: |
+  Entra interactive sign-in logs - Core filter: successful sign-in for first-party CLI or admin clients with a localhost redirect such as `http://localhost:1605/?code=` or `http://localhost:<port>/?code=`. Triage values: `app ID`, `resource name`, `source IP address`, `user agent`, `session ID`, `authentication requirement`. Pivot: keep the `session ID`, `app ID`, and `user principal name` for token use correlation.
+  Entra non-interactive sign-in logs - Core filter: same `user principal name` and `app ID` later using tokens from a `new ASN`, `new source IP address`, or changed `user agent` without a fresh interactive MFA event. Correlation: compare the interactive leg to later refresh or resource events by `session ID` and `token identifier`. Strong red flags: token use begins within `10 minutes` of the callback.
+  Microsoft 365 audit logs - Core filter: resource reads after the token handoff, especially `MailItemsAccessed`, `Graph`, `SharePoint`, `OneDrive`, `FileDownloaded`, or `FileSyncDownloadedFull`. Triage values: `client request ID`, `session ID`, `source IP address`, `user agent`, `object path`. Pivot: identify mail, file, and directory objects touched by the replayed token.
+  OAuth and app consent audit logs - Core filter: new delegated grant, service principal assignment, or consent change near the same session. Triage values: `client ID`, `app ID`, `scope`, `actor`, `target resource`. Strong red flags: broad mail or file scopes such as `Mail.Read`, `Files.Read.All`, or `offline_access` paired with resource reads from a different network.
+---
+# H227
+
+ConsentFix is a browser-based OAuth authorization-code theft technique. The user may interact with the legitimate Microsoft sign-in flow, then gets instructed to move a localhost callback URL containing authorization material back into an attacker-controlled page. Malwarebytes reported the technique being used to steal Microsoft 365 accounts without malware, while Push Security and NVISO documented the Azure CLI centered flow, the localhost callback, and the later token use. The hunt should not start with the phishing page or domain. Start with the identity chokepoint: a localhost OAuth callback that leads to token use from a different network, then Microsoft 365 resource access.
+
+## Why
+
+- ConsentFix matters because the Microsoft login can be legitimate while the attacker steals the OAuth callback after the user handles it. Password and MFA failure telemetry will not be the primary signal.
+- The localhost callback and token replay chain survives domain rotation. The domain only gets the user to the handoff point; the invariant behavior is authorization code capture followed by token use from another network.
+- Entra sign-in logs and Microsoft 365 audit logs give the two halves of the chain: the interactive authorization event and later non-interactive resource access tied by session ID, client request ID, app ID, or user.
+- False positives are controllable because admin and developer use of Azure CLI can be scoped by role, but same-user SharePoint, OneDrive, or mailbox access from a new ASN after the callback is much harder to explain.
+
+## References
+
+- [Verified X ad spreads Mac malware, while ConsentFix steals Microsoft accounts](https://www.malwarebytes.com/blog/news/2026/07/verified-x-ad-spreads-mac-malware-while-consentfix-steals-microsoft-accounts)
+- [ConsentFix: Browser-native ClickFix hijacks OAuth grants](https://pushsecurity.com/blog/consentfix)
+- [New Attack Technique ConsentFix Hijacks OAuth Consent Grants](https://arcticwolf.com/resources/blog/new-attack-technique-consentfix-hijacks-oauth-consent-grants/)
+- [ConsentFix AuthCodeFix: Detecting OAuth2 Authorization Code Phishing](https://blog.nviso.eu/2026/01/29/consentfix-a-k-a-authcodefix-detecting-oauth2-authorization-code-phishing/)
+- [Use MailItemsAccessed to investigate compromised accounts](https://learn.microsoft.com/en-us/purview/audit-log-investigate-accounts)


### PR DESCRIPTION
## Summary

Adds `H222`: ConsentFix OAuth callback token replay into Microsoft 365 resource access.

## Sources

- https://www.malwarebytes.com/blog/news/2026/07/verified-x-ad-spreads-mac-malware-while-consentfix-steals-microsoft-accounts

## Validation

- Draft reviewed locally before submission.
- Source links are preserved in the hunt writeup.
