### PR TITLE
fix(ci): fail hunt-ID collision check closed on empty origin/main

### DIFF
--- a/scripts/check_hunt_id_collisions.py
+++ b/scripts/check_hunt_id_collisions.py
@@ -8,6 +8,9 @@ Run on a PR with the head checked out and ``origin/main`` fetched. Detects:
      contributor's hunt overwritten by a different hunt under the same ID,
   4. two files in the working tree sharing an ID.
 
+Fails closed if ``origin/main`` yields no hunts, since an empty baseline (an
+unresolved base ref) would otherwise let every colliding ID pass.
+
 Exits 1 (printing each problem) on any collision, else 0.
 """
 
@@ -78,6 +81,20 @@ def _show_main(path: str) -> str:
 
 
 def main() -> int:
+    # Establish the baseline first, and fail closed if it looks empty. ``main``
+    # always has hunts, so an empty result means ``origin/main`` didn't resolve
+    # (e.g. the remote-tracking ref wasn't populated in a fork-PR runner) rather
+    # than a genuinely clean base. Trusting it would let every colliding ID pass.
+    main_out = _git("ls-tree", "-r", "--name-only", "origin/main", "--", *DIRS)
+    main_ids = {Path(p).stem for p in main_out.splitlines() if p.endswith(".md")}
+    if not main_ids:
+        print(
+            "Hunt ID collision check FAILED: found no hunts on origin/main. "
+            "The base didn't resolve (is origin/main fetched?); refusing to pass "
+            "against an empty baseline."
+        )
+        return 1
+
     added_out = _git(
         "diff", "--diff-filter=A", "--name-only", "origin/main...HEAD", "--", *DIRS
     )
@@ -96,9 +113,6 @@ def main() -> int:
         pr_id, pr_submitter = extract_identity(p.read_text(encoding="utf-8"), p.stem)
         _, main_submitter = extract_identity(_show_main(p.as_posix()), p.stem)
         modified.append((p.stem, pr_id, pr_submitter, main_submitter))
-
-    main_out = _git("ls-tree", "-r", "--name-only", "origin/main", "--", *DIRS)
-    main_ids = {Path(p).stem for p in main_out.splitlines() if p.endswith(".md")}
 
     all_stems = [p.stem for d in DIRS for p in Path(d).glob("*.md")]
 

--- a/scripts/tests/test_check_hunt_id_collisions.py
+++ b/scripts/tests/test_check_hunt_id_collisions.py
@@ -1,5 +1,6 @@
 """Tests for identity extraction used by the hunt-ID collision check."""
 
+from scripts import check_hunt_id_collisions as collisions
 from scripts.check_hunt_id_collisions import extract_identity
 
 # The original H210 as it lived on main: legacy table format, submitter th3CyF0x.
@@ -62,3 +63,11 @@ def test_extract_identity_handles_garbage():
     declared, submitter = extract_identity("not a hunt file", "H999")
     assert declared is None
     assert submitter is None
+
+
+def test_main_fails_closed_when_origin_main_empty(monkeypatch, capsys):
+    # When origin/main resolves to no hunts (e.g. the base ref wasn't fetched in
+    # a fork-PR runner), the check must fail rather than pass every ID through.
+    monkeypatch.setattr(collisions, "_git", lambda *args: "")
+    assert collisions.main() == 1
+    assert "no hunts on origin/main" in capsys.readouterr().out


### PR DESCRIPTION
## What

The hunt-ID collision check builds its baseline from `git ls-tree origin/main`. If that resolves to **no hunts** — which happens in a fork-PR runner where the `origin/main` remote-tracking ref isn't populated — `main_ids` is empty and `find_id_problems` reports no collision, so every added ID passes.

This is the false-pass that let **#339 (H224)** report `validate: success` and merge-clean against a `main` that already contained H224.

## Fix

Compute `main_ids` first in `main()` and **fail closed** if it's empty — `main` always has hunts, so an empty baseline means the base ref didn't resolve, not that the tree is clean.

```
main_ids populated -> collision detected        # correct, unchanged
main_ids EMPTY     -> FAIL (was: pass silently)  # this PR
```

## Testing

- New regression test: `main()` returns 1 and prints the fail-closed message when `origin/main` yields nothing (monkeypatched `_git`).
- Full suite green: `test_check_hunt_id_collisions.py` + `test_hunt_ids.py` (19 passed).
- Happy path unchanged: run against the real populated `main` still prints "passed" / exit 0.

## Scope

This closes **Gap 1** from #341. Gap 2 (no recheck when `main` advances → wants branch protection with "require branches up to date before merging") is config, tracked separately in the issue.

Closes #341

🤖 Generated with [Claude Code](https://claude.com/claude-code)