### PR TITLE
Add H238: RenPy Loader temp BAT execution through forfiles and MSBuild

### DIFF
--- a/Flames/H238.md
+++ b/Flames/H238.md
@@ -1,0 +1,67 @@
+---
+id: H238
+category: Flames
+title: RenPy Loader temp BAT execution through forfiles and MSBuild
+hypothesis: >-
+  An adversary hides a loader inside a Ren'Py package so a trojanized installer extracts a temporary BAT file, launches it through `forfiles.exe`, and proxies execution through MSBuild before credential theft.
+tactics:
+  - Initial Access
+  - Execution
+  - Stealth
+  - Credential Access
+  - Command and Control
+techniques:
+  - T1127.001
+  - T1059.003
+  - T1202
+  - T1027
+  - T1055
+  - T1555.003
+tags:
+  - endpoint
+  - windows
+  - renpy_loader
+  - msbuild
+  - forfiles
+  - amatera
+  - etherhiding
+submitter:
+  name: Joshua Strickland
+  link: https://novasky.io
+required_data_sources:
+  - EDR process telemetry
+  - EDR file telemetry
+  - Alternate data stream or file metadata telemetry
+  - EDR module load telemetry
+  - Endpoint network telemetry
+  - Browser credential access telemetry
+false_positive_notes: |
+  MSBuild and Ren'Py can both be legitimate. The discriminator is not the presence of either tool by itself. Prioritize cases where a user-launched installer reads Ren'Py archive files, creates a random temp directory, clears `Zone.Identifier`, uses `forfiles.exe` to rename and call a BAT, then runs MSBuild against a project file from that temp path. Developer builds rarely use that chain, and they should not lead directly into browser credential-store reads or EtherHiding traffic.
+notes: |
+  EDR process telemetry - Core filter: Ren'Py, game installer, archive extraction, or user-launched installer ancestry followed by `forfiles.exe` with `/p` pointing at `%TEMP%` and `/c` invoking `cmd /c ren @file` before calling a BAT. Triage values: `process command line`, `parent process command line`, `file path`, `user`, `host`. Strong red flags: `forfiles.exe` renaming an arbitrary extension to `.bat`, then `conhost.exe --headless` and `cmd.exe` in the same process lineage.
+  
+  EDR file telemetry - Core filter: creation of a fresh `%TEMP%\tmp-*` directory containing `*.bat`, `*.csproj`, `*.props`, or `*.targets` after reads of `data/libwin32.rpa`, `data/.GEg`, or `data/*.E3`. Triage values: `file path`, `original file name`, `creating process`, `parent process command line`. Pivot: inspect for `Nancy.csproj`, `Nancy.csproj.user`, `Internal.props`, and `Nancy.Compile.targets` created within the same extraction window.
+  
+  Alternate data stream telemetry - Core filter: a process writes `Zone.Identifier` with `ZoneId=0` to files it just extracted into `%TEMP%`. Triage values: `file path`, `stream name`, `stream content`, `creating process`. Correlation: require the same host to show temp BAT execution or MSBuild project execution within minutes.
+  
+  MSBuild and .NET loader telemetry - Core filter: `%WINDIR%\Microsoft.NET\Framework*\v4.0.30319\MSBuild.exe` or `%WINDIR%\Microsoft.NET\Framework64\v4.0.30319\MSBuild.exe` launched against `Nancy.csproj` from a user-writable temp path after `MSBUILDENABLEALLPROPERTYFUNCTIONS=1` is set. Pivot: module-load or script telemetry showing `AppDomain.CurrentDomain.Load`, `DefaultEvaluator5`, or `AppDomain.Load`.
+  
+  Endpoint network and credential-access telemetry - Core filter: the MSBuild-descended .NET chain makes Ethereum JSON-RPC `eth_call` requests to `bsc-dataseed.binance.org`, then stages `GollopDevest.dll`, `PavinWide`, or `LanoseThrip`. Correlation: follow the same process lineage into browser credential access such as `Login Data`, `Local State`, `key4.db`, extension data, wallet paths, or messaging-app credential stores. False positive: blockchain JSON-RPC alone is not enough. Require the loader process chain.
+---
+# H238
+
+Malwarebytes reported July 2026 campaigns that use RenPy Loader to deliver Amatera Stealer. The loader abuses Ren'Py packaging to decrypt configuration data and a ZIP archive, writes the contents under `%TEMP%`, clears Mark of the Web by writing `Zone.Identifier` with `ZoneId=0`, and launches a renamed BAT through `forfiles.exe`. The BAT starts a headless console, sets `MSBUILDENABLEALLPROPERTYFUNCTIONS=1`, and runs MSBuild against `Nancy.csproj`. The project files reconstruct a trojanized .NET component, which loads additional stages and uses EtherHiding through Ethereum JSON-RPC before Amatera delivery.
+
+## Why
+
+- Malwarebytes reported this activity in July 2026 and gave enough execution detail to hunt the chain without relying on game names, domains, hashes, or download pages.
+- The behavior survives IOC rotation because the loader still has to decrypt a ZIP, write a temp BAT and MSBuild project, rename and execute the BAT, and proxy code through MSBuild before the stealer runs.
+- The telemetry is observable in common endpoint data sources: process lineage, temp file creation, alternate data stream writes, module-load behavior, outbound HTTP, and browser credential-store access.
+- False positives are controllable because normal Ren'Py games and normal MSBuild use do not usually combine `forfiles.exe`, `cmd /c ren @file`, `conhost.exe --headless`, `MSBUILDENABLEALLPROPERTYFUNCTIONS=1`, and credential-store reads in one chain.
+
+## References
+
+- [Malwarebytes: Fake games spread stealers with RenPy Loader, MSBuild and EtherHiding](https://www.malwarebytes.com/blog/threat-intel/2026/07/fake-games-spread-stealers-with-renpy-loader-msbuild-and-etherhiding)
+- [MITRE ATT&CK T1127.001: Trusted Developer Utilities: MSBuild](https://attack.mitre.org/techniques/T1127/001/)
+- [MITRE ATT&CK T1202: Indirect Command Execution](https://attack.mitre.org/techniques/T1202/)
+- [MITRE ATT&CK T1555.003: Credentials from Web Browsers](https://attack.mitre.org/techniques/T1555/003/)


### PR DESCRIPTION
## Summary

Adds `H238`: RenPy Loader temp BAT execution through forfiles and MSBuild.

## Sources

- https://www.malwarebytes.com/blog/threat-intel/2026/07/fake-games-spread-stealers-with-renpy-loader-msbuild-and-etherhiding

## Validation

- Draft reviewed locally before submission.
- Source links are preserved in the hunt writeup.
