### PR TITLE
Add H248: Microsoft Graph calendar events used as a command channel

### DIFF
--- a/Flames/H248.md
+++ b/Flames/H248.md
@@ -1,0 +1,55 @@
+---
+id: H248
+category: Flames
+title: Microsoft Graph calendar events used as a command channel
+hypothesis: >-
+  An implant with Entra application credentials uses Microsoft Graph to read command attachments from far-future Outlook events, delete them after use, and write encrypted results back to the same mailbox.
+tactics:
+  - Command and Control
+  - Credential Access
+  - Persistence
+techniques:
+  - T1078.004
+  - T1102.002
+  - T1550.001
+tags:
+  - microsoft_graph
+  - outlook
+  - entra_id
+  - cav3rn
+  - oilrig
+  - calendar_c2
+  - dns_aaaa_recovery
+submitter:
+  name: Joshua Strickland
+  link: https://novasky.io
+required_data_sources:
+  - Entra application sign-in logs
+  - Microsoft Graph activity logs
+  - Mailbox audit logs
+  - DNS query telemetry
+  - Endpoint module-load telemetry
+  - Endpoint file telemetry
+false_positive_notes: |
+  Legitimate Graph integrations and backup tools can read calendars, create events, and upload attachments. Keep the first pass broad, then require multiple CAV3RN-specific anchors before escalating: the fixed 2050 one-hour window, the Event ID or Boss subject prefixes, command attachment delete behavior, client-credentials Graph access, and .p/.q AAAA recovery queries. Graph calendar traffic alone is too broad for an alert.
+notes: |
+  Entra application sign-in logs - Core filter: successful client credentials token requests where `grant_type=client_credentials` and `scope=https://graph.microsoft.com/.default`. Triage values: `application ID`, `tenant ID`, `service principal`, `source IP address`, `user agent`, `correlation ID`. Pivot: look for the same application calling `/v1.0/organization`, then mailbox calendar APIs without normal business app context. Strong red flags: newly observed application credential use followed by calendar access to a specific mailbox.
+  Microsoft Graph and mailbox audit logs - Core filter: calendar reads and writes against a far-future fixed window, especially `calendarView` with `startDateTime=2050-05-13T22:00:00` and `endDateTime=2050-05-13T23:00:00`. Triage values: `mailbox`, `application ID`, `client request ID`, `event subject`, `attachment name`, `event ID`. Correlation: match `GET /v1.0/users/<mailbox>/calendarView`, `GET /v1.0/users/<mailbox>/events/<event-id>/attachments`, `DELETE /v1.0/users/<mailbox>/calendar/events/<event-id>`, `POST /v1.0/users/<mailbox>/calendar/events`, and `PATCH /v1.0/users/<mailbox>/events/<event-id>`. Strong red flags: subjects `Event ID:`, `Boss update ID:`, or `Boss Report ID:` with attachment names `file0.txt` or `File0.txt`.
+  DNS telemetry - Core filter: AAAA lookups for subdomains matching the recovery shape `d.<hex-implant-id>.<field-index>.p.<host>` or `d.<hex-implant-id>.<field-index>.<offset>.q.<host>`. Triage values: `query name`, `record type`, `response address`, `source host`, `process name`, `resolver`. Pivot: sequence `.p` length requests before `.q` data-fragment requests for field indexes `0`, `1`, `2`, and `3`. Strong red flags: AAAA responses used as structured data, including sentinel `2001:4998:44:3507::8000`, followed by renewed Microsoft Graph token activity.
+  Endpoint file and module telemetry - Core filter: processes loading `AzureCommunication.dll` or Native AOT DLLs that write or read `logAzure.txt` from the current working directory. Triage values: `process command line`, `parent process command line`, `module path`, `file path`, `working directory`, `hash`. Correlation: endpoint execution that touches `logAzure.txt` near Graph client credentials token requests or the calendar event sequence. False positive: business applications can use Graph calendars, but they should not combine a local config file named `logAzure.txt`, 2050 calendar dead drops, command attachment deletion, and DNS AAAA configuration recovery.
+---
+# H248
+
+Securelist reported a Project CAV3RN communication module named AzureCommunication.dll. The module is compiled with .NET Native AOT and exposes QueryInterface for get and send operations. It stores Microsoft Entra tenant ID, client ID, client secret, mailbox, DNS bootstrap host, and RSA key material in a local logAzure.txt configuration file or hard-coded defaults. The module obtains a client credentials token for Microsoft Graph with grant_type=client_credentials and scope=https://graph.microsoft.com/.default, validates access with GET /v1.0/organization, then uses one mailbox calendar as a dead-drop channel. Commands, heartbeats, and results all use the fixed calendar window 2050-05-13T22:00:00 to 2050-05-13T23:00:00 UTC. Operator commands use Event ID: <implant-id>, heartbeats use Boss update ID: <implant-id>1500, and results use Boss Report ID: <implant-id>1500. When Microsoft Graph authentication or tenant validation fails, the module falls back to DNS AAAA queries under cloudlanecdn.com to recover tenant ID, client ID, client secret, and user email values through .p length requests and .q data-fragment requests.
+
+## Why
+
+- The source describes an active Project CAV3RN module that moved C2 into Outlook calendar events through Microsoft Graph, which puts the command channel in telemetry many MDRs can request from Microsoft 365 and Entra.
+- The hunt survives hash, domain, and mailbox rotation because the channel needs the fixed behavior chain: client-credentials token use, /organization validation, calendarView access to the 2050 window, attachment handling, event deletion, and result event creation.
+- False positives are controllable because normal Graph calendar applications should not use the 2050-05-13 window with Event ID, Boss update ID, or Boss Report ID subjects and then run DNS AAAA recovery for Graph configuration fields.
+- Endpoint telemetry gives a second angle when available: AzureCommunication.dll and logAzure.txt can connect the Microsoft 365 activity back to a process tree on a host.
+
+## References
+
+- [New Project CAV3RN module abuses Outlook calendar events for C2 and DNS AAAA records for configuration recovery](https://securelist.com/project-cav3rn-cyberespionage-framework-using-outlook-and-dns/120757/)
+- [List calendarView - Microsoft Graph v1.0](https://learn.microsoft.com/en-us/graph/api/user-list-calendarview?view=graph-rest-1.0)


### PR DESCRIPTION
## Summary

Adds `H248`: Microsoft Graph calendar events used as a command channel.

Filed under the canonical `Flames` category.

## Sources

- https://securelist.com/project-cav3rn-cyberespionage-framework-using-outlook-and-dns/120757/

## Validation

- Rebased onto current `main`.
- Hunt ID collision check passed.
- Hunt parser, schema, and ID tests passed.
- Source links are preserved in the hunt writeup.
