### PR TITLE
ci: run Validate Hunt Schema on every PR

### DIFF
--- a/.github/workflows/validate-hunt-schema.yml
+++ b/.github/workflows/validate-hunt-schema.yml
@@ -1,15 +1,10 @@
 name: Validate Hunt Schema
 
 on:
+  # Run on every PR (no path filter) so this can be a required status check
+  # without hanging PRs that don't touch hunt files. The collision check and
+  # schema validation are cheap and no-op when nothing relevant changed.
   pull_request:
-    paths:
-      - "Flames/**.md"
-      - "Embers/**.md"
-      - "Alchemy/**.md"
-      - "scripts/hunt_parser.py"
-      - "scripts/hunt_schema.py"
-      - "scripts/cti_extract.py"
-      - "scripts/tests/**"
   push:
     branches: [main]
     paths:


### PR DESCRIPTION
Prep for making `validate` a required status check on `main` (part of #341, Gap 2).

## Why
`validate` (which runs the hunt-ID collision check) is currently path-filtered to hunt files. If it were required as-is, any PR that doesn't touch `Flames/Embers/Alchemy` (workflow/script/docs PRs — which are common here) would hang forever on "Expected — waiting for validate". Dropping the `pull_request` paths filter makes the check report on every PR.

## Change
- `pull_request:` now runs on all PRs (no paths filter).
- `push:` trigger unchanged (still filtered to hunt dirs on main).
- The collision check and schema validation are cheap (~15s) and no-op when nothing relevant changed.

## Next
Once merged, I'll create a ruleset on `main` requiring `validate` + "branches up to date before merging", with the GitHub Actions app bypassed so the nightly direct-push workflows keep working.

Refs #341

🤖 Generated with [Claude Code](https://claude.com/claude-code)