### PR TITLE
[TEST-DO-NOT-MERGE] verify hunt-id-recheck sweep

### DIFF
--- a/Flames/H227.md
+++ b/Flames/H227.md
@@ -1,0 +1,7 @@
+---
+id: H227
+category: Flames
+title: TEST throwaway to verify the recheck-open-prs sweep
+---
+# H227
+Deliberate ID collision for end-to-end testing of the collision sweep. Delete me.


### PR DESCRIPTION
Throwaway PR to end-to-end test the recheck-open-prs sweep (#344). Adds Flames/H227.md which already exists on main → should get a red hunt-id-recheck status. Will be closed immediately after verification.