### PR TITLE
ci: sweep open PRs for hunt-ID collisions when main advances

### DIFF
--- a/.github/workflows/recheck-open-prs.yml
+++ b/.github/workflows/recheck-open-prs.yml
@@ -1,0 +1,42 @@
+name: Recheck open PRs for hunt-ID collisions
+
+# When a hunt lands on main it can retroactively collide with an open PR that
+# was green when last checked. The per-PR validate check only re-runs on head
+# changes, not when main moves — so this sweep replays the collision check for
+# every open PR against the new main and reports a hunt-id-recheck status.
+on:
+  push:
+    branches: [main]
+    paths:
+      - "Flames/**.md"
+      - "Embers/**.md"
+      - "Alchemy/**.md"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  statuses: write
+  pull-requests: read
+
+concurrency:
+  group: recheck-open-prs
+  cancel-in-progress: true
+
+jobs:
+  recheck:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
+        with:
+          python-version: "3.11"
+      - run: pip install -r requirements.txt
+      - name: Recheck open PRs against current main
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          RUNNER_TEMP: ${{ runner.temp }}
+        run: python scripts/recheck_open_prs.py

--- a/scripts/recheck_open_prs.py
+++ b/scripts/recheck_open_prs.py
@@ -1,0 +1,125 @@
+#!/usr/bin/env python3
+"""Re-run the hunt-ID collision check against every open PR.
+
+Runs on ``push`` to ``main``. When a hunt lands on main it can retroactively
+collide with an open PR that was green when it was last checked (the per-PR
+``validate`` check only re-runs when the PR head changes, not when main moves).
+This sweep closes that staleness window: for each open PR it replays
+``check_hunt_id_collisions.py`` with the PR head checked out against the current
+main, and reports the result as a ``hunt-id-recheck`` commit status on the PR.
+
+The status is advisory — it surfaces a now-stale collision as a red check on the
+PR so it isn't merged blind; it does not hard-block the merge. Reassigning the
+PR's hunt ID (and rebasing) clears it.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+REPO = os.environ["GITHUB_REPOSITORY"]  # "owner/repo"
+CHECK = Path(__file__).resolve().parent / "check_hunt_id_collisions.py"
+TMP = Path(os.environ.get("RUNNER_TEMP", "/tmp"))
+
+STATUS_CONTEXT = "hunt-id-recheck"
+
+
+def _run(*args: str, check: bool = True) -> subprocess.CompletedProcess:
+    return subprocess.run(args, check=check, capture_output=True, text=True)
+
+
+def _open_prs() -> list[dict]:
+    out = _run(
+        "gh",
+        "pr",
+        "list",
+        "--state",
+        "open",
+        "--limit",
+        "200",
+        "--json",
+        "number,headRefOid",
+    ).stdout
+    return json.loads(out)
+
+
+def _post_status(sha: str, state: str, description: str) -> None:
+    _run(
+        "gh",
+        "api",
+        "--method",
+        "POST",
+        f"repos/{REPO}/statuses/{sha}",
+        "-f",
+        f"state={state}",
+        "-f",
+        f"context={STATUS_CONTEXT}",
+        "-f",
+        f"description={description[:140]}",
+    )
+
+
+def _recheck(number: int, sha: str) -> bool:
+    """Return True if PR #number now collides with main; post its status."""
+    worktree = TMP / f"recheck-pr-{number}"
+    _run("git", "fetch", "origin", f"pull/{number}/head", check=False)
+    _run(
+        "git",
+        "worktree",
+        "add",
+        "--detach",
+        "--force",
+        str(worktree),
+        "FETCH_HEAD",
+        check=False,
+    )
+    try:
+        result = subprocess.run(
+            [sys.executable, str(CHECK)],
+            cwd=worktree,
+            capture_output=True,
+            text=True,
+        )
+    finally:
+        _run("git", "worktree", "remove", "--force", str(worktree), check=False)
+
+    collided = result.returncode != 0
+    if collided:
+        _post_status(
+            sha,
+            "failure",
+            "Hunt ID now collides with main since this PR was opened — "
+            "reassign a free ID and rebase.",
+        )
+        print(f"PR #{number}: COLLISION\n{result.stdout}{result.stderr}")
+    else:
+        _post_status(sha, "success", "No hunt-ID collision with current main.")
+        print(f"PR #{number}: ok")
+    return collided
+
+
+def main() -> int:
+    prs = _open_prs()
+    if not prs:
+        print("No open PRs to recheck.")
+        return 0
+
+    collisions = 0
+    for pr in prs:
+        try:
+            if _recheck(pr["number"], pr["headRefOid"]):
+                collisions += 1
+        except Exception as exc:  # never let one PR abort the sweep
+            print(f"PR #{pr['number']}: recheck errored: {exc}", file=sys.stderr)
+
+    print(f"Rechecked {len(prs)} open PR(s); {collisions} now colliding.")
+    # The signal is carried by per-PR commit statuses, not the workflow result.
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Closes the staleness gap (#341, Gap 2) without branch protection — the bot-safe alternative, since GitHub Actions can't be added as a ruleset bypass actor on this repo (so a required-check gate would break the nightly direct-to-main workflows).

## Problem
The per-PR `validate` check only re-runs when the PR head changes, not when `main` moves. So a PR that was green can silently develop an ID collision once a new hunt lands on `main` under the same ID — exactly what happened to #336/#337 (opened before their IDs existed, collided after the weekly CTI pipeline advanced main).

## What this does
New workflow `recheck-open-prs.yml` triggers on push to `main` touching `Flames/Embers/Alchemy` (and `workflow_dispatch`). For each open PR it replays the existing `check_hunt_id_collisions.py` with the PR head checked out against current `main`, and posts a `hunt-id-recheck` commit status:
- **failure** → the PR's hunt ID now collides with main; reassign + rebase
- **success** → clear

It reuses the already-tested collision logic verbatim (checks the PR head in a throwaway worktree), so behavior matches the PR-time check.

## Advisory, not blocking
The status surfaces a red check on the PR so it isn't merged blind, but doesn't hard-block the merge — no branch protection, no bypass needed, nightly bot pushes unaffected. Pairs with #342 (which fixed the false-pass root cause).

## Verification
- YAML + `py_compile` clean; local dry-run no-ops correctly with 0 open PRs.
- The per-PR worktree+check mechanism is the same one used to reproduce #339's collision.
- End-to-end run (workflow_dispatch against a deliberately-colliding throwaway PR) will be done **after merge**, since the workflow must be on `main` to dispatch; result will be posted here.

Refs #341

🤖 Generated with [Claude Code](https://claude.com/claude-code)