### PR TITLE
Add H230: Entra OAuth Client ID Spoofing in ROPC Token Requests

### DIFF
--- a/Flames/H230.md
+++ b/Flames/H230.md
@@ -1,0 +1,55 @@
+---
+id: H230
+category: Flames
+title: Entra OAuth Client ID Spoofing in ROPC Token Requests
+hypothesis: >-
+  An adversary submits Microsoft Entra ROPC token requests with spoofed or unregistered OAuth client IDs to validate passwords, leaving blank app identifiers and AADSTS700016 failures before later cloud access.
+tactics:
+  - Credential Access
+  - Initial Access
+techniques:
+  - T1110.004
+  - T1078.004
+tags:
+  - microsoft_entra_id
+  - oauth
+  - ropc
+  - aadsts700016
+  - cloud_identity
+  - password_spraying
+submitter:
+  name: Joshua Strickland
+  link: https://novasky.io
+required_data_sources:
+  - Microsoft Entra sign-in logs
+  - Microsoft Entra non-interactive sign-in logs
+  - Identity provider authentication telemetry
+  - Microsoft 365 audit logs
+  - Microsoft Graph activity logs
+false_positive_notes: |
+  Misconfigured or retired legacy applications can produce unrecognized client ID errors, but they usually affect a small account set and known app owners. Developer testing can leave app name or app ID gaps. The stronger signal is breadth across many users or tenants, password-grant flow, and later same-account resource access. Authorized password testing should have a known source range and change record. Treat unknown infrastructure, randomized client IDs, and alphabetical username progression as higher risk.
+notes: |
+  Entra sign-in logs - Core filter: authentication flow `Resource Owner Password Credentials` or grant type `password` with result or error `AADSTS700016`. Triage values: `application ID`, `application display name`, `source IP address`, `user agent`, `session ID`, `client request ID`, `username`. Pivot: group by `source IP address`, `user agent`, and `tenant` to find breadth across many users. Strong red flags: `application ID` blank, `application display name` blank, or many unique client IDs with the same request pattern.
+  
+  Non-interactive sign-in logs - Core filter: repeated password-grant attempts where the app identity is missing or the app name is empty. Triage values: `username`, `result code`, `failure reason`, `conditional access result`, `MFA requirement`, `source IP address`. Correlation: look for the same `username` moving from `AADSTS700016` to successful cloud access from the same infrastructure or user agent. Strong red flags: alphabetical username ordering, initial-plus-surname patterns like `jsmith`, or many tenants hit by the same request shape.
+  
+  Microsoft 365 and Graph activity - Core filter: mailbox, file, or Graph reads after the ROPC validation sequence. Triage values: `session ID`, `client request ID`, `resource name`, `operation name`, `user agent`, `source IP address`. Pivot: correlate later Exchange, SharePoint, OneDrive, Teams, or Graph activity to prior ROPC failures for the same account. Strong red flags: resource access without a fresh interactive sign-in, new ASN or proxy infrastructure, and data reads shortly after `AADSTS700016`.
+  
+  Identity investigation - False positive: legacy app testing can produce unrecognized-client errors, but it should be limited to one app team, a small set of accounts, and known test infrastructure. Escalate when blank app identity, ROPC, `AADSTS700016`, breadth across users, and later resource access appear together.
+---
+# H230
+
+Proofpoint reporting, summarized by Infosecurity and Help Net Security, describes campaigns using Microsoft Entra OAuth client ID spoofing against millions of users across thousands of tenants. The technique sends POST requests to the Microsoft OAuth token endpoint through the Resource Owner Password Credentials flow. Entra returns different errors depending on the username, password, and client ID state. AADSTS700016 can mean the username and password were correct but the submitted client ID was unrecognized. The log may show a blank application name or no application ID, which can make per-application alerting miss the credential validation step.
+
+## Why
+
+- Proofpoint reporting described multiple campaigns using this technique against Entra tenants, including one that reached more than a million users across nearly 4,000 tenants and another that reached more than 2 million users.
+- The hunt is not tied to an IP, domain, or lure. It follows the required OAuth behavior: password-grant token requests, spoofed or missing app identity, AADSTS700016, and later cloud resource access.
+- Most MDR teams already collect Entra sign-in and Microsoft 365 audit data. The core fields are portable: application identity, result code, source IP address, user agent, session ID, and client request ID.
+- False positives are controllable because app misconfiguration usually stays narrow, while this tradecraft spreads across many users, many fake client IDs, or repeated username patterns.
+
+## References
+
+- [Infosecurity Magazine - Novel OAuth Client ID Spoofing Technique Targets Cloud Environments](https://www.infosecurity-magazine.com/news/novel-spoofing-technique-targets/)
+- [Help Net Security - Fake OAuth client IDs are helping attackers slip past sign-in logs](https://www.helpnetsecurity.com/2026/07/13/entra-id-oauth-client-id-spoofing/)
+- [Microsoft Learn - Microsoft identity platform and OAuth 2.0 Resource Owner Password Credentials](https://learn.microsoft.com/en-us/entra/identity-platform/v2-oauth-ropc)


### PR DESCRIPTION
## Summary

Adds `H230`: Entra OAuth Client ID Spoofing in ROPC Token Requests.

## Sources

- https://www.infosecurity-magazine.com/news/novel-spoofing-technique-targets/

## Validation

- Draft reviewed locally before submission.
- Source links are preserved in the hunt writeup.
