### PR TITLE
Add H239: Starland RAT launching WLDR tasking from pythonw LICENSE.txt

### DIFF
--- a/Flames/H239.md
+++ b/Flames/H239.md
@@ -1,0 +1,61 @@
+---
+id: H239
+category: Flames
+title: Starland RAT launching WLDR tasking from pythonw LICENSE.txt
+hypothesis: >-
+  An adversary uses a weaponized HTA and trojanized NSIS installer to launch Starland RAT through pythonw.exe and LICENSE.txt, then pulls WLDR PowerShell tasking for interactive control.
+tactics:
+  - Execution
+  - Persistence
+  - Discovery
+  - Credential Access
+  - Command and Control
+techniques:
+  - T1218.005
+  - T1059.001
+  - T1053.005
+  - T1547.001
+  - T1055
+  - T1555.003
+tags:
+  - endpoint
+  - clickfix
+  - starland_rat
+  - wldr
+  - powershell
+submitter:
+  name: Joshua Strickland
+  link: https://novasky.io
+required_data_sources:
+  - Endpoint process creation telemetry
+  - Endpoint file creation telemetry
+  - Endpoint registry telemetry
+  - Windows scheduled task telemetry
+  - PowerShell script block or command telemetry
+  - Endpoint network connection telemetry
+false_positive_notes: |
+  Installer wrapping and Python runtimes are common on developer and admin endpoints, but the combined sequence is narrow: remote HTA execution, HKCU Run value MyApp pointing to mshta.exe, pythonw.exe executing LICENSE.txt from a trojanized installer, PythonLauncher-* persistence, domain reconnaissance, and curl or PowerShell loading WLDR. Browser testing and admin scripts may use mshta.exe or PowerShell in isolation, but they should not create this persistence chain or perform the reported Starland reconnaissance before encrypted C2 polling.
+notes: |
+  Endpoint process telemetry - Core filter: `mshta.exe` launched from browser, clipboard, user shell, or script lineage and reaching a remote `.hta` or web path. Triage values: `process command line`, `parent process command line`, `user`, `file path`, `process integrity level`. Pivot: look for a nearby trojanized installer execution such as `MobaXterm_v26.1.exe`, `WebEx_Client.exe`, `Zoom`, `dbeaver-ce-windows-x86_64.exe`, or `FaceitInstaller_x64.exe` followed by `pythonw.exe` running `LICENSE.txt`. Strong red flags: `mshta.exe` persistence, remote HTA execution, installer lineage into `pythonw.exe`, and user-profile temp BAT activity.
+  Registry and scheduled task telemetry - Core filter: writes to `HKCU\Software\Microsoft\Windows\CurrentVersion\Run` with value name `MyApp` pointing back to `mshta.exe`, plus scheduled tasks matching `PythonLauncher-*`. Triage values: `registry key path`, `registry value name`, `registry value data`, `task name`, `task trigger`, `task action`, `run level`. Correlation: require the Run key or `PythonLauncher-*` task to appear before or shortly after `pythonw.exe LICENSE.txt`. Strong red flags: `AtLogOn`, `RunLevel Highest`, startup LNK creation through `WScript.Shell`, and `ShellExecuteW` with `runas`.
+  Discovery and credential-access telemetry - Core filter: `pythonw.exe` or its PowerShell child executes `Get-CimInstance -Class Win32_ComputerSystemProduct.UUID`, `wmic memorychip get Capacity`, `Get-CimInstance -Namespace root/SecurityCenter2 -ClassName AntiVirusProduct`, `Get-WmiObject Win32_ComputerSystem.Domain`, `whoami`, `systeminfo`, `net user /dom`, `nltest /dclist`, or `whoami /all`. Triage values: `process command line`, `parent process command line`, `working directory`, `user`, `host name`. Pivot: check for browser credential-store or cryptocurrency wallet enumeration from the same process tree. Strong red flags: reconnaissance output staged with a screenshot or JSON file before outbound HTTP POST activity.
+  PowerShell and network telemetry - Core filter: `curl` or PowerShell downloads the WLDR stager, then PowerShell executes obfuscated Base64 or XOR decode logic and polls a C2 path carrying a hardware identifier derived from the C: drive volume serial number. Triage values: `process command line`, `script content`, `destination host`, `request path`, `user agent`, `HTTP method`, `process-owned connection`. Correlation: tie `curl` download, PowerShell stager execution, and follow-on encrypted polling to prior Starland `pythonw.exe` activity on the same host. Strong red flags: `RunspacePool`, `WSv1`, `PBKDF2`, `AES-256-CBC`, 10 second polling, or 50 to 60 second Starland polling from the same infection chain.
+---
+# H239
+
+Cisco Talos reported UAT-11795 activity targeting users in the United States and Europe since at least June 2025. The campaign uses ClickFix-style HTA execution, trojanized installers for tools such as MobaXterm, WebEx, Zoom, DBeaver, and FACEIT, a Python-based RAT tracked as Starland RAT, and a PowerShell C2 implant tracked as WLDR. The stronger hunting angle is the ordered execution chain: mshta.exe runs a remote HTA, the HTA establishes HKCU Run persistence with the value MyApp, an NSIS installer executes pythonw.exe with LICENSE.txt, Starland performs host and domain reconnaissance, then a curl-launched PowerShell stager loads WLDR in memory.
+
+## Why
+
+- Talos described an active financially motivated campaign with a repeatable chain from ClickFix-style HTA execution to trojanized NSIS installers, Starland RAT, and WLDR PowerShell tasking. That gives hunters several ordered pivots before later payload delivery.
+- The hunt keys on remote HTA execution, the MyApp Run key, pythonw.exe executing LICENSE.txt, PythonLauncher-* scheduled tasks, and Starland reconnaissance from the same process tree instead of relying on replaceable infrastructure.
+- The telemetry is available to most MDR teams through endpoint process, registry, scheduled task, PowerShell, file, and process-owned network events. The network indicators enrich the case, but the behavior chain carries the detection.
+- False positives are controllable because legitimate installers rarely combine mshta.exe persistence, a disguised Python loader, domain reconnaissance commands, wallet or browser credential access, and a curl-launched PowerShell C2 stager on the same host.
+
+## References
+
+- [Cisco Talos: UAT-11795 deploys novel Starland RAT and bespoke WLDR C2 implant in financially motivated campaign](https://blog.talosintelligence.com/uat-11795-deploys-novel-starland-rat-and-bespoke-wldr-c2-implant-in-financially-motivated-campaign/)
+- [MITRE ATT&CK T1218.005: Mshta](https://attack.mitre.org/techniques/T1218/005/)
+- [MITRE ATT&CK T1059.001: PowerShell](https://attack.mitre.org/techniques/T1059/001/)
+- [MITRE ATT&CK T1053.005: Scheduled Task](https://attack.mitre.org/techniques/T1053/005/)
+- [MITRE ATT&CK T1547.001: Registry Run Keys and Startup Folder](https://attack.mitre.org/techniques/T1547/001/)


### PR DESCRIPTION
## Summary

Adds `H239`: Starland RAT launching WLDR tasking from pythonw LICENSE.txt.

## Sources

- https://blog.talosintelligence.com/uat-11795-deploys-novel-starland-rat-and-bespoke-wldr-c2-implant-in-financially-motivated-campaign/

## Validation

- Draft reviewed locally before submission.
- Source links are preserved in the hunt writeup.
