### PR TITLE
Add H262: Local passkey state access before key-based cloud sign-in and account persistence

### DIFF
--- a/Flames/H262.md
+++ b/Flames/H262.md
@@ -1,0 +1,56 @@
+---
+id: H262
+category: Flames
+title: Local passkey state access before key-based cloud sign-in and account persistence
+hypothesis: >-
+  Malware on a signed-in Windows workstation reads Chrome synced passkey state and uses device-bound key material to obtain a key-based cloud sign-in before adding same-account persistence.
+tactics:
+  - Credential Access
+  - Initial Access
+  - Persistence
+techniques:
+  - T1550
+  - T1555
+  - T1098
+  - T1078
+tags:
+  - passkey
+  - passwordless
+  - webauthn
+  - chrome
+  - credential_access
+  - account_persistence
+  - identity
+submitter:
+  name: Joshua Strickland
+  link: https://novasky.io
+required_data_sources:
+  - Endpoint EDR process and file telemetry
+  - "Endpoint module, process access, or API telemetry when available"
+  - Identity provider sign-in logs with authentication method and device details
+  - "Cloud identity audit logs for MFA, recovery, OAuth, app password, and access policy changes"
+false_positive_notes: |
+  Chrome, Google Password Manager, operating-system credential providers, and browser update flows can touch passkey state during normal sign-in or enrollment. Keep this hunt high-signal by requiring a non-browser or script-host process, browser memory access, passkey state deletion or recreation, or cryptographic API use before the identity event. Help desk recovery and planned passwordless enrollment can create MFA, recovery, OAuth, or app password changes, but those should not be preceded by unexpected endpoint access to Chrome passkey state from the same user context.
+notes: |
+  Endpoint EDR process and file telemetry - Core filter: non-browser or script-host process opens `%LocalAppData%\Google\Chrome\User Data\<Profile>\Sync Data\LevelDB`, `passkey_enclave_state`, or browser credential stores. Triage values: `process command line`, `parent process command line`, `file path`, `process integrity`, `loaded module`. Strong red flags: `powershell.exe`, `wscript.exe`, `cscript.exe`, `rundll32.exe`, or an unknown user process reading passkey state shortly before a passkey sign-in.
+  Endpoint cryptographic API and memory telemetry - Core filter: same process tree loads CNG or touches Chrome memory around passkey state access. Triage values: `process command line`, `module path`, `target process`, `file path`. Pivot: look for `NCryptOpenStorageProvider`, `NCryptImportKey`, `NCryptSignHash`, access to `wrapped_identity_private_key`, or memory reads against `chrome.exe`. Strong red flags: deletion or recreation of `passkey_enclave_state` followed by browser memory access.
+  Identity sign-in and cloud account audit logs - Core filter: key-based or WebAuthn sign-in for the same user and device shortly after endpoint passkey access. Triage values: `authentication method`, `device identity`, `source IP address`, `user agent`, `session ID`, `client request ID`. Correlation: require a same-account persistence event such as `MFA method registration`, `recovery method change`, `OAuth grant`, `app password creation`, or `access policy exclusion` after the sign-in. Strong red flags: source change, no fresh user interaction signal, or same-session account changes.
+---
+# H262
+
+Unit 42 described Pass-ta-key attacks against Google-synced passkeys. Malware already running on a Windows endpoint can read Chrome's Sync Data LevelDB and passkey_enclave_state, use device-bound key material through standard Windows cryptographic calls, or force passkey re-onboarding to expose material needed for account takeover. This hunt focuses on the observable chokepoint: local passkey state access followed by key-based cloud authentication and same-account persistence.
+
+## Why
+
+- Unit 42's Pass-ta-key research depends on malware reading local passkey state and using device-bound key material to obtain authentication assertions, so the local access happens before the target account or relying-party domain matters.
+- The hunt survives URL, relying-party, and campaign changes because it starts with local passkey store access and CNG signing behavior, then asks whether the same user obtained key-based cloud access.
+- The chain is visible to a mature MDR through endpoint file and process telemetry plus identity sign-in and audit logs when those logs include authentication method, device identity, session ID, and client request ID values.
+- False positives are controllable because browser processes and planned enrollment workflows are expected, while a script host or unknown process reading passkey state followed by MFA, recovery, OAuth, app password, or access policy changes is not a normal user flow.
+
+## References
+
+- [Pass the Passkey: A Novel Attack Surface in Passwordless Authentication](https://unit42.paloaltonetworks.com/passwordless-authentication-security-risks/)
+- [MITRE ATT&CK T1550: Use Alternate Authentication Material](https://attack.mitre.org/techniques/T1550/)
+- [MITRE ATT&CK T1555: Credentials from Password Stores](https://attack.mitre.org/techniques/T1555/)
+- [MITRE ATT&CK T1098: Account Manipulation](https://attack.mitre.org/techniques/T1098/)
+- [MITRE ATT&CK T1078: Valid Accounts](https://attack.mitre.org/techniques/T1078/)


### PR DESCRIPTION
## Summary

Adds `H262`: Local passkey state access before key-based cloud sign-in and account persistence.

## Sources

- https://unit42.paloaltonetworks.com/passwordless-authentication-security-risks/

## Validation

- Draft reviewed locally before submission.
- Source links are preserved in the hunt writeup.
