### PR TITLE
chore(ci): unify CLAUDE_MODEL config across both hunt pipelines

### DIFF
--- a/.github/workflows/issue-generate-hunts.yml
+++ b/.github/workflows/issue-generate-hunts.yml
@@ -315,7 +315,7 @@ jobs:
           AI_PROVIDER: ${{ vars.AI_PROVIDER || 'claude' }}
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
-          CLAUDE_MODEL: ${{ vars.CLAUDE_MODEL || 'claude-sonnet-4-5-20250929' }}
+          CLAUDE_MODEL: ${{ vars.CLAUDE_MODEL || 'claude-sonnet-5' }}
           CTI_SOURCE_URL: ${{ steps.parse_issue.outputs.source_url }}
           EXISTING_HUNT_FILE: ${{ steps.find_hunt.outputs.hunt_file_path }}
           SUBMITTER_NAME: ${{ steps.parse_issue.outputs.submitter_name }}

--- a/.github/workflows/process-hunt-submission.yml
+++ b/.github/workflows/process-hunt-submission.yml
@@ -36,6 +36,7 @@ jobs:
         id: generate_draft_file
         env:
           AI_PROVIDER: ${{ vars.AI_PROVIDER || 'claude' }}
+          CLAUDE_MODEL: ${{ vars.CLAUDE_MODEL || 'claude-sonnet-5' }}
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
           ISSUE_BODY: ${{ github.event.issue.body }}


### PR DESCRIPTION
## Problem

The Sonnet 5 bump in #365 changed the **script-level** defaults, but `issue-generate-hunts.yml` overrides `CLAUDE_MODEL` with its own fallback:

```yaml
CLAUDE_MODEL: ${{ vars.CLAUDE_MODEL || 'claude-sonnet-4-5-20250929' }}
```

No repo variable was set, so that fallback won. Net effect — the two pipelines have been running on **different models**:

| Script | Workflow | Model actually used |
|---|---|---|
| `generate_from_cti.py` | `issue-generate-hunts.yml` | Sonnet **4.5** (workflow override) |
| `duplicate_detection.py` | same | Sonnet **4.5** (inherits env) |
| `process_hunt_submission.py` | `process-hunt-submission.yml` | Sonnet **5** (no override, script default) |

## Fix

- Bump the stale `claude-sonnet-4-5-20250929` fallback in `issue-generate-hunts.yml` to `claude-sonnet-5`
- Add the missing `CLAUDE_MODEL` passthrough to `process-hunt-submission.yml`

Both workflows now read the same `vars.CLAUDE_MODEL`, with matching defaults when it's unset. Paired with setting the repo variable, the model version becomes visible in repo settings instead of being buried across three source files and two workflow fallbacks.

## Note on prior testing

The regeneration validation I ran against issue #369 went through `issue-generate-hunts.yml`, so it exercised **Sonnet 4.5**, not Sonnet 5. The behavioral finding still stands — the off-distribution regeneration prompt produced a hypothesis on a different ATT&CK tactic, while the control run without it produced a near-duplicate — but that result was measured on 4.5. Worth re-checking the first CTI regeneration after this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)