### PR TITLE
fix(ci): make hunt regeneration actually regenerate

### DIFF
--- a/.github/workflows/issue-generate-hunts.yml
+++ b/.github/workflows/issue-generate-hunts.yml
@@ -104,7 +104,16 @@ jobs:
         id: find_hunt
         if: github.event.label.name == 'regenerate'
         run: |
-          HUNT_FILE=$(ls Flames/H-*.md | head -n 1)
+          # Find the hunt file added by a previous attempt on THIS draft branch.
+          # A bare glob is wrong twice over: Flames/H-*.md never matches (files
+          # are HNNN.md, not H-NNN.md), and Flames/H*.md would match every hunt
+          # already on main and overwrite a production file.
+          HUNT_FILE=$(git diff --name-only origin/main...HEAD -- 'Flames/H*.md' | head -n 1)
+          if [ -z "$HUNT_FILE" ]; then
+            echo "::error::Regeneration requested but no hunt file was found on draft/issue-${{ github.event.issue.number }}."
+            exit 1
+          fi
+          echo "Regenerating existing hunt file: $HUNT_FILE"
           echo "hunt_file_path=$HUNT_FILE" >> $GITHUB_OUTPUT
 
       - name: "Parse Issue Body"


### PR DESCRIPTION
## Problem

Hunt regeneration has never worked. Found while testing the regeneration path after the Sonnet 5 migration.

`.github/workflows/issue-generate-hunts.yml:107`:

```bash
HUNT_FILE=$(ls Flames/H-*.md | head -n 1)
```

Hunt files are named `H259.md` — not `H-259.md`. The glob has never matched:

```
ls: cannot access 'Flames/H-*.md': No such file or directory
```

`ls` fails → `EXISTING_HUNT_FILE` is empty → `is_regeneration` is `False` → `generate_from_cti.py` logs `🌱 Generating new hunt: H260` and writes an **additional** hunt file instead of updating the existing one.

### Observed on a live test run

Issue #369, regeneration [run 30830538400](https://github.com/THORCollective/HEARTH/actions/runs/30830538400). The draft branch ended up with **both** `H259.md` and `H260.md`.

### Effects

| | |
|---|---|
| Regeneration doesn't regenerate | A new hunt file is added per attempt |
| Orphan hunts accumulate | Draft branches hold every attempt |
| Hunt IDs consumed | Each attempt burns a number |
| Regeneration prompt never runs | The `is_regeneration` branch in `generate_from_cti.py` is unreachable |
| Attempts still counted | Users burn 1 of 5 for a no-op |

Broken since `5a0b4bc` (2025-06-21), the commit that added the regeneration loop.

## Fix

Select the hunt file added *on the draft branch* rather than globbing the working tree:

```bash
HUNT_FILE=$(git diff --name-only origin/main...HEAD -- 'Flames/H*.md' | head -n 1)
```

**Note the naive fix is worse than the bug.** Changing the glob to `Flames/H*.md` matches every hunt already on main — verified, it returns `Flames/H001.md`, so regeneration would silently overwrite a production hunt.

Also fails loudly when no draft file is found, instead of silently degrading to a new generation.

### Verified

Against the real `draft/issue-369`:

```
$ git diff --name-only origin/main...origin/draft/issue-369 -- 'Flames/H*.md' | head -n 1
Flames/H259.md      # correct — the original draft
```

## Testing note

`on: issues` workflows always run the copy on the **default branch**, so this fix can't be exercised from a PR branch. It needs to land on `main` before regeneration can be verified end to end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)