### PR TITLE
Add H224: GigaWiper OneDrive Update Persistence Before Destructive Commands

### DIFF
--- a/Flames/H229.md
+++ b/Flames/H229.md
@@ -1,0 +1,64 @@
+---
+id: H229
+category: Flames
+title: GigaWiper OneDrive Update Persistence Before Destructive Commands
+hypothesis: >-
+  An adversary deploys GigaWiper as a post-compromise backdoor, keeps state under a fake OneDrive registry key, and uses a recurring task to reach destructive disk, boot, or fake-ransomware commands.
+tactics:
+  - Persistence
+  - Stealth
+  - Collection
+  - Command and Control
+  - Impact
+techniques:
+  - T1053.005
+  - T1112
+  - T1113
+  - T1485
+  - T1490
+  - T1486
+  - T1071
+tags:
+  - windows
+  - gigawiper
+  - wiper
+  - scheduled_task
+  - registry
+  - ransomware
+submitter:
+  name: Joshua Strickland
+  link: https://novasky.io
+required_data_sources:
+  - EDR process telemetry
+  - EDR registry telemetry
+  - Windows scheduled task telemetry
+  - EDR file telemetry
+  - EDR network connection telemetry
+  - Windows event log telemetry
+false_positive_notes: |
+  Legitimate OneDrive scheduled tasks should run Microsoft-signed OneDrive components from expected installation paths and should not maintain a custom HKCU OneDrive Environment key. Backup, imaging, and disk-management tools may open raw disk handles, but they should not pair raw disk access with fake OneDrive persistence, screen recording under ProgramData, AMQP or Redis command traffic, .candy file renames, event-log clearing, and boot recovery deletion in the same process lineage.
+notes: |
+  Windows scheduled task telemetry - Core filter: task name `OneDrive Update` with an action path outside normal OneDrive install paths. Triage values: `task action`, `process command line`, `parent process command line`, `signer`, `file path`. Pivot: same host and user creating or updating `HKCU\SOFTWARE\OneDrive\Environment`.
+  EDR registry and process telemetry - Core filter: unsigned or newly created Go PE writes `HKCU\SOFTWARE\OneDrive\Environment`, then launches from the scheduled task. Correlation: same process tree opens `\\.\PHYSICALDRIVE0`, `\\.\PHYSICALDRIVE1`, invokes `bcdedit`, or deletes recovery, boot, or kernel files. Strong red flags: `.candy` file renames or immediate reboot after the task fires.
+  EDR file, screen capture, and network telemetry - Core filter: process tree creates `C:\ProgramData\output` or screenshot folders like `.\2026-06-10_12-30-00\0.png`, then connects over `AMQP`, `RabbitMQ`, `Redis`, or remote-control TCP traffic. Pivot: correlate these events with raw disk writes, service manager commands, registry manager commands, or firewall rule creation by the same binary.
+  Windows event log telemetry - Core filter: process attempts to clear `System`, `Setup`, `Application`, `ForwardedEvents`, or `Security.evtx` after the OneDrive task appears. Correlation: treat log clearing as supporting context only unless the same lineage also shows `\\.\PHYSICALDRIVE*`, `.candy`, `bcdedit`, boot file deletion, or fake-ransomware encryption.
+---
+# H229
+
+Microsoft reported GigaWiper as a Windows Go backdoor observed in destructive intrusions since October 2025. The implant combines remote access, system management, screen capture, RabbitMQ and Redis command handling, raw disk wiping, boot sabotage, and fake ransomware encryption that does not preserve a recovery path.
+
+The best hunting angle is not the C2 address or the sample hash. GigaWiper has to create persistence and state before it can receive destructive commands. Microsoft described a scheduled task named OneDrive Update and a registry key at HKCU\\SOFTWARE\\OneDrive\\Environment, followed by activity such as raw physical drive writes, .candy file renames, screen recording under ProgramData, event-log clearing, recovery control changes, and remote-control firewall rule creation.
+
+## Why
+
+- GigaWiper is current destructive tradecraft from Microsoft reporting, and the proposed hunt starts before the wipe command lands by looking at the persistence and state the implant needs to keep running.
+- The chain survives IP and hash rotation because the implant still needs a recurring task, the HKCU OneDrive state key, command traffic, and destructive disk or boot operations to complete the same objective.
+- The telemetry is available in common MDR data sets: process creation, scheduled task changes, registry writes, file operations, network connections, and Windows event-log activity on the endpoint.
+- False positives are controllable because normal OneDrive, backup, and admin tooling do not combine fake OneDrive persistence, raw physical drive writes, screen capture, event-log clearing, and fake-ransomware file renames in one lineage.
+
+## References
+
+- [Microsoft Security Blog: GigaWiper: Anatomy of a destructive backdoor assembled from multiple malware](https://www.microsoft.com/en-us/security/blog/2026/07/09/gigawiper-anatomy-of-a-destructive-backdoor-assembled-from-multiple-malware/)
+- [Malwarebytes: This new Windows malware can take over your PC and wipe it clean](https://www.malwarebytes.com/blog/news/2026/07/this-new-windows-malware-can-take-over-your-pc-and-wipe-it-clean)
+- [MITRE ATT&CK: Scheduled Task/Job: Scheduled Task](https://attack.mitre.org/techniques/T1053/005/)
+- [MITRE ATT&CK: Data Destruction](https://attack.mitre.org/techniques/T1485/)


### PR DESCRIPTION
## Summary

Adds `H224`: GigaWiper OneDrive Update Persistence Before Destructive Commands.

## Sources

- https://www.microsoft.com/en-us/security/blog/2026/07/09/gigawiper-anatomy-of-a-destructive-backdoor-assembled-from-multiple-malware/

## Validation

- Draft reviewed locally before submission.
- Source links are preserved in the hunt writeup.
