### PR TITLE
Add H264: npm lifecycle hook launches an alternate runtime before harvesting developer and CI secrets

### DIFF
--- a/Flames/H264.md
+++ b/Flames/H264.md
@@ -1,0 +1,76 @@
+---
+id: H264
+category: Flames
+title: npm lifecycle hook launches an alternate runtime before harvesting developer and CI secrets
+hypothesis: >-
+  A compromised npm dependency is executing an install lifecycle hook on a developer workstation or CI runner, switching from Node.js to a downloaded Bun runtime, reading credential stores, and establishing developer-context persistence before the dependency installation completes.
+tactics:
+  - Initial Access
+  - Execution
+  - Credential Access
+  - Collection
+  - Persistence
+  - Command and Control
+  - Exfiltration
+techniques:
+  - T1195.001
+  - T1059.007
+  - T1059.004
+  - T1552.001
+  - T1105
+  - T1005
+  - T1543.001
+  - T1543.002
+  - T1041
+tags:
+  - npm
+  - software_supply_chain
+  - developer_workstation
+  - ci_runner
+  - lifecycle_hook
+  - bun_runtime
+  - credential_theft
+  - developer_tooling
+  - launch_agent
+  - systemd_user_service
+submitter:
+  name: Joshua Strickland
+  link: https://novasky.io
+required_data_sources:
+  - Endpoint process creation and ancestry telemetry
+  - Endpoint file-open and file-write telemetry
+  - Endpoint network connection and DNS telemetry
+  - macOS LaunchAgent and Linux systemd user-service telemetry
+  - "CI job, runner, and dependency-install logs"
+  - Source-control and package-registry audit logs
+  - "Cloud identity, control-plane, and resource-access audit logs"
+false_positive_notes: |
+  Legitimate npm dependencies may use lifecycle scripts, download platform-specific binaries, compile native modules, or read limited configuration required for authentication to an internal registry. Some approved build pipelines also install Bun or access cloud credentials during deployment. Control noise by comparing the full chain rather than alerting on any single atom: require package-manager ancestry plus an alternate runtime or sensitive-file access, and strengthen confidence with persistence writes, unrelated credential families, metadata-service access, or unexpected publishing and repository activity. Maintain per-repository allowlists for approved lifecycle scripts, executable locations, registry and artifact destinations, credential paths, and deployment stages. Treat `.vscode/tasks.json` alone as low confidence because projects legitimately define folder tasks; elevate it when the task invokes a newly added setup script or appears across unrelated branches. A systemd user service or LaunchAgent that watches a token for revocation and executes a stored handler has no ordinary package-install justification and should be treated as high confidence.
+notes: |
+  Endpoint process and network telemetry - Core filter: package-manager ancestry such as `npm install`, `npm ci`, `pnpm install`, or `yarn install` spawning `node setup.mjs`, followed by `bun`, `Math_Symbol.js`, or `math_init.js`. Triage values: `process command line`, `parent process command line`, `executable path`, `working directory`, `user`, `repository path`, `CI job ID`. Pivot/Correlation: follow the same process tree for a download from `github.com/oven-sh/bun/releases/download/bun-v1.3.13/`, execution from `/tmp/bun-dl-*` or another writable directory, and outbound connections before the install process exits. Strong red flags: a package lifecycle script introducing a previously absent runtime, Bun launched from a temporary path, or the alternate runtime making connections unrelated to the configured package registry.
+  
+  Endpoint file-access telemetry - Core filter: a process descended from the install chain opening `~/.npmrc`, `~/.config/gh/hosts.yml`, `~/.aws/credentials`, `~/.kube/config`, `~/.vault-token`, `~/.ssh/id_rsa`, `~/.ssh/id_ed25519`, `.env`, or `/var/run/secrets/kubernetes.io/serviceaccount/token`. Triage values: `file path`, `access type`, `process command line`, `parent process command line`, `file owner`, `repository path`. Correlation: require multiple credential families, high-rate file enumeration, or a sensitive-file read followed by archive creation or outbound HTTPS from the same process lineage. Strong red flags: install-time access to credentials that the build stage does not require, reads across home directories, access to `/proc/<pid>/mem`, or simultaneous collection of package-publishing and cloud credentials.
+  
+  Persistence and repository-write telemetry - Core filter: creation or modification of `~/.local/bin/gh-token-monitor.sh`, `~/.config/gh-token-monitor/token`, `~/.config/gh-token-monitor/handler`, `~/.config/systemd/user/gh-token-monitor.service`, `~/Library/LaunchAgents/com.user.gh-token-monitor.plist`, or `.vscode/tasks.json` by `node`, `bun`, a package manager, or their shell children. Triage values: `file path`, `write process`, `service label`, `unit description`, `RunAtLoad`, `KeepAlive`, `runOn`, `folderOpen`. Pivot: inspect service creation, `loginctl enable-linger`, `launchctl` activity, a polling interval near `60` seconds, and requests to `api.github.com/user`. Strong red flags: a service described as `GitHub Token Validity Monitor`, a handler evaluated after an HTTP `4xx`, or repository configuration that launches a setup script when a folder opens.
+  
+  Identity, registry, and source-control audit telemetry - Core filter: after the host-side chain, find token validation or publishing activity involving `/-/whoami`, `/-/npm/v1/tokens`, `/-/npm/v1/oidc/token/exchange/package/`, `POST /user/repos`, or repository commits and package publications outside the normal release workflow. Triage values: `principal`, `token type`, `package name`, `version`, `repository`, `workflow identity`, `source IP address`, `user agent`. Correlation: join activity to the affected developer, runner, repository, and install interval; then compare package-publication and repository-write events against approved release jobs. Strong red flags: one identity publishing newly patched versions across unrelated packages, adding `preinstall: node setup.mjs`, creating repositories used only for encrypted uploads, or writing development-tool trigger files across many branches.
+  
+  Post-compromise cloud and resource-access telemetry - Core filter: the affected identity or runner accesses `169.254.169.254`, `169.254.170.2`, `/v1/sys/mounts`, or the Kubernetes API shortly after the install chain. Triage values: `principal`, `source workload`, `API path`, `resource`, `namespace`, `region`, `source IP address`, `session identifier`. Pivot/Correlation: connect credential-file reads to subsequent secret enumeration, cloud API calls, Vault KV access, Kubernetes secret reads, or package-registry changes using the host, user, runner, and time window. Strong red flags: metadata access from `node` or `bun`, secrets enumeration by a build identity that normally only downloads dependencies, or cross-service access beginning immediately after dependency installation.
+---
+# H264
+
+Compromised npm releases added `preinstall: node setup.mjs` while leaving normal library output unchanged. The loader can download Bun 1.3.13 when the runtime is absent and use it to execute a large JavaScript payload named Math_Symbol.js or math_init.js. Reported follow-on behavior includes reading npm, source-control, cloud, Vault, Kubernetes, database, and SSH credentials; querying cloud and container metadata services; propagating through stolen package-publishing access; writing project-local development-tool triggers; and installing a GitHub-token monitor as a macOS LaunchAgent or Linux systemd user service. The durable detection opportunity is the install-time chain from package-manager ancestry to an alternate runtime, sensitive-file access, persistence writes, and subsequent account or resource access—not a package name, version, hash, or fixed destination.
+
+## Why
+
+- The incident demonstrates that valid package provenance does not prevent malicious execution when the trusted source or release path is already compromised; install-time behavior must therefore be observed on developer systems and runners.
+- The chain survives package, hash, and destination rotation because the attacker still needs a lifecycle trigger, an executable runtime, access to credential stores, and a way to use or persist the stolen access.
+- Process ancestry, sensitive-file opens, temporary-runtime execution, service-file writes, registry activity, and cloud API access are observable across endpoint, CI, identity, and control-plane telemetry, allowing independent signals to reinforce one another.
+- False positives are controllable by scoping activity to the dependency-install interval and requiring behavior that normal builds rarely combine, such as alternate-runtime execution plus unrelated credential reads, token-monitor persistence, or unapproved package publication.
+
+## References
+
+- [Inside the keyv npm Compromise: preinstall Malware, Trusted Provenance, and IDE Hooks](https://snyk.io/blog/inside-keyv-npm-compromise-preinstall-malware-trusted-provenance-ide-hooks/)
+- [Popular npm Packages in the keyv and Cacheable Namespaces Compromised in Active Supply Chain Attack](https://socket.dev/blog/popular-npm-packages-in-the-keyv-and-cacheable-namespaces-compromised-in-active-supply-chain)
+- [Keyv and friends compromised in active Shai-Hulud supply chain attack](https://www.aikido.dev/blog/keyv-and-friends-compromised-in-npm-supply-chain-attack)
+- [keyv and cacheable npm Package Hijacked in Supply Chain Attack](https://www.wiz.io/blog/keyv-and-cacheable-npm-supply-chain-attack)


### PR DESCRIPTION
## Summary

Adds `H264`: npm lifecycle hook launches an alternate runtime before harvesting developer and CI secrets.

## Sources

- https://snyk.io/blog/inside-keyv-npm-compromise-preinstall-malware-trusted-provenance-ide-hooks/

## Validation

- Draft reviewed locally before submission.
- Source links are preserved in the hunt writeup.
