### PR TITLE
Add H249: Vidar App-Bound Encryption bypass before multipart exfiltration

### DIFF
--- a/Flames/H249.md
+++ b/Flames/H249.md
@@ -1,0 +1,62 @@
+---
+id: H249
+category: Flames
+title: Vidar App-Bound Encryption bypass before multipart exfiltration
+hypothesis: >-
+  An adversary injects work into browser memory to decrypt Chrome App-Bound Encryption keys, then collects browser credentials, cloud tokens, wallet files, and local files before multipart HTTP exfiltration.
+tactics:
+  - Stealth
+  - Credential Access
+  - Collection
+  - Exfiltration
+techniques:
+  - T1055
+  - T1562.001
+  - T1555.003
+  - T1005
+  - T1041
+tags:
+  - vidar
+  - infostealer
+  - chrome
+  - app_bound_encryption
+  - browser_credentials
+  - multipart_exfiltration
+submitter:
+  name: Joshua Strickland
+  link: https://novasky.io
+required_data_sources:
+  - EDR process telemetry
+  - EDR module-load telemetry
+  - EDR file telemetry
+  - Endpoint network telemetry
+  - Windows security process creation events
+  - "Sysmon process, file, image-load, and network events"
+false_positive_notes: |
+  Browser updaters, password managers, backup tools, and EDR components can touch browser files, but they should not patch `AmsiScanBuffer`, clone browser memory, call `CryptUnprotectMemory` through an injected browser task, and then perform multipart POST exfiltration. Chrome remote debugging and browser automation can read profile data in developer workflows, so keep the correlation on non-browser process memory access, credential-store reads, staging, and outbound transfer from the same process tree.
+notes: |
+  Endpoint process and module telemetry - Core filter: non-browser loader process touching `amsi.dll`, resolving or patching `AmsiScanBuffer`, then interacting with `chrome.exe` or `msedge.exe` memory. Triage values: `process command line`, `parent process command line`, `file path`, `module path`, `process integrity level`. Pivot: require the same process tree to call browser memory operations or spawn a child that accesses browser profile data. Strong red flags: `AmsiScanBuffer`, `amsi.dll`, `NtCreateProcessEx`, `CryptUnprotectMemory`, `chrome.exe`, `msedge.exe`, or a loader with a fabricated or untrusted signature.
+  
+  Endpoint file telemetry - Core filter: reads from browser and credential paths after browser memory access. Triage values: `file path`, `user`, `host`, `process command line`. Pivot: follow the same process tree into reads of `Login Data`, `Cookies`, `Local State`, `cookies.sqlite`, `key4.db`, `.aws`, `.azure`, `msal.cache`, `FileZilla\recentservers.xml`, `WinSCP 2\Sessions`, `Local Extension Settings`, or wallet directories. Strong red flags: browser-store reads from a non-browser process followed by archive staging, screenshot capture, or removable-drive file walking.
+  
+  Endpoint network telemetry - Core filter: outbound HTTP POST from the same loader or staged stealer process after credential and file collection. Triage values: `process command line`, `destination port`, `remote URL`, `user agent`, `source IP address`, `file path`. Correlation: require multipart form submission after browser memory access and credential-store reads. Strong red flags: `multipart/form-data`, Telegram or Steam profile access used before C2 resolution, round-robin HTTP destinations, and POST activity shortly after `Login Data`, `Local State`, `.aws`, or wallet-file reads.
+---
+# H249
+
+Picus reported Vidar 2.0 as a Windows information stealer with a pure C rewrite, multithreaded theft, App-Bound Encryption bypass, and HTTP multipart exfiltration. The important hunting chain is not the loader name or C2. Vidar patches AMSI, clones or scans browser memory for the Chrome v20 master-key marker, uses an APC inside the browser process to run CryptUnprotectMemory, then reads browser stores, wallet paths, cloud CLI credentials, FTP and SSH sessions, screenshots, and local files before sending the loot by multipart POST.
+
+## Why
+
+- Picus reported Vidar 2.0 with an App-Bound Encryption bypass, multithreaded theft, and multipart exfiltration, so the behavior is current and has enough detail for an endpoint hunt.
+- The hunt survives IOC rotation because Vidar still has to reach browser memory, get the ABE master key decrypted inside the browser process, read credential stores, and move collected data out.
+- The telemetry is observable in common endpoint data: process lineage, module loads, file reads from browser and credential paths, and process-owned HTTP POST activity.
+- False positives are controllable by requiring the ordered chain. Browser file reads alone are noisy, but browser memory access plus `AmsiScanBuffer` patching, credential-store reads, and multipart transfer is a much narrower shape.
+
+## References
+
+- [Picus: Vidar Malware: How the Multithreaded Windows Stealer Works](https://www.picussecurity.com/resource/blog/vidar-malware-how-the-multithreaded-windows-stealer-works)
+- [MITRE ATT&CK T1055: Process Injection](https://attack.mitre.org/techniques/T1055/)
+- [MITRE ATT&CK T1562.001: Impair Defenses: Disable or Modify Tools](https://attack.mitre.org/techniques/T1562/001/)
+- [MITRE ATT&CK T1555.003: Credentials from Web Browsers](https://attack.mitre.org/techniques/T1555/003/)
+- [MITRE ATT&CK T1005: Data from Local System](https://attack.mitre.org/techniques/T1005/)
+- [MITRE ATT&CK T1041: Exfiltration Over C2 Channel](https://attack.mitre.org/techniques/T1041/)


### PR DESCRIPTION
## Summary

Adds `H249`: Vidar App-Bound Encryption bypass before multipart exfiltration.

## Sources

- https://www.picussecurity.com/resource/blog/vidar-malware-how-the-multithreaded-windows-stealer-works

## Validation

- Draft reviewed locally before submission.
- Source links are preserved in the hunt writeup.
