### PR TITLE
test: add duplicate detection regression suite; correct SQLite claims

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ Maintainers reviewing submissions: see **[Review-Process.md](/Keepers/Review-Pro
 | **Coverage Heatmap**         | [/coverage-heatmap.html](https://hearth.thorcollective.com/coverage-heatmap.html) — the full MITRE ATT&CK matrix, colored by how many community hunts cover each technique. Click a cell to see the hunts (or the gap). Lives alongside the [Coverage Map](https://hearth.thorcollective.com/graph.html) under the [Coverage hub](https://hearth.thorcollective.com/coverage.html). |
 | **AI-Powered CTI Analysis**  | Submit a CTI link — **Claude** reads, analyzes, and drafts a complete hunt hypothesis automatically.                                                                                                                                                                                                                                                                                |
 | **MITRE ATT&CK Integration** | Validates technique IDs against the full Enterprise framework (691 techniques, 99% accuracy).                                                                                                                                                                                                                                                                                       |
-| **Duplicate Detection**      | AI-powered similarity analysis flags potential duplicates before they're merged. 30-60x faster with SQLite indexing.                                                                                                                                                                                                                                                                |
+| **Duplicate Detection**      | AI-powered similarity analysis flags potential duplicates before they're merged, ranked by closeness with an explanation for each.                                                                                                                                                                                                                                                  |
 | **Automated Workflows**      | GitHub Actions manage the full submission lifecycle — from draft to PR to merge.                                                                                                                                                                                                                                                                                                    |
 | **Review & Regeneration**    | Maintainers can re-roll AI-generated hunts by adding a `regenerate` label — iterate until it's right.                                                                                                                                                                                                                                                                               |
 | **Contributor Leaderboard**  | [Automated tracking](/Keepers/Contributors.md) of submissions. We celebrate our community.                                                                                                                                                                                                                                                                                          |
@@ -120,9 +120,9 @@ Maintainers reviewing submissions: see **[Review-Process.md](/Keepers/Review-Pro
 
 ### Database Index
 
-- **SQLite database** (`database/hunts.db`) provides fast querying for duplicate detection
-- Automatically updated when hunt files change
-- **30-60x faster** duplicate detection in GitHub Actions
+- **SQLite database** (`database/hunts.db`) provides a queryable index of every hunt
+- Automatically rebuilt when hunt files change
+- Used for reporting and ad-hoc queries. Duplicate detection reads the hunt files directly rather than this index
 - See [database/README.md](database/README.md) for details
 
 ### CTI Extraction

--- a/docs/TESTING_GUIDE.md
+++ b/docs/TESTING_GUIDE.md
@@ -304,15 +304,17 @@ total_hunts
 
 ### Test 2: Test Database Performance
 
-The index is what duplicate detection queries against, so the check that matters is whether it's current — every hunt file should have a row.
+Nothing in the pipeline reads this index at runtime — `duplicate_detection.py` walks the hunt directories directly. The index is built by `update-hunt-database.yml` and used for reporting. The check that matters is still whether it's current.
 
 ```bash
 python3 - <<'EOF'
 import sqlite3, pathlib
-rows = sqlite3.connect("database/hunts.db").execute("SELECT COUNT(*) FROM hunts").fetchone()[0]
-files = sum(1 for d in ("Flames", "Embers", "Alchemy") for _ in pathlib.Path(d).glob("*.md"))
-print(f"indexed: {rows}\nfiles:   {files}")
-print("✅ current" if rows == files else f"⚠️  stale — rebuild ({files - rows} missing)")
+con = sqlite3.connect("database/hunts.db")
+indexed = {r[0] for r in con.execute("SELECT filename FROM hunts")}
+files = {p.name for d in ("Flames", "Embers", "Alchemy") for p in pathlib.Path(d).glob("*.md")}
+missing = sorted(files - indexed - {"secret.md"})
+print(f"indexed: {len(indexed)}\nfiles:   {len(files)}")
+print("✅ current" if not missing else f"⚠️  stale — rebuild, missing: {missing}")
 EOF
 ```
 
@@ -324,7 +326,7 @@ python scripts/build_hunt_database.py --rebuild
 
 `database/hunts.db` is gitignored — it's a local build artifact, so your copy drifts as you pull new hunts. In production `update-hunt-database.yml` rebuilds it on every merge that touches a hunt file.
 
-> The README's "30-60x faster" figure refers to duplicate detection's repeated similarity lookups, not a single count query. Don't expect a bare `COUNT(*)` to beat a file scan — at this corpus size it won't.
+> `Flames/secret.md` is a challenge-coin puzzle page, not a hunt, so the parser skips it. A current index therefore holds one row fewer than the file count.
 
 ### Test 3: Test Duplicate Detection
 
@@ -582,13 +584,12 @@ act -s ANTHROPIC_API_KEY=sk-... -s GITHUB_TOKEN=ghp_...
 
 - [x] Unit tests for CTI extraction — `scripts/tests/test_cti_extract.py`
 - [x] Automated format validation — `test_hunt_schema.py`, plus `validate-hunt-schema.yml` in CI
-
 - [x] Integration tests in CI — `validate-hunt-schema.yml` runs pytest on every PR
+- [x] Regression tests for duplicate detection — `scripts/tests/test_duplicate_detection.py`, 31 tests, no API calls
 
 **Still open:**
 
-- [ ] Regression tests for duplicate detection
-- [ ] Performance benchmarking in CI
+- [ ] Performance benchmarking in CI. Deferred: the obvious target was the SQLite index, but nothing in the pipeline reads it at runtime, so there is currently no hot path worth gating on.
 
 ---
 

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -21,7 +21,7 @@ Turns a CTI link or a manual submission into a drafted hunt and a pull request.
 | `cti_extract.py`             | Extracts clean article text from raw HTML. Library module — no CLI.                                | imported                         |
 | `generate_from_cti.py`       | The core drafting step. Sends extracted CTI to Claude (or OpenAI) and writes a complete hunt file. | `issue-generate-hunts.yml`       |
 | `process_hunt_submission.py` | Parses a submission issue body and drafts a hunt from it.                                          | `process-hunt-submission.yml`    |
-| `duplicate_detection.py`     | AI similarity check against the SQLite index; flags likely duplicates before merge.                | called by the drafting workflows |
+| `duplicate_detection.py`     | AI similarity check against every existing hunt; flags likely duplicates before merge.             | called by the drafting workflows |
 | `reassign_hunt_id.py`        | Reassigns a draft's hunt ID when it collides with one already taken.                               | `pr-from-approval.yml`           |
 
 **Environment:** `generate_from_cti.py` reads `AI_PROVIDER`, `ANTHROPIC_API_KEY`, `OPENAI_API_KEY`, and `CLAUDE_MODEL`, plus per-run inputs `CTI_SOURCE_URL`, `SUBMITTER_NAME`, `PROFILE_LINK`, `FEEDBACK`, and `EXISTING_HUNT_FILE` (set when regenerating). `process_hunt_submission.py` reads the same provider variables plus `ISSUE_BODY`. `duplicate_detection.py` reads `ANTHROPIC_API_KEY` and `CLAUDE_MODEL`.

--- a/scripts/tests/test_duplicate_detection.py
+++ b/scripts/tests/test_duplicate_detection.py
@@ -1,0 +1,305 @@
+import scripts.duplicate_detection as dd
+from scripts.duplicate_detection import (
+    _build_prompt,
+    _emoji_for_score,
+    _parse_response,
+    _resolve_filepath,
+    check_duplicates_for_new_submission,
+    extract_hunt_info,
+    format_comment,
+)
+
+HUNT_MD = """# H999
+
+Threat actors are abusing the Snowflake GET command to exfiltrate compressed
+archives from internal stages.
+
+| Hunt # | Idea / Hypothesis | Tactic | Notes | Tags | Submitter |
+|--------|-------------------|--------|-------|------|-----------|
+| H999 | Threat actors abuse Snowflake GET. | Exfiltration | ATT&CK T1567.002. | #exfiltration #T1567_002 | tester |
+"""
+
+
+# --- extract_hunt_info -------------------------------------------------------
+
+
+def test_extracts_hypothesis_tactic_and_tags():
+    info = extract_hunt_info(HUNT_MD, "H999.md", "Flames/H999.md")
+    assert info["hypothesis"].startswith("Threat actors are abusing")
+    assert info["tactic"] == "Exfiltration"
+    assert info["tags"] == ["#T1567_002", "#exfiltration"]
+    assert info["filepath"] == "Flames/H999.md"
+
+
+def test_returns_none_when_no_hypothesis():
+    # A file of only headings and tables has no prose line to use as the
+    # hypothesis. Returning None is what makes the caller fall back to
+    # "manual review recommended" instead of sending an empty prompt.
+    assert extract_hunt_info("# Title\n\n| a | b |\n", "X.md", "X.md") is None
+
+
+def test_ignores_headings_and_table_rows_when_finding_hypothesis():
+    content = "# Heading\n\n| table | row |\n\nThe actual hypothesis line.\n"
+    assert (
+        extract_hunt_info(content, "X.md", "X.md")["hypothesis"]
+        == "The actual hypothesis line."
+    )
+
+
+def test_tags_are_deduplicated_and_sorted():
+    content = "Hypothesis here.\n\n#zeta #alpha #zeta #alpha\n"
+    assert extract_hunt_info(content, "X.md", "X.md")["tags"] == ["#alpha", "#zeta"]
+
+
+def test_missing_tactic_does_not_crash():
+    # Hunts without the standard table still need to be comparable; tactic
+    # just comes back empty and is rendered as "Unknown" in the prompt.
+    info = extract_hunt_info("A hypothesis with no table.\n", "X.md", "X.md")
+    assert info["tactic"] == ""
+
+
+# --- _parse_response ---------------------------------------------------------
+
+
+def test_parses_plain_json():
+    raw = '{"top_matches": [{"filename": "H1.md", "score": 90, "explanation": "x"}]}'
+    assert _parse_response(raw)[0]["filename"] == "H1.md"
+
+
+def test_parses_json_wrapped_in_code_fences():
+    # The prompt says "no code fences", but models add them anyway. Before this
+    # was tolerated, a fenced response silently produced zero matches.
+    raw = '```json\n{"top_matches": [{"filename": "H1.md", "score": 90}]}\n```'
+    assert _parse_response(raw)[0]["score"] == 90
+
+
+def test_parses_json_embedded_in_prose():
+    raw = 'Here you go:\n{"top_matches": [{"filename": "H2.md", "score": 55}]}\nHope that helps.'
+    assert _parse_response(raw)[0]["filename"] == "H2.md"
+
+
+def test_returns_empty_list_on_unparseable_response():
+    assert _parse_response("I could not complete that request.") == []
+
+
+def test_returns_empty_list_when_top_matches_is_not_a_list():
+    assert _parse_response('{"top_matches": "H1.md"}') == []
+
+
+def test_returns_empty_list_when_payload_is_not_an_object():
+    assert _parse_response('["H1.md", "H2.md"]') == []
+
+
+# --- score thresholds --------------------------------------------------------
+
+
+def test_threshold_values_are_pinned():
+    # Asserted as literals, not via the constants. These cutoffs decide whether
+    # a maintainer is told to review before approving, so moving one is a
+    # product decision that should have to change this test too.
+    assert (dd.HIGH_SIMILARITY, dd.MODERATE_SIMILARITY) == (80, 60)
+
+
+def test_emoji_thresholds_are_inclusive_at_the_boundary():
+    assert _emoji_for_score(80) == "🔴"
+    assert _emoji_for_score(79) == "🟡"
+    assert _emoji_for_score(60) == "🟡"
+    assert _emoji_for_score(59) == "🟢"
+
+
+# --- format_comment ----------------------------------------------------------
+
+
+EXISTING = [
+    {
+        "filename": "H1.md",
+        "filepath": "Flames/H1.md",
+        "hypothesis": "h",
+        "tactic": "t",
+        "tags": [],
+    },
+]
+
+
+def test_formats_matches_with_links_and_scores():
+    out = format_comment(
+        [{"filename": "H1.md", "score": 87, "explanation": "Both hunt X."}], EXISTING
+    )
+    assert "[H1.md](Flames/H1.md)" in out
+    assert "87% similar" in out
+    assert "Both hunt X." in out
+
+
+def test_high_score_footer_asks_for_review():
+    out = format_comment(
+        [{"filename": "H1.md", "score": 95, "explanation": "e"}], EXISTING
+    )
+    assert "before approving" in out
+
+
+def test_low_score_footer_reports_unique():
+    out = format_comment(
+        [{"filename": "H1.md", "score": 10, "explanation": "e"}], EXISTING
+    )
+    assert "appears unique" in out
+
+
+def test_empty_matches_recommends_manual_review():
+    assert "manual review recommended" in format_comment([], EXISTING)
+
+
+def test_non_numeric_score_degrades_to_zero_instead_of_crashing():
+    # A model returning "high" instead of 87 must not take down the whole
+    # drafting workflow — the comment still renders, scored 0.
+    out = format_comment(
+        [{"filename": "H1.md", "score": "high", "explanation": "e"}], EXISTING
+    )
+    assert "0% similar" in out
+
+
+def test_entries_without_filename_are_dropped():
+    matches = [
+        {"score": 90, "explanation": "no filename"},
+        {"filename": "H1.md", "score": 50, "explanation": "e"},
+    ]
+    out = format_comment(matches, EXISTING)
+    assert "H1.md" in out
+    assert "no filename" not in out
+
+
+def test_all_invalid_entries_recommends_manual_review():
+    assert "manual review recommended" in format_comment(
+        [{"score": 90}, "not a dict"], EXISTING
+    )
+
+
+def test_output_is_capped_at_top_n():
+    matches = [
+        {"filename": f"H{i}.md", "score": 50, "explanation": "e"} for i in range(10)
+    ]
+    out = format_comment(matches, EXISTING)
+    assert out.count("% similar") == dd.TOP_N
+
+
+def test_missing_explanation_gets_placeholder():
+    out = format_comment([{"filename": "H1.md", "score": 50}], EXISTING)
+    assert "No explanation provided." in out
+
+
+def test_unknown_filename_falls_back_to_bare_name():
+    # Claude occasionally invents a filename. It should still render rather
+    # than raising, just without a working repo link.
+    assert _resolve_filepath("H404.md", EXISTING) == "H404.md"
+
+
+# --- _build_prompt -----------------------------------------------------------
+
+
+def test_prompt_includes_submission_and_every_candidate():
+    new = {"hypothesis": "New hypothesis", "tactic": "Execution", "tags": ["#a"]}
+    existing = [
+        {"filename": "H1.md", "hypothesis": "First", "tactic": "Exfiltration"},
+        {"filename": "H2.md", "hypothesis": "Second", "tactic": ""},
+    ]
+    prompt = _build_prompt(new, existing)
+    assert "New hypothesis" in prompt
+    assert "H1.md | Exfiltration | First" in prompt
+    assert "H2.md | Unknown | Second" in prompt
+
+
+def test_prompt_truncates_long_hypotheses():
+    # Every existing hunt goes into one prompt, so an unbounded hypothesis
+    # would let a single pathological file blow the context budget.
+    existing = [{"filename": "H1.md", "hypothesis": "x" * 500, "tactic": "T"}]
+    assert "x" * 201 not in _build_prompt({"hypothesis": "n"}, existing)
+
+
+def test_prompt_flattens_newlines_in_candidate_hypotheses():
+    # One candidate per line is what makes the listing parseable; an embedded
+    # newline would split a single hunt across two lines.
+    existing = [
+        {"filename": "H1.md", "hypothesis": "line one\nline two", "tactic": "T"}
+    ]
+    assert "line one line two" in _build_prompt({"hypothesis": "n"}, existing)
+
+
+# --- check_duplicates_for_new_submission -------------------------------------
+
+
+def test_unparseable_submission_short_circuits_before_calling_claude(monkeypatch):
+    def boom(*args, **kwargs):
+        raise AssertionError("Claude must not be called for an unparseable submission")
+
+    monkeypatch.setattr(dd, "rank_with_claude", boom)
+    assert "Could not extract hypothesis" in check_duplicates_for_new_submission(
+        "# Only a heading\n", "X.md"
+    )
+
+
+def test_claude_failure_degrades_to_manual_review(monkeypatch):
+    # An API outage must not fail the drafting workflow — the hunt still gets
+    # drafted, just without duplicate analysis.
+    monkeypatch.setattr(dd, "load_existing_hunts", lambda: EXISTING)
+
+    def boom(*args, **kwargs):
+        raise RuntimeError("API down")
+
+    monkeypatch.setattr(dd, "rank_with_claude", boom)
+    assert "manual review recommended" in check_duplicates_for_new_submission(
+        HUNT_MD, "H999.md"
+    )
+
+
+def test_submission_is_excluded_from_its_own_comparison_set(monkeypatch):
+    # On regeneration the hunt file already exists on disk, so without this
+    # filter every re-roll would report itself as a 100% duplicate.
+    seen = {}
+
+    monkeypatch.setattr(
+        dd,
+        "load_existing_hunts",
+        lambda: [
+            {
+                "filename": "H999.md",
+                "filepath": "Flames/H999.md",
+                "hypothesis": "self",
+                "tactic": "T",
+                "tags": [],
+            },
+            {
+                "filename": "H1.md",
+                "filepath": "Flames/H1.md",
+                "hypothesis": "other",
+                "tactic": "T",
+                "tags": [],
+            },
+        ],
+    )
+
+    def capture(new_hunt, existing):
+        seen["filenames"] = [h["filename"] for h in existing]
+        return []
+
+    monkeypatch.setattr(dd, "rank_with_claude", capture)
+    check_duplicates_for_new_submission(HUNT_MD, "H999.md")
+    assert seen["filenames"] == ["H1.md"]
+
+
+def test_empty_corpus_reports_first_submission(monkeypatch):
+    monkeypatch.setattr(dd, "load_existing_hunts", list)
+    assert "first submission" in check_duplicates_for_new_submission(HUNT_MD, "H999.md")
+
+
+def test_happy_path_renders_ranked_comment(monkeypatch):
+    monkeypatch.setattr(dd, "load_existing_hunts", lambda: EXISTING)
+    monkeypatch.setattr(
+        dd,
+        "rank_with_claude",
+        lambda new, existing: [
+            {"filename": "H1.md", "score": 91, "explanation": "Near duplicate."}
+        ],
+    )
+    out = check_duplicates_for_new_submission(HUNT_MD, "H999.md")
+    assert "🔴" in out
+    assert "[H1.md](Flames/H1.md)" in out
+    assert "before approving" in out


### PR DESCRIPTION
Adds the regression tests for duplicate detection that #372 left on the open list, and corrects a set of claims about SQLite that turned out not to be true — including two I introduced in that PR.

## The tests

`scripts/tests/test_duplicate_detection.py` — 31 tests covering hunt parsing, response parsing, score thresholds, comment formatting, and the public entry point. No API calls: `rank_with_claude` is monkeypatched, so this runs in CI alongside the existing suite. Total is now 101 tests, still under a second.

Coverage was verified by mutation rather than by assuming green means covered. Eight deliberate regressions were introduced one at a time, and the suite caught each:

| Mutation | Caught by |
| :--- | :--- |
| Drop the self-exclusion filter | `test_submission_is_excluded_from_its_own_comparison_set` |
| Move `HIGH_SIMILARITY` or `MODERATE_SIMILARITY` | `test_threshold_values_are_pinned` |
| Change `TOP_N` | `test_output_is_capped_at_top_n` |
| Drop the missing-filename skip | `test_entries_without_filename_are_dropped` |
| Remove hypothesis truncation | `test_prompt_truncates_long_hypotheses` |
| Remove the `int()` guard on scores | `test_non_numeric_score_degrades_to_zero_instead_of_crashing` |
| Remove newline flattening | `test_prompt_flattens_newlines_in_candidate_hypotheses` |

That process found one test worthless and it was rewritten. The threshold test referenced `dd.HIGH_SIMILARITY` symbolically, so it moved with the constant and could not detect a changed cutoff. It now pins 80 and 60 as literals, since those values decide whether a maintainer is told to review before approving.

The self-exclusion test is the one worth keeping an eye on: without that filter, every `regenerate` re-roll would report itself as a 100% duplicate.

## Duplicate detection does not use the SQLite index

It calls `load_existing_hunts()`, which walks `Flames/`, `Embers/`, and `Alchemy/` with `Path.glob` on every invocation. Nothing in the pipeline reads `database/hunts.db` at runtime — only `build_hunt_database.py` writes it, and `update-hunt-database.yml` reports on it.

`docs/OPTIMIZATION_GUIDE.md` lists the SQLite migration as a proposal with a 2-4 hour estimate. It appears to have been documented as done but never wired up.

Corrected accordingly:

- README feature table no longer claims "30-60x faster with SQLite indexing"
- README's Database Index section now describes what the index is actually for
- `scripts/README.md` no longer describes duplicate detection as querying the index

## Two corrections to my own work in #372

- The testing guide stated the index is what duplicate detection queries against. It is not.
- The index-currency snippet compared raw counts, so it reported "stale" permanently: `Flames/secret.md` is a challenge-coin puzzle page, not a hunt, and the parser correctly skips it. The snippet now diffs filenames and excludes that file by name.

## Performance benchmarking is left open

It was the other item on #372's open list. The obvious target was the SQLite index, and nothing reads it on a hot path, so gating on it would guard infrastructure the pipeline does not use. The reason is recorded in the testing guide rather than silently dropped.

Three options if you want it closed: leave it deferred, wire duplicate detection to the index so the original claim becomes true, or benchmark the file walk that actually runs.

## Verification

`pytest` 101/101 · `flake8` clean at CI's exact settings (`--select=E9,F63,F7,F82`) · `npm test` 11/11 · `npm run type-check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)