### PR TITLE
fix(scripts): stop manual hunt drafts from using OpenAI; bump to Sonnet 5

### DIFF
--- a/scripts/generate_from_cti.py
+++ b/scripts/generate_from_cti.py
@@ -3,6 +3,7 @@ import random
 import re
 import time
 from pathlib import Path
+
 from dotenv import load_dotenv
 from pypdf import PdfReader
 
@@ -37,7 +38,7 @@ load_dotenv()
 AI_PROVIDER = os.getenv("AI_PROVIDER", "claude").lower()
 
 # Claude model configuration - use environment variable or default to latest
-CLAUDE_MODEL = os.getenv("CLAUDE_MODEL", "claude-sonnet-4-5-20250929")
+CLAUDE_MODEL = os.getenv("CLAUDE_MODEL", "claude-sonnet-5")
 
 if AI_PROVIDER == "claude":
     if not CLAUDE_AVAILABLE:
@@ -321,8 +322,8 @@ def summarize_cti_with_map_reduce(text, model="gpt-4", max_tokens=128000):
                 )
                 response = _anthropic_create_with_retries(
                     model=CLAUDE_MODEL,
-                    max_tokens=1024,
-                    temperature=0.2,
+                    max_tokens=2048,
+                    thinking={"type": "disabled"},
                     messages=[{"role": "user", "content": prompt}],
                 )
                 summary = response.content[0].text.strip()
@@ -363,8 +364,8 @@ def summarize_cti_with_map_reduce(text, model="gpt-4", max_tokens=128000):
             )
             final_response = _anthropic_create_with_retries(
                 model=CLAUDE_MODEL,
-                max_tokens=2048,
-                temperature=0.2,
+                max_tokens=4096,
+                thinking={"type": "disabled"},
                 messages=[{"role": "user", "content": prompt}],
             )
             return final_response.content[0].text.strip()
@@ -461,7 +462,11 @@ def generate_hunt_content(
                 "IMPORTANT: The previous attempt to generate a hunt from this CTI was not satisfactory. "
                 "Your task is to generate a NEW and DIFFERENT hunt hypothesis. "
                 "Analyze the CTI report again and focus on a different technique, a more specific behavior, "
-                "or a unique, actionable aspect that was missed before. Do not repeat the previous hypothesis.\n\n"
+                "or a unique, actionable aspect that was missed before. Do not repeat the previous hypothesis.\n"
+                "Deliberately choose an off-distribution angle: pick the technique or behavior you would "
+                "rank second or third most obvious from this report, not the first one that comes to mind. "
+                "Prefer a hypothesis that targets a different ATT&CK tactic or a different stage of the "
+                "intrusion than the most self-evident reading of the report.\n\n"
             )
             temperature = 0.7
 
