### PR TITLE
Add H240: Chaos msaRAT headless browser C2 after MSI staging

### DIFF
--- a/Command and Control/H240.md
+++ b/Command and Control/H240.md
@@ -1,0 +1,62 @@
+---
+id: H240
+category: Command and Control
+title: Chaos msaRAT headless browser C2 after MSI staging
+hypothesis: >-
+  Chaos operators stage `update_ms.msi` under `ProgramData`, load `lib.dll`, then launch Chrome or Edge in headless mode with remote debugging so WebRTC C2 runs through the browser.
+tactics:
+  - Execution
+  - Stealth
+  - Command and Control
+techniques:
+  - T1105
+  - T1218.007
+  - T1059.003
+  - T1090
+  - T1071.001
+tags:
+  - chaos_ransomware
+  - msarat
+  - chrome_devtools_protocol
+  - webrtc
+  - msi
+  - headless_browser
+submitter:
+  name: Joshua Strickland
+  link: https://novasky.io
+required_data_sources:
+  - Endpoint process creation telemetry with command lines
+  - Endpoint file creation telemetry
+  - Module load telemetry
+  - Browser process command-line telemetry
+  - Process-owned network connection telemetry
+  - Localhost connection telemetry where available
+false_positive_notes: |
+  Legitimate browser automation, QA tools, and some developer workflows can start Chrome or Edge with a remote debugging port. Keep the core filter chained to `curl.exe` MSI staging in `ProgramData`, `msiexec.exe` execution, `lib.dll` loading, and non-browser local control of a new headless browser. Managed software deployment may install MSIs from `ProgramData`, but it should not create a browser debugging C2 path or CDP JavaScript injection behavior.
+notes: |
+  Endpoint process telemetry - Core filter: `curl.exe` writing `C:\ProgramData\update_ms.msi` or `msiexec.exe` executing an MSI from `C:\ProgramData`. Triage values: `process command line`, `parent process command line`, `file path`, `user`, `host`. Pivot: look for `msiexec.exe` custom action behavior and follow-on DLL load from the same installer window. Strong red flags: plain `http://` transfer on port `443`, `update_ms.msi`, and staging outside a managed software deployment path.
+  
+  Module and browser launch telemetry - Core filter: MSI execution followed by `lib.dll` load and Chrome or Edge launched by a non-browser parent. Triage values: `loaded module path`, `process command line`, `parent process name`, `parent process command line`. Pivot: search for browser flags such as `--headless`, `--remote-debugging-port`, `--remote-debugging-address`, and Chrome or Edge started from an unusual parent after the MSI runs. Strong red flags: a newly launched headless browser with a local debugging port immediately after `msiexec.exe` activity.
+  
+  Local browser control telemetry - Core filter: a non-browser process connecting to `127.0.0.1` on the browser debugging port, then issuing CDP style paths or WebSocket control. Triage values: `source process`, `destination IP address`, `destination port`, `process command line`, `user`. Pivot: correlate local debugging connections with browser-owned requests to `/json/list/`, `Target.createTarget`, `Page.setBypassCSP`, `Runtime.addBinding`, or `Runtime.evaluate`. Strong red flags: callbacks or binding names such as `msaOpen`, `msaClose`, `msaError`, `msaMessage`, or `dataAck`.
+  
+  Process-owned network telemetry - Core filter: headless Chrome or Edge making external signaling and WebRTC traffic shortly after local RAT execution. Triage values: `process name`, `process command line`, `destination domain`, `destination IP address`, `user agent`, `parent process name`. Correlation: browser traffic to `workers.dev` style signaling, `HeadlessChrome` user agent, then TURN relay traffic such as `global.turn.twilio.com` after a local debugging session. False positive: browser automation and QA systems can use remote debugging, but they should not follow `curl.exe` MSI staging, `lib.dll` load, and local malware-to-browser control on an end-user host.
+---
+# H240
+
+Cisco Talos reported a Rust-based RAT named msaRAT attributed to the Chaos ransomware group. The infection chain downloads `update_ms.msi` to `C:\ProgramData\update_ms.msi` with `curl.exe`, executes the MSI, and triggers a custom action that loads an embedded `lib.dll` payload. The RAT locates Chrome or Edge, starts the browser in headless mode with a remote debugging port, connects to the browser through Chrome DevTools Protocol, injects JavaScript, and uses the browser to perform Cloudflare Workers signaling and WebRTC DataChannel C2 over Twilio TURN. The RAT process mostly talks to localhost while the external traffic appears as browser-owned activity.
+
+## Why
+
+- Talos tied this behavior to active Chaos ransomware operations and named concrete artifacts: `update_ms.msi`, `C:\ProgramData\update_ms.msi`, `lib.dll`, and CDP binding names such as `msaOpen` and `msaMessage`.
+- The hunt survives IP and domain rotation because the RAT still has to stage an MSI, load the embedded DLL, start a headless browser, and control it through a local debugging channel.
+- MDR teams can observe the chain with standard endpoint telemetry: process creation, file creation, module loads, browser command lines, localhost connections, and process-owned network metadata.
+- False positives are controllable because benign browser automation is not expected to appear immediately after `curl.exe` writes an MSI into `ProgramData` and `msiexec.exe` loads a payload DLL.
+
+## References
+
+- [Cisco Talos: Chaos ransomware msaRAT browser C2](https://blog.talosintelligence.com/chaos-msarat-living-off-the-browser-to-build-covert-c2-channel/)
+- [MITRE ATT&CK T1105 Ingress Tool Transfer](https://attack.mitre.org/techniques/T1105/)
+- [MITRE ATT&CK T1218.007 Msiexec](https://attack.mitre.org/techniques/T1218/007/)
+- [MITRE ATT&CK T1090 Proxy](https://attack.mitre.org/techniques/T1090/)
+- [MITRE ATT&CK T1071.001 Web Protocols](https://attack.mitre.org/techniques/T1071/001/)


### PR DESCRIPTION
## Summary

Adds `H240`: Chaos msaRAT headless browser C2 after MSI staging.

## Sources

- https://blog.talosintelligence.com/chaos-msarat-living-off-the-browser-to-build-covert-c2-channel/

## Validation

- Draft reviewed locally before submission.
- Source links are preserved in the hunt writeup.
