### PR TITLE
Add H233: AsyncAPI Import-Time Node Loader Persistence

### DIFF
--- a/Flames/H233.md
+++ b/Flames/H233.md
@@ -1,0 +1,63 @@
+---
+id: H233
+category: Flames
+title: AsyncAPI Import-Time Node Loader Persistence
+hypothesis: >-
+  A poisoned npm dependency executes during module import, spawns a detached Node child, writes `sync.js` into a NodeJS masquerade directory, and installs `miasma-monitor` persistence on a developer workstation or build host.
+tactics:
+  - Initial Access
+  - Execution
+  - Persistence
+  - Credential Access
+  - Command and Control
+techniques:
+  - T1195.002
+  - T1059.007
+  - T1105
+  - T1547.001
+  - T1552.001
+tags:
+  - supply_chain
+  - npm
+  - developer_endpoint
+  - ci_cd
+  - nodejs
+  - miasma
+  - ipfs
+  - persistence
+submitter:
+  name: Joshua Strickland
+  link: https://novasky.io
+required_data_sources:
+  - EDR process creation telemetry from developer workstations and build hosts
+  - EDR file creation and module execution telemetry
+  - "Endpoint registry, launch item, shell profile, and systemd user persistence telemetry"
+  - Endpoint network connection telemetry
+  - Repository audit logs
+  - CI workflow logs and package publishing audit logs
+false_positive_notes: |
+  Node-heavy developer hosts are noisy, so do not alert on package import or Node child processes alone. Require the ordered chain of package or build-tool lineage, detached Node execution, `sync.js` creation in a NodeJS masquerade directory, and `miasma-monitor` persistence or IPFS retrieval. IPFS, Ethereum RPC, Nostr, BitTorrent DHT, and libp2p can be legitimate in some projects, but they should not appear from `sync.js` immediately after a package import chain. Trusted publishing and bot pushes can be normal release activity, so treat repository evidence as scoping context unless it lines up with the risky workflow and poisoned package versions.
+notes: |
+  Endpoint process telemetry - Core filter: `node`, `node.exe`, `npm`, `yarn`, `pnpm`, or a build tool spawning a detached child after package import. Triage values: `process command line`, `parent process command line`, `working directory`, `package cache path`, `user account`. Pivot: join the child process to file writes under `node_modules`, `%LOCALAPPDATA%\NodeJS`, `~/Library/Application Support/NodeJS`, `~/.local/share/NodeJS`, or `~/.config/NodeJS`. Strong red flags: a child `node` process executing `sync.js` outside the project tree with hidden window or ignored stdio behavior.
+  Endpoint file and persistence telemetry - Core filter: creation or execution of `sync.js` from a NodeJS masquerade directory, then persistence named `miasma-monitor`. Triage values: `file path`, `registry key path`, `launch agent path`, `systemd user unit path`, `file signer`, `process hash`. Pivot: Windows `HKCU\Software\Microsoft\Windows\CurrentVersion\Run`, Linux `miasma-monitor.service`, macOS `.zshrc`, `.bashrc`, or `.bash_profile`. Strong red flags: package import lineage plus a persistence write by `node` or `sync.js`.
+  Endpoint network telemetry - Core filter: `node` or `sync.js` retrieving a second stage from `ipfs.io/ipfs/`, CID `Qmet4fhsAaWMBUxNDfREHwgiyDeSWy4YSYs9wiKUW5jGyf`, CID `QmQobZSp1wRPrpSEQ56qnyq7ecZh5Bg5k1fnjt4SUwwHb9`, or connecting to `85.137.53.71` on `8080`, `8081`, or `8091`. Triage values: `destination host`, `destination IP address`, `destination port`, `process command line`, `parent process command line`. Correlation: IPFS retrieval followed by local `sync.js` execution and `miasma-monitor` persistence. Strong red flags: fallback traffic to Ethereum RPC, Nostr relay, BitTorrent DHT, or libp2p after the local loader chain.
+  Repository and CI workflow logs - Core filter: `pull_request_target` workflow execution that checks out an untrusted pull request head while secrets or persisted checkout credentials are available. Triage values: `workflow name`, `pull request number`, `actor`, `commit SHA`, `bot account`, `branch name`, `release tag`. Pivot: PR `#2155`, commit `47be388`, bot-authenticated pushes, release branches `next` or `schema`, and trusted publishing releases for `@asyncapi/specs@6.11.2`, `@asyncapi/specs@6.11.2-alpha.1`, `@asyncapi/generator@3.3.1`, `@asyncapi/generator-helpers@1.1.1`, or `@asyncapi/generator-components@0.7.1`. False positive: release workflows are normal, but a risky PR workflow followed by bot pushes and package publication is not normal release hygiene.
+---
+# H233
+
+Microsoft reported a coordinated compromise of the @asyncapi npm organization on July 14, 2026. Five package versions across four package names were republished through the normal trusted publishing path after a GitHub Actions pwn request exposed a privileged bot token. The important hunting detail is the trigger. This was not a preinstall or postinstall hook. The poisoned packages ran when a consuming application or developer tool imported the package. The loader spawned a hidden detached Node child, fetched `sync.js` from IPFS, wrote it into OS-specific NodeJS-looking directories, and installed user persistence as `miasma-monitor`. Unit 42 tied the same July campaign to the miasma-train-p1 lineage and documented the NodeJS masquerade paths, lockfile, persistence names, credential targets, and decentralized C2 fallbacks.
+
+## Why
+
+- The July AsyncAPI compromise changed the common npm hunt shape. The package did not need an install script to run, so hunts that only watch preinstall or postinstall hooks can miss the trigger.
+- The behavior survives package and infrastructure rotation because it keys on the required execution chain: import, detached Node child, `sync.js` in NodeJS masquerade paths, user persistence, and second-stage retrieval.
+- The telemetry is available to most MDR programs on developer workstations and build hosts through process, file, persistence, and network events, with repository and CI logs used to scope affected projects.
+- False positives are controllable when the hunt requires the full sequence. Normal package imports do not write `sync.js` into OS profile storage, install `miasma-monitor`, and immediately retrieve an IPFS-hosted second stage.
+
+## References
+
+- [Microsoft Security Blog - Unpacking the AsyncAPI npm supply chain compromise and import-time payload delivery](https://www.microsoft.com/en-us/security/blog/2026/07/15/unpacking-asyncapi-npm-supply-chain-compromise-import-time-payload-delivery/)
+- [Unit 42 - The npm Threat Landscape: Attack Surface and Mitigations](https://unit42.paloaltonetworks.com/monitoring-npm-supply-chain-attacks/)
+- [MITRE ATT&CK T1195.002 - Compromise Software Supply Chain](https://attack.mitre.org/techniques/T1195/002/)
+- [MITRE ATT&CK T1059.007 - JavaScript](https://attack.mitre.org/techniques/T1059/007/)
+- [MITRE ATT&CK T1547.001 - Registry Run Keys / Startup Folder](https://attack.mitre.org/techniques/T1547/001/)


### PR DESCRIPTION
## Summary

Adds `H233`: AsyncAPI Import-Time Node Loader Persistence.

## Sources

- https://www.microsoft.com/en-us/security/blog/2026/07/15/unpacking-asyncapi-npm-supply-chain-compromise-import-time-payload-delivery/

## Validation

- Draft reviewed locally before submission.
- Source links are preserved in the hunt writeup.