@@ -475,8 +480,8 @@ def generate_hunt_content(
             full_prompt = f"\n\nHuman: {SYSTEM_PROMPT}\n\n{prompt}\n\nAssistant:"
             response = _anthropic_create_with_retries(
                 model=CLAUDE_MODEL,
-                max_tokens=1200,
-                temperature=temperature,
+                max_tokens=4096,
+                thinking={"type": "disabled"},
                 messages=[{"role": "user", "content": full_prompt}],
             )
             return response.content[0].text.strip()
@@ -492,7 +497,7 @@ def generate_hunt_content(
             )
             return response.choices[0].message.content.strip()
     except Exception as e:
-        print(f"❌ Error generating hunt content: {str(e)}")
+        print(f"❌ Error generating hunt content: {e!s}")
         return None
 
 
@@ -506,13 +511,13 @@ def read_file_content(file_path):
                 text += page.extract_text() + "\n"
             return text.strip()
         except Exception as e:
-            print(f"Error reading PDF {file_path}: {str(e)}")
+            print(f"Error reading PDF {file_path}: {e!s}")
             return None
     else:
         try:
             return file_path.read_text()
         except Exception as e:
-            print(f"Error reading file {file_path}: {str(e)}")
+            print(f"Error reading file {file_path}: {e!s}")
             return None
 
 

--- a/scripts/process_hunt_submission.py
+++ b/scripts/process_hunt_submission.py
@@ -1,11 +1,38 @@
 import os
 import re
 from pathlib import Path
-from openai import OpenAI
+
 from dotenv import load_dotenv
 
+# Add Anthropic (Claude) support
+try:
+    import anthropic
+
+    CLAUDE_AVAILABLE = True
+except ImportError:
+    CLAUDE_AVAILABLE = False
+
 load_dotenv()
-client = OpenAI(api_key=os.getenv("OPENAI_API_KEY"))
+
+# AI provider selection
+AI_PROVIDER = os.getenv("AI_PROVIDER", "claude").lower()
+
+# Claude model configuration - use environment variable or default to latest
+CLAUDE_MODEL = os.getenv("CLAUDE_MODEL", "claude-sonnet-4-5-20250929")
+
+if AI_PROVIDER == "claude":
+    if not CLAUDE_AVAILABLE:
+        raise ImportError(
+            "Anthropic (Claude) client not installed. Please install 'anthropic' Python package."
+        )
+    ANTHROPIC_API_KEY = os.getenv("ANTHROPIC_API_KEY")
+    if not ANTHROPIC_API_KEY:
+        raise ValueError("ANTHROPIC_API_KEY not set in environment.")
+    anthropic_client = anthropic.Anthropic(api_key=ANTHROPIC_API_KEY)
+else:
+    from openai import OpenAI
+
+    client = OpenAI(api_key=os.getenv("OPENAI_API_KEY"))
 
 SYSTEM_PROMPT = """You are an expert threat hunter, and your task is to reformat a manually submitted hunt idea into the official HEARTH markdown format.
 You will be given the raw components of a hunt from a GitHub issue.
@@ -97,6 +124,16 @@ def generate_hunt_file(details):
         references=details.get("references", ""),
         submitter=details.get("submitter", "A Helpful Contributor"),
     )
+
+    if AI_PROVIDER == "claude":
+        response = anthropic_client.messages.create(
+            model=CLAUDE_MODEL,
+            max_tokens=1200,
+            temperature=0.1,
+            system=SYSTEM_PROMPT,
+            messages=[{"role": "user", "content": prompt}],
+        )
+        return response.content[0].text.strip()
 
     response = client.chat.completions.create(
         model="gpt-4",

--- a/scripts/process_hunt_submission.py
+++ b/scripts/process_hunt_submission.py
@@ -18,7 +18,7 @@ load_dotenv()
 AI_PROVIDER = os.getenv("AI_PROVIDER", "claude").lower()
 
 # Claude model configuration - use environment variable or default to latest
-CLAUDE_MODEL = os.getenv("CLAUDE_MODEL", "claude-sonnet-4-5-20250929")
+CLAUDE_MODEL = os.getenv("CLAUDE_MODEL", "claude-sonnet-5")
 
 if AI_PROVIDER == "claude":
     if not CLAUDE_AVAILABLE:
@@ -128,8 +128,8 @@ def generate_hunt_file(details):
     if AI_PROVIDER == "claude":
         response = anthropic_client.messages.create(
             model=CLAUDE_MODEL,
-            max_tokens=1200,
-            temperature=0.1,
+            max_tokens=4096,
+            thinking={"type": "disabled"},
             system=SYSTEM_PROMPT,
             messages=[{"role": "user", "content": prompt}],
         )


### PR DESCRIPTION
## Problem

Manual hunt submissions have been failing to draft since **2026-07-29**.

`scripts/process_hunt_submission.py` hardcoded the OpenAI client and `gpt-4`, ignoring the `AI_PROVIDER` and `ANTHROPIC_API_KEY` env vars that `process-hunt-submission.yml` already passes it. Once the OpenAI account hit its quota, every manual submission died with:

```
openai.RateLimitError: 429 - insufficient_quota
```

This is what broke issue #361. The draft run ([30419895216](https://github.com/THORCollective/HEARTH/actions/runs/30419895216)) failed, so `draft/issue-361` was never created. When the `approved` label was later added, the downstream *Create PR from Approved Draft* run ([30788995945](https://github.com/THORCollective/HEARTH/actions/runs/30788995945)) failed with the confusing symptom:

```
##[error]A branch or tag with the name 'draft/issue-361' could not be found
```

The sibling script `generate_from_cti.py` already had proper provider selection — this one was left behind.

## Changes

**1. Honor `AI_PROVIDER` (`8fa89fd`)**

Mirrors the provider-selection block already used by `generate_from_cti.py`. Defaults to Claude; OpenAI stays available as an opt-in fallback via `AI_PROVIDER=openai`.

**2. Bump both scripts to Claude Sonnet 5 (`351fe23`)**

`CLAUDE_MODEL` default goes from `claude-sonnet-4-5-20250929` to `claude-sonnet-5`, which requires two breaking changes:

| Change | Why |
|---|---|
| Removed `temperature` from all 4 Anthropic call sites | Sonnet 5 returns 400 on non-default sampling params |
| Set `thinking={"type": "disabled"}` | Adaptive thinking is on by default on Sonnet 5 and shares the `max_tokens` budget |
| `max_tokens` 1024/1200/2048 → 2048/4096 | Headroom for Sonnet 5's tokenizer (~30% more tokens for the same text) |
| Strengthened regeneration prompt | Replaces the lost variance lever (see below) |

The OpenAI fallback branches keep `temperature` unchanged.

### Note on hunt regeneration

The regeneration path used `temperature=0.7` to force a different hypothesis on retry. Sonnet 5 removes that parameter, so the regeneration prompt now explicitly asks for an off-distribution angle — a different ATT&CK tactic or intrusion stage than the most self-evident reading of the report. This is Anthropic's recommended substitute, but it is a **behavioral change worth watching** on the first few regenerations.

## Testing

- AST check confirms zero sampling params reach any of the 4 Anthropic call sites
- Stubbed end-to-end run against issue #361's real body produces a valid `H258.md` with the correct next hunt ID, asserting `model=claude-sonnet-5` and no banned params
- A tripwire `openai` module that raises on import never fires, confirming provider selection works
- Missing `ANTHROPIC_API_KEY` now fails closed with a clear error instead of silently falling back to OpenAI

**Not covered:** no live API call was made (no local key). Wiring is proven; actual Sonnet 5 output quality is not. `ANTHROPIC_API_KEY` is confirmed present and valid at repo level — run [29666947431](https://github.com/THORCollective/HEARTH/actions/runs/29666947431) shows `generate_from_cti.py` successfully calling Claude — but whether that account has `claude-sonnet-5` enabled is untested. If not, expect a 404 on the model ID, fixable with a `CLAUDE_MODEL` env override.

## Unblocking #361 after merge

1. Remove and re-add the `submission` label to regenerate `draft/issue-361`
2. Re-add the `approved` label to trigger PR creation

🤖 Generated with [Claude Code](https://claude.com/claude-code)