### PR TITLE
fix(scripts): keep multi-line submitter from breaking the hunt table

### DIFF
--- a/scripts/process_hunt_submission.py
+++ b/scripts/process_hunt_submission.py
@@ -81,6 +81,21 @@ The final markdown file content should look like this:
 """
 
 
+def flatten_for_table_cell(value):
+    """Collapse a multi-line form field into one line.
+
+    The 'HEARTH Crafter' field is a markdown bullet list, but it renders into a
+    single markdown table cell. An embedded newline breaks the table row, so
+    strip bullet markers and join the entries with commas.
+    """
+    entries = [
+        re.sub(r"^\s*[-*+]\s+", "", line).strip()
+        for line in value.splitlines()
+        if line.strip()
+    ]
+    return ", ".join(entries)
+
+
 def parse_issue_body(body):
     """Parses the structured data from the HEARTH Hunt Submission Form issue."""
     details = {}
@@ -106,7 +121,7 @@ def parse_issue_body(body):
             elif "knowledge base" in header:
                 details["references"] = content
             elif "hearth crafter" in header:
-                details["submitter"] = content
+                details["submitter"] = flatten_for_table_cell(content)
         except IndexError:
             continue  # Ignore malformed sections
     return details


### PR DESCRIPTION
## Problem

The `HEARTH Crafter` field in the hunt submission form is a markdown bullet list, but it renders into a **single cell** of the hunt's markdown table. The embedded newline splits the table row.

Seen on `H258.md`, generated from issue #361:

```
| ... | - [Twitter - 0xDroogy](https://t.co/JHM8u3D9na)
- [Github - Droogy](https://github.com/Droogy) |
```

This is pre-existing and unrelated to the recent provider swap in #365 — it would have happened on `gpt-4` too.

## Fix

Flatten the field at parse time in `parse_issue_body`: strip leading bullet markers (`-`, `*`, `+`), drop blank lines, and join entries with commas. The model then receives a single-line submitter and emits a well-formed row.

```
| ... | [Twitter - 0xDroogy](https://t.co/JHM8u3D9na), [Github - Droogy](https://github.com/Droogy) |
```

## Testing

Unit-tested `flatten_for_table_cell` against issue #361's real field plus edge cases (single line, blank lines, `*`/`+` bullets, empty input). All outputs newline-free.

Notably `Bob - Security Team` is preserved intact — only *leading* bullet markers are stripped, so hyphens inside names survive.

End-to-end stubbed run against #361's body confirms the generated file contains exactly one table data row with both links intact.

## Scope note

Only the `submitter` field is flattened. `tactic` and `tags` also land in table cells and would break the same way if a contributor entered them multi-line, but those form fields are single-line in practice, so I left them alone rather than widening the change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)