### PR TITLE
Add H223: GodDamn credential theft into PsExec fan-out and PoisonX impairment

### DIFF
--- a/Flames/H228.md
+++ b/Flames/H228.md
@@ -1,0 +1,65 @@
+---
+id: H228
+category: Flames
+title: GodDamn credential theft into PsExec fan-out and PoisonX impairment
+hypothesis: >-
+  A ransomware operator harvests local credential stores, uses PsExec to move across hosts, then loads a signed PoisonX driver or masqueraded security binary to impair endpoint defenses before encryption.
+tactics:
+  - Credential Access
+  - Lateral Movement
+  - Persistence
+  - Defense Impairment
+  - Impact
+techniques:
+  - T1555
+  - T1003
+  - T1021.002
+  - T1569.002
+  - T1570
+  - T1219
+  - T1543.003
+  - T1562.001
+  - T1486
+tags:
+  - ransomware
+  - windows
+  - psexec
+  - byovd
+  - credential_access
+submitter:
+  name: Joshua Strickland
+  link: https://novasky.io
+required_data_sources:
+  - Endpoint process telemetry
+  - Endpoint file telemetry
+  - Windows service creation telemetry
+  - Windows driver load telemetry
+  - Windows remote logon telemetry
+  - Endpoint security alert or tamper telemetry
+false_positive_notes: |
+  PsExec, remote support tools, and service creation are normal in many Windows estates, so they should not alert by themselves. This hunt depends on the ordered chain: credential-store tooling or browser credential reads, PsExec fan-out, unattended remote access setup, `symantec.exe` or `g11.sys` driver activity, then security impairment or encryption. Software deployment and IT support workflows can explain one or two pieces, but they should not include NirSoft credential tools, a masqueraded security binary, a signed driver used to blind endpoint defenses, and ransomware file renames in the same sequence.
+notes: |
+  Endpoint process and file telemetry - Core filter: user-profile execution of credential tooling or browser credential access before remote execution. Triage values: `process command line`, `parent process command line`, `file path`, `user context`. Strong red flags: `Mimikatz`, `WebBrowserPassView`, `ChromePass`, `PasswordFox`, `VNCPassView`, `MailPassView`, `WirelessKeyView`, or `NetPass` staged under `C:\Users\*\Music\` or another user-writable path, followed by archive creation or network movement.
+  Windows service and remote execution telemetry - Core filter: PsExec-style service execution across hosts. Triage values: `service name`, `service image path`, `source host`, `target host`, `account name`. Correlation: chain `psexesvc.exe` to `services.exe` and `wininit.exe`, then look for remote command execution, administrative share writes, or tool transfer in the same operator window. Strong red flags: the same account touches multiple hosts after local credential-store reads.
+  Remote access persistence telemetry - Core filter: remote access tool installation after PsExec movement. Triage values: `process command line`, `service name`, `file path`, `parent process command line`. Strong red flags: `AnyDesk.exe` configured for unattended access, an access password piped through standard input, consent prompts disabled, and two Windows services created so the tool starts after reboot.
+  Driver and endpoint defense impairment telemetry - Core filter: signed or masqueraded driver activity paired with security process termination. Triage values: `driver file path`, `driver signer`, `service name`, `process command line`, `target process`. Correlation: `symantec.exe` dropping or loading `g11.sys`, then security process termination, real-time monitoring disabled, or endpoint sensor errors before ransomware activity.
+  Impact telemetry - Core filter: encryption binary and mass file rename after the impairment chain. Triage values: `process command line`, `file path`, `renamed file extension`, `host role`. Strong red flags: `encrypter-windows-gui-x86.exe`, `.God8Damn`, victim-name file extensions, or qTox ransom-note contact text after credential tooling, PsExec, AnyDesk, and `g11.sys` are seen in sequence.
+---
+# H228
+
+GodDamn is a ransomware family tied by Symantec to Hyadina, the same lineage behind Monster and Beast. Reporting from GBHackers, The Hacker News, and SecurityAffairs describes a June 2026 intrusion where operators used AnyDesk for access, a NirSoft-heavy credential toolkit, PsExec for lateral movement, a masqueraded `symantec.exe` utility, and the signed PoisonX driver `g11.sys` before ransomware execution. The initial access path was not confirmed, so the useful hunt starts after foothold with the chain the operator needs to complete: credential-store collection, remote execution, endpoint defense impairment, persistence through remote access tooling, and encryption.
+
+## Why
+
+- The reporting is current, and the June 2026 intrusion gives a concrete post-foothold chain even though initial access was not confirmed.
+- The hunt survives filename and hash rotation because the operator still has to collect credentials, move with a remote execution mechanism, impair endpoint defenses, and encrypt files.
+- The telemetry is common for MDR coverage: endpoint process and file events, Windows service creation, driver load activity, remote logon evidence, and file rename activity.
+- False positives are controllable because the signal is the sequence across phases, not the presence of PsExec, AnyDesk, or a driver load by itself.
+
+## References
+
+- [GBHackers: GodDamn Ransomware Attack Uses PsExec Lateral Movement and NirSoft Toolkit for Credential Theft](https://gbhackers.com/goddamn-ransomware-attack/)
+- [The Hacker News: GodDamn Ransomware Uses PoisonX Driver to Disable Endpoint Defenses](https://thehackernews.com/2026/07/goddamn-ransomware-uses-poisonx-driver.html)
+- [SecurityAffairs: GodDamn Ransomware Uses PoisonX to Blind Security Software](https://securityaffairs.com/195042/malware/goddamn-ransomware-uses-poisonx-to-blind-security-software.html)
+- [MITRE ATT&CK T1555: Credentials from Password Stores](https://attack.mitre.org/techniques/T1555/)
+- [MITRE ATT&CK T1562.001: Impair Defenses: Disable or Modify Tools](https://attack.mitre.org/techniques/T1562/001/)


### PR DESCRIPTION
## Summary

Adds `H223`: GodDamn credential theft into PsExec fan-out and PoisonX impairment.

## Sources

- https://gbhackers.com/goddamn-ransomware-attack/

## Validation

- Draft reviewed locally before submission.
- Source links are preserved in the hunt writeup.
