### PR TITLE
Add H263: Remote-control session on a managed endpoint installs a Cloudflare Tunnel service and runs svchost.exe from a user Documents folder

### DIFF
--- a/Flames/H263.md
+++ b/Flames/H263.md
@@ -1,0 +1,108 @@
+---
+id: H263
+category: Flames
+title: Remote-control session on a managed endpoint installs a Cloudflare Tunnel service and runs svchost.exe from a user Documents folder
+hypothesis: >-
+  An adversary who has taken over an RMM console is using its built-in remote-control feature to reach managed endpoints and convert that transient session into durable, outbound-only access: a Cloudflare Tunnel connector is registered as a Windows service (service name `Cloudflared`) and the connector binary is staged under a user-writable path — observed as an executable named `svchost.exe` inside a user's Documents folder. The chain is invariant regardless of which RMM platform or CVE provided the initial access, because the adversary must (1) execute under the remote-control or agent process lineage, (2) write a binary to a user-writable directory, (3) create an auto-start service whose image path points at that directory, and (4) egress to the tunnel provider's connector endpoints on a non-standard port. Hunt Windows service installations whose image path resolves to a user profile path or references tunnel-connector arguments, correlate them backwards to the remote-control session window on the same host, and forwards to long-lived outbound sessions to the tunnel provider's edge.
+tactics:
+  - Persistence
+  - Command and Control
+  - Lateral Movement
+  - Stealth
+  - Execution
+techniques:
+  - T1219
+  - T1572
+  - T1543.003
+  - T1036.005
+  - T1105
+  - T1078
+tags:
+  - persistence
+  - command_and_control
+  - lateral_movement
+  - windows
+  - rmm_abuse
+  - n_central
+  - n_able
+  - take_control
+  - cve_2026_18577
+  - cve_2026_18556
+  - cloudflare_tunnel
+  - cloudflared
+  - tunnel_persistence
+  - service_persistence
+  - masquerading
+  - svchost
+  - msp
+  - t1543_003
+  - t1036_005
+submitter:
+  name: Joshua Strickland
+  link: https://novasky.io
+required_data_sources:
+  - "Endpoint EDR service-installation telemetry, or Windows System log Event ID 7045 and Security Event ID 4697 - service name, display name, service image path, start type, installing account"
+  - "Endpoint EDR process-creation telemetry - process name, full process command line, file path, parent process name, parent process command line, signer and original-filename metadata"
+  - "Endpoint EDR file-creation telemetry - file path, file name, writing process, file hash, for user-writable directories such as Documents, Downloads, Public, AppData and ProgramData"
+  - Endpoint registry telemetry - writes under the Services hive image path value and to per-profile tunnel configuration directories
+  - Windows Application event log from managed endpoints - remote-control session start and stop records including account name and source address
+  - "RMM platform console audit logs - administrator authentication, account creation and modification, and remote-control session history with viewer source IP, operator identity, target device and timestamp"
+  - "Network egress telemetry from DNS, proxy, or firewall - destination hostname, destination port, transport protocol, session duration, bytes transferred, and the initiating process where available"
+  - "Software and service inventory or configuration-management data - authorized installations of tunnel connector software, to separate sanctioned deployments from adversary-installed ones"
+false_positive_notes: |
+  Sanctioned Cloudflare Tunnel use is the dominant false positive and is common in organisations that expose internal web applications or run developer previews. Separate it structurally rather than by tuning thresholds: legitimate connectors are installed under `%ProgramFiles%` by a deployment or configuration-management identity, appear in software inventory and change records, and cluster on a small, stable set of hosts. Adversary connectors run from user-writable paths, are installed inside an interactive remote-control session, and appear on a host that has never had one before. Establish a one-time baseline of hosts with a `Cloudflared` service and hosts with port `7844` egress, get each owner-confirmed, and thereafter alert only on additions to that set.
+  
+  Port `7844` egress can also originate from sanctioned Cloudflare Zero Trust deployments on managed laptops. Pin the allowlist to the initiating process file path, not just the destination — an approved connector at a `%ProgramFiles%` path is fine, the same destination from a Documents folder is not.
+  
+  Remote-control session events are legitimately high volume in an MSP or managed estate: the `MSP Support` operator account and Take Control session records are expected during normal support work, so session events alone are not a finding. The signal is a session that is followed within the same window by a file write to a user-writable path, a service installation, or new outbound tunnel egress. Sessions targeting domain controllers, hypervisors, or backup infrastructure, or occurring outside a change window, deserve review even without a follow-on artifact, but should be resolved with the technician rather than escalated blind.
+  
+  Software distribution and patching can install services whose binaries sit temporarily in `%PROGRAMDATA%` or a staging directory. Those are installed by known deployment lineage and the service is normally short-lived or immediately repointed; check the installing parent before escalating.
+  
+  The masqueraded-`svchost.exe` filter is the cleanest of the four and needs almost no tuning — a `svchost.exe` outside `System32` or `SysWOW64`, without a `-k` argument, or with a parent other than `services.exe`, does not occur in normal Windows operation. The rare benign hit is a security-tool sandbox or a software test harness copying system binaries, which is identifiable by the writing process.
+  
+  The reported IP and domain infrastructure will decay quickly and should never be the alerting logic — used as a scoping aid it tells you which console sessions to review first, but an environment that only searches those values will miss the same tradecraft on rotated infrastructure.
+notes: |
+  Endpoint service-creation telemetry (EDR service events, or Windows System log `Event ID 7045` / Security `Event ID 4697`) - Core filter: service installations where the service name or display name contains `Cloudflared`, OR where the `service image path` references `cloudflared.exe`, `tunnel run`, `service install`, or `--token`. Triage values: `service name`, `display name`, `service image path`, `start type`, `installing account name`, `file path` of the service binary, `parent process command line` of the installing process. Strong red flags: an image path resolving under a user-writable directory — `C:\Users\<user>\Documents\`, `C:\Users\<user>\Downloads\`, `C:\Users\Public\`, `%APPDATA%`, or `%PROGRAMDATA%` — instead of `%ProgramFiles%`; an image path carrying an inline connector token, e.g. `cloudflared.exe service install <base64 token>` or `cloudflared.exe tunnel run --token <base64>`; `start type` of auto on a host with no sanctioned tunnel deployment; the service installed by an account that is not a software-deployment or configuration-management identity. Pivot: registry telemetry for writes to `HKLM\SYSTEM\CurrentControlSet\Services\Cloudflared\ImagePath`, and for connector configuration staged at `C:\Windows\System32\config\systemprofile\.cloudflared\` or `%USERPROFILE%\.cloudflared\` — look for `config.yml`, `cert.pem`, and a `<tunnel-uuid>.json` credentials file. False positive: sanctioned tunnel connectors installed by IT will normally live under `%ProgramFiles%`, appear in software inventory, and be installed by a deployment account — pin those to an allowlist of host plus image path rather than suppressing the service name globally.
+  
+  Endpoint process and file telemetry (EDR process create and file create) - Core filter: any process named `svchost.exe` whose `file path` is neither `C:\Windows\System32\svchost.exe` nor `C:\Windows\SysWOW64\svchost.exe`. Triage values: `file path`, `process command line`, `parent process name`, `parent process command line`, publisher/signer, `original filename` metadata, `file hash`. Strong red flags: genuine `svchost.exe` is always launched by `services.exe` and always carries a service-group argument such as `-k netsvcs` or `-k LocalServiceNetworkRestricted` — a `svchost.exe` with no `-k` argument, or with any parent other than `services.exe`, is a masquerade regardless of path; a `svchost.exe` whose `original filename` metadata does not read `svchost.exe`; a process claiming to be `svchost.exe` while carrying connector argument vocabulary such as `--token`, `tunnel run`, `--protocol quic`, `--edge-ip-version`, or `--no-autoupdate`. Correlation: find the file-write that created the binary and pull the writing process — in this campaign the write lands minutes before the service install and is parented by a remote-control or RMM agent lineage rather than by a browser or installer. Pivot: hash the binary and sweep the estate for the same hash under any user-writable path, since one console reaches many endpoints and many tenants.
+  
+  Remote-control and RMM agent telemetry (Windows Application event log plus vendor agent logs on the endpoint) - Core filter: remote-control session records on managed endpoints — for N-central Take Control these are Windows Application log `Event ID 8192` (session start) and `Event ID 8193` (session end), plus `Event ID 4102`, under the default operator account name `MSP Support`. Triage values: `account name`, `session start time`, `session end time`, `viewer source IP address`, `device name`. Pivot: file-creation telemetry for `C:\ProgramData\GetSupportService_N-Central\Logs\BASupSrvc_*.log.gz` — each new archived log bounds a session window; join that window by host and time to process, file, service, and network events and treat everything inside it as operator-attributable. Correlation: on the console side, review `ui_access_control.log` for administrator logins and remote-control launches from source IPs with no history for that operator, for out-of-hours sessions, and for use of the built-in vendor support identity `mspsupport@n-able.com`; every device touched in those sessions is in scope. Strong red flags: a remote-control session targeting a domain controller, hypervisor, or backup server outside a change window; scripting and job execution pushed through the management agent — `AutomationManager.AgentService.exe`, `AutomationManager.ScriptRunner64.exe`, `AutomationManager.ScriptRunner32.exe`, or `agent.exe` — spawning `cmd.exe` or `powershell.exe` inside the same window; local administrator account creation or modification on the endpoint during the session.
+  
+  Network egress telemetry (DNS, proxy, firewall, and EDR network events) - Core filter: outbound resolution of or connection to `region1.v2.argotunnel.com` and `region2.v2.argotunnel.com` (or the `us-region1` / `us-region2` equivalents), and any session to destination port `7844` — TCP for the http2 transport, UDP for the QUIC transport, which is the default. Triage values: `initiating process name`, `file path` of the initiating process, `destination hostname`, `destination port`, transport protocol, session duration, bytes sent versus bytes received. Strong red flags: `7844/udp` egress originating from a workstation, domain controller, or server rather than from a sanctioned connector host; a session that survives a reboot and re-establishes without user logon; an initiating process whose `file path` is a user Documents or AppData directory; a small number of very long-lived sessions rather than short bursts. Correlation: join egress by host and time back to the service-install event and the remote-control session window — the three together are the confirmation, and any one alone is only a lead. Scoping pivot: the reported infrastructure — `173.249.252[.]200`, `87.249.138[.]34`, `37.19.210[.]32`, `68.235.46[.]214`, `37.153.90[.]88`, `92.118.112[.]181`, `173.249.252[.]176`, `185.156.46[.]150`, `23.234.94[.]43`, `68.235.46[.]235`, and the domains `mousears.synology[.]me`, `wagoosh.direct.quickconnect[.]to`, `who-ripped-one.direct.quickconnect[.]to` — should be used to scope which console sessions and which endpoints to examine first, not as the hunt itself; these rotate, the service-plus-tunnel chain does not.
+  
+  False positive - Development and IT teams legitimately run tunnel connectors, so drive triage from three qualifiers rather than from the connector's presence: image path outside `%ProgramFiles%`, an installing lineage that traces to a remote-control or agent session rather than to a deployment tool, and absence from software inventory. Build a one-time baseline of every host with a `Cloudflared` service and every host with `7844` egress, get each entry owner-confirmed, then alert only on additions to that baseline. Genuine `svchost.exe` outside `System32`/`SysWOW64` effectively does not occur, so that filter needs no tuning; the parent-and-argument check catches renamed connectors even when the path looks plausible.
+---
+# H263
+
+On August 2, 2026 N-able disclosed CVE-2026-18577, an authentication bypass in N-central that lets an unauthenticated remote attacker obtain full administrative access to the console. It is an incomplete-fix bypass of CVE-2026-18556; exploitation was observed in the wild from August 1, 2026, and CISA added it to the KEV catalog on August 3. All builds up to and including 2026.3.1 are affected; 2026.3.1 Hotfix 1 (2026.3.1.7) mitigates it, with Hotfix 2 (2026.3.1.10) following on August 6.
+
+What makes this hunt-worthy is not the vulnerability but what the operators did after it. Rapid7, Huntress, and N-able all describe the same post-exploitation pattern: administrative console access is used to enumerate managed devices and running processes, high-value targets such as domain controllers are selected, and the platform's Take Control remote-access feature is used to reach endpoints directly. On those endpoints the operators dropped a file named `svchost.exe` into a user's Documents folder and registered a Windows service named `Cloudflared` that establishes an outbound Cloudflare Tunnel. Huntress confirmed exploitation of one self-hosted instance where the operators reached nine managed organizations and touched one endpoint in each.
+
+That endpoint chain is the durable part. The tunnel is dialed outbound, so no inbound firewall rule or listening port is required and perimeter controls never see an inbound connection attempt. Running as a service means it survives reboot and reconnects unattended. The masqueraded `svchost.exe` name means casual process-list review by a technician reads as normal. The result is a second, vendor-independent access path into a managed estate that persists after the RMM server is patched and its credentials rotated — which is precisely why the hunt should target the endpoint artifacts rather than the console vulnerability.
+
+This is also an MSP-scale problem: one compromised console reaches every downstream tenant it manages, so a single missed endpoint artifact leaves standing access into a customer environment whose defenders may never learn the platform was involved.
+
+## Why
+
+- Access via a compromised RMM console is one-to-many by construction, and this chain converts it into access that outlives the fix: patching N-central to 2026.3.1.7 or 2026.3.1.10 and rotating console credentials removes the adversary's front door but does nothing to the tunnel service already running on the endpoints. Huntress documented one compromised self-hosted instance reaching nine downstream organisations, so a defender who patched and closed the incident on August 3 may still have standing operator access in customer environments today.
+- The chain forces the adversary through steps that cannot be renamed away. Outbound-only tunnel persistence requires an auto-start service pointing at a binary the adversary controls, and reaching the tunnel provider's edge requires connecting to `region1.v2.argotunnel.com` or `region2.v2.argotunnel.com` on port `7844`. The tunnel token, the service display name, the dropped filename, and every IP in the current reporting can all rotate, but a service whose image path lands in a user profile directory and a long-lived `7844` session from a host that had neither yesterday survive all of it.
+- Every link is visible in telemetry organisations already collect, with no specialised tooling: service installation is a standard Windows System-log record, the masqueraded binary appears in ordinary process-creation events, and the remote-control session is bounded precisely by Application-log session-start and session-stop records plus the archived `BASupSrvc_*.log.gz` files on disk. That last artifact is the pivot that makes this practical — it converts a vague 'were we accessed?' question into a specific time window per host that can be joined to process, service, and network events.
+- The false positives are bounded and resolvable rather than statistical. A `svchost.exe` outside `System32` or `SysWOW64`, or one lacking a `-k` service-group argument, effectively does not occur on healthy Windows, and sanctioned tunnel connectors are few, owner-attributable, and separable by install path and installing lineage — so a one-time baseline reduces this to alert-on-addition instead of a tuning exercise that decays.
+
+## References
+
+- [Rapid7 - CVE-2026-18577: N-able N-central Authentication Bypass Exploited in the Wild](https://www.rapid7.com/blog/post/etr-cve-2026-18577-n-able-n-central-authentication-bypass-exploited-in-the-wild/)
+- [Huntress - Critical N-able N-central Vulnerability and Active Exploitation](https://www.huntress.com/blog/n-able-vulnerability-exploitation)
+- [Beazley Security - N-central Authorization Bypass exploited in the wild (CVE-2026-18577)](https://beazley.security/alerts-advisories/n-central-authorization-bypass-exploited-in-the-wild-cve-2026-18577)
+- [N-able Status - N-central 2026.3 Hotfix 1, mitigation for CVE-2026-18577](https://status.n-able.com/2026/08/02/n-central-2026-3-hotfix-1-mitigation-for-cve-2026-18577/)
+- [Help Net Security - Attackers exploit N-able N-central flaw to reach managed endpoints (CVE-2026-18577)](https://www.helpnetsecurity.com/2026/08/03/cve-2026-18577-n-able-n-central-vulnerability/)
+- [CISA Known Exploited Vulnerabilities Catalog](https://www.cisa.gov/known-exploited-vulnerabilities-catalog)
+- [Cloudflare Docs - Tunnel with firewall (edge endpoints and port 7844)](https://developers.cloudflare.com/cloudflare-one/networks/connectors/cloudflare-tunnel/configure-tunnels/tunnel-with-firewall/)
+- [Cloudflare Docs - Tunnel run parameters (--token, --protocol, --edge-ip-version)](https://developers.cloudflare.com/cloudflare-one/networks/connectors/cloudflare-tunnel/configure-tunnels/run-parameters/)
+- [Cloudflare Docs - Run cloudflared as a service on Windows](https://developers.cloudflare.com/cloudflare-one/networks/connectors/cloudflare-tunnel/downloads/)
+- [GuidePoint Security - Tunnel Vision: cloudflared Abused in the Wild](https://www.guidepointsecurity.com/blog/tunnel-vision-cloudflared-abused-in-the-wild/)
+- [MITRE ATT&CK T1219 - Remote Access Tools](https://attack.mitre.org/techniques/T1219/)
+- [MITRE ATT&CK T1572 - Protocol Tunneling](https://attack.mitre.org/techniques/T1572/)
+- [MITRE ATT&CK T1543.003 - Create or Modify System Process: Windows Service](https://attack.mitre.org/techniques/T1543/003/)
+- [MITRE ATT&CK T1036.005 - Masquerading: Match Legitimate Name or Location](https://attack.mitre.org/techniques/T1036/005/)
+- [N-able Documentation - Automation Manager agent and Windows agent components](https://documentation.n-able.com/N-central/userguide/Content/Automation/AutoMgr_Overview.html)


### PR DESCRIPTION
## Summary

Adds `H263`: Remote-control session on a managed endpoint installs a Cloudflare Tunnel service and runs svchost.exe from a user Documents folder.

## Sources

- https://www.rapid7.com/blog/post/etr-cve-2026-18577-n-able-n-central-authentication-bypass-exploited-in-the-wild

## Validation

- Draft reviewed locally before submission.
- Source links are preserved in the hunt writeup.
