### PR TITLE
Add H251: AsyncAPI import-time Node staging before developer token theft

### DIFF
--- a/Flames/H251.md
+++ b/Flames/H251.md
@@ -1,0 +1,66 @@
+---
+id: H251
+category: Flames
+title: AsyncAPI import-time Node staging before developer token theft
+hypothesis: >-
+  A poisoned AsyncAPI package runs during Node import, stages `sync.js` under a user-writable NodeJS directory, then reads developer or CI credentials for follow-on API access.
+tactics:
+  - Initial Access
+  - Execution
+  - Persistence
+  - Command and Control
+  - Credential Access
+techniques:
+  - T1195.001
+  - T1195.002
+  - T1059.007
+  - T1105
+  - T1552.001
+  - T1555.003
+  - T1547.001
+tags:
+  - supply_chain
+  - npm
+  - nodejs
+  - developer_workstation
+  - ci_cd
+  - credential_access
+  - ipfs
+submitter:
+  name: Joshua Strickland
+  link: https://novasky.io
+required_data_sources:
+  - Endpoint process creation telemetry from developer workstations and CI runners
+  - Endpoint file creation and sensitive-file access telemetry
+  - Endpoint network connection telemetry for Node and package manager processes
+  - Windows registry telemetry for user Run key writes
+  - Linux and macOS user persistence file telemetry
+  - Source-control and package-registry audit logs
+  - "Cloud, source-control, and package-registry token-use audit logs"
+false_positive_notes: |
+  Node builds and local development workflows spawn many child processes. Do not alert on child Node execution by itself. Require the import-time lineage plus at least one hard artifact: `sync.js` in a masqueraded `NodeJS` user directory, one of the IPFS content paths, `miasma-monitor` persistence, sensitive credential-file reads, or follow-on token use. Legitimate IPFS usage is uncommon in most enterprise build environments, but treat it as supporting evidence rather than the only signal.
+notes: |
+  Endpoint process telemetry - Core filter: `node` or `node.exe` launched from a build, test, application startup, `npm`, `yarn`, or `pnpm` lineage and spawning a detached child that outlives the parent. Triage values: `process command line`, `parent process command line`, `working directory`, `user`, `file path`. Pivot: look for inline execution such as `node -e`, hidden-window execution, or a child created during import of `@asyncapi/specs`, `@asyncapi/generator`, `@asyncapi/generator-components`, or `@asyncapi/generator-helpers`. Strong red flags: parent process exits while the child keeps running, Node child has no matching build job purpose, or execution starts from a dependency path rather than a developer command.
+  Endpoint file and persistence telemetry - Core filter: creation or execution of `sync.js` under `%LOCALAPPDATA%\NodeJS`, `~/Library/Application Support/NodeJS`, `~/.local/share/NodeJS`, or `~/.config/NodeJS`. Triage values: `file path`, `initiating process command line`, `file hash`, `user`, `registry key path`. Pivot: correlate with `HKCU\Software\Microsoft\Windows\CurrentVersion\Run` value `miasma-monitor`, Linux `~/.config/systemd/user/miasma-monitor.service`, macOS shell startup file changes such as `.zshrc`, `.bashrc`, or `.bash_profile`, and lock or identity paths under `~/.config/.miasma/`. Strong red flags: `sync.js` written by a Node process that started from a package import, followed by user-space persistence within the same session.
+  Endpoint network telemetry - Core filter: Node processes reaching IPFS gateway paths such as `/ipfs/Qmet4fhsAaWMBUxNDfREHwgiyDeSWy4YSYs9wiKUW5jGyf` or `/ipfs/QmQobZSp1wRPrpSEQ56qnyq7ecZh5Bg5k1fnjt4SUwwHb9`, then later connecting to `85.137.53.71` on `8080`, `8081`, or `8091`. Triage values: `destination IP address`, `destination port`, `URL path`, `process command line`, `parent process command line`. Correlation: require the network event to come from the detached Node child or `sync.js`, not from a browser or package manager doing normal dependency resolution. Strong red flags: IPFS retrieval immediately followed by beacon-like HTTP every 30 seconds.
+  Credential and token telemetry - Core filter: Node or `sync.js` reading developer and CI secret locations such as `.npmrc`, `.netrc`, `.aws/credentials`, `kubeconfig`, `.docker/config.json`, `google_credentials.json`, `.vault-token`, `id_rsa`, or `id_ed25519`. Triage values: `file path`, `process command line`, `user`, `host`, `repository`, `runner job`. Pivot: check package-registry, source-control, and cloud audit logs for token use from the same host or runner after the file reads. Strong red flags: token use that publishes packages, lists repositories, reads secrets, or calls cloud identity APIs after `sync.js` staging.
+---
+# H251
+
+Microsoft reported a coordinated compromise of the AsyncAPI npm organization on July 14, 2026. Five package versions across four package names were republished with malicious loaders: `@asyncapi/specs@6.11.2-alpha.1`, `@asyncapi/specs@6.11.2`, `@asyncapi/generator@3.3.1`, `@asyncapi/generator-components@0.7.1`, and `@asyncapi/generator-helpers@1.1.1`. The loader did not use npm lifecycle hooks. It ran when the poisoned module was imported, spawned a hidden detached `node` child, fetched a second stage from IPFS, and wrote `sync.js` under an OS-specific `NodeJS` user-data directory. Aikido recovered the same chain and noted that the implant had persistence and remote shell capability. BleepingComputer reported that existing lock files and caches could still contain the removed versions after npm cleanup.
+
+## Why
+
+- This campaign bypassed install-script controls because the loader ran when the package was imported. That makes `npm install --ignore-scripts` and hook-only package monitoring insufficient.
+- The hunt survives package and infrastructure rotation because the detection pivot is the required chain: module import, detached Node staging, `sync.js` in a user-writable `NodeJS` path, persistence, and credential access.
+- The telemetry is available in endpoint and CI runner data most MDR teams can collect: process lineage, file writes, registry or user persistence, network connections, and token-use audit logs.
+- False positives are controllable because normal Node development does not write `sync.js` into OS user-data paths, create `miasma-monitor` persistence, fetch IPFS second stages, and read credential stores in the same chain.
+
+## References
+
+- [Microsoft Security Blog - Unpacking the AsyncAPI npm supply chain compromise and import-time payload delivery](https://www.microsoft.com/en-us/security/blog/2026/07/15/unpacking-asyncapi-npm-supply-chain-compromise-import-time-payload-delivery/)
+- [Aikido - AsyncAPI npm packages backdoored via GitHub Actions](https://www.aikido.dev/blog/asyncapi-npm-packages-backdoored-via-github-actions)
+- [BleepingComputer - AsyncAPI npm packages infected with credential-stealing malware](https://www.bleepingcomputer.com/news/security/-asyncapi-npm-packages-infected-with-credential-stealing-malware/)
+- [MITRE ATT&CK T1195.001 - Compromise Software Dependencies and Development Tools](https://attack.mitre.org/techniques/T1195/001/)
+- [MITRE ATT&CK T1059.007 - JavaScript](https://attack.mitre.org/techniques/T1059/007/)
+- [MITRE ATT&CK T1552.001 - Credentials In Files](https://attack.mitre.org/techniques/T1552/001/)


### PR DESCRIPTION
## Summary

Adds `H251`: AsyncAPI import-time Node staging before developer token theft.

Renumbered from `H248` to avoid colliding with the earlier Microsoft Graph calendar C2 PR.

## Sources

- https://cybersecuritynews.com/asyncapi-malware-contains-modules/

## Validation

- Compared against current `main`.
- Hunt ID collision check passed.
- Hunt parser, schema, and ID tests passed.
- Source links are preserved in the hunt writeup.
