### PR TITLE
fix(scripts): migrate duplicate detection to Sonnet 5

### DIFF
--- a/scripts/duplicate_detection.py
+++ b/scripts/duplicate_detection.py
@@ -16,7 +16,7 @@ from dotenv import load_dotenv
 
 load_dotenv()
 
-CLAUDE_MODEL = os.getenv("CLAUDE_MODEL", "claude-sonnet-4-5-20250929")
+CLAUDE_MODEL = os.getenv("CLAUDE_MODEL", "claude-sonnet-5")
 HUNT_DIRECTORIES = ("Flames", "Embers", "Alchemy")
 TOP_N = 3
 
@@ -153,8 +153,8 @@ def rank_with_claude(new_hunt: dict, existing: list[dict]) -> list[dict]:
 
     response = client.messages.create(
         model=CLAUDE_MODEL,
-        max_tokens=600,
-        temperature=0.0,
+        max_tokens=2048,
+        thinking={"type": "disabled"},
         messages=[{"role": "user", "content": prompt}],
     )
     raw = response.content[0].text if response.content else ""


### PR DESCRIPTION
## Problem

`scripts/duplicate_detection.py` was missed in the Sonnet 5 migration (#365) — it's the third LLM-calling script, and only the two hunt generators were updated.

It reads the **same `CLAUDE_MODEL` env var** as those scripts, but kept its own `claude-sonnet-4-5-20250929` default and passed `temperature=0.0`.

**Not broken today** — `CLAUDE_MODEL` is unset in CI, so it still runs on Sonnet 4.5 where `temperature` is accepted.

**But it's a latent trap.** Setting `CLAUDE_MODEL=claude-sonnet-5` as a repo variable — the natural follow-up to #365 — would make every duplicate-detection call 400. And `rank_with_claude` is wrapped in a bare `except` that logs and returns a placeholder:

```python
except Exception as exc:
    print(f"❌ Claude call failed: {exc}")
    return "⚠️ Duplicate detection ran but produced no usable result — manual review recommended."
```

So it would **fail soft and silently stop flagging duplicate hunts**, with only a log line to show for it.

## Fix

| Change | Why |
|---|---|
| `CLAUDE_MODEL` default → `claude-sonnet-5` | Consistency with the other two scripts |
| Dropped `temperature=0.0` | Sonnet 5 rejects non-default sampling params |
| Added `thinking={"type": "disabled"}` | On by default on Sonnet 5; shares the `max_tokens` budget |
| `max_tokens` 600 → 2048 | Headroom under Sonnet 5's tokenizer (~30% more tokens) |

## How it surfaced

Found while testing the hunt **regeneration** path from #365. A stubbed run asserting no sampling params reach the Anthropic SDK failed with `temperature sent -> Sonnet 5 would 400`, pointing at this third call site.

A repo-wide AST audit now confirms **all 6 Anthropic call sites across all 3 scripts** are free of `temperature`/`top_p`/`top_k`, and all 3 `CLAUDE_MODEL` defaults agree on `claude-sonnet-5`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)