### PR TITLE
fix(scripts): reassign hunt IDs in all categories, not just Flames

### DIFF
--- a/scripts/hunt_ids.py
+++ b/scripts/hunt_ids.py
@@ -1,30 +1,46 @@
 """Shared helpers for HEARTH hunt-ID parsing, allocation, and rewriting.
 
-Flames hunt IDs use the format ``HNNN`` (e.g. ``H200``), one monotonic sequence
-across the whole catalog. Embers/Alchemy use ``BNNN``/``MNNN`` in their own
-namespaces; this allocator is Flames-only and ignores them.
+Each category owns an independent, monotonic sequence: Flames ``HNNN``
+(e.g. ``H200``), Embers ``BNNN``, Alchemy ``MNNN``. The number spaces do not
+interact — ``H200`` and ``B200`` are unrelated IDs — so every helper here takes
+the category's prefix and reasons within that one namespace.
+
+The prefix defaults to ``"H"`` so Flames-only callers read unchanged.
 """
 
 from __future__ import annotations
 
 import re
+from collections.abc import Iterable
 from pathlib import Path
-from typing import Iterable
+
+#: Directory -> ID prefix. Mirrors the allocation map in
+#: ``scripts/process_hunt_submission.py``; keep the two in sync.
+CATEGORY_PREFIXES = {"Flames": "H", "Embers": "B", "Alchemy": "M"}
 
 HUNT_STEM_RE = re.compile(r"^H(\d+)$")
 
 
-def parse_hunt_number(stem: str) -> int | None:
-    """Return the numeric part of an ``HNNN`` stem, or None if it isn't one."""
-    match = HUNT_STEM_RE.match(stem)
+def prefix_for_category(category: str) -> str:
+    """ID prefix for a category directory name. Unknown categories -> ``"H"``."""
+    return CATEGORY_PREFIXES.get(category, "H")
+
+
+def parse_hunt_number(stem: str, prefix: str = "H") -> int | None:
+    """Return the numeric part of a ``<prefix>NNN`` stem, or None if it isn't one.
+
+    Only matches the given prefix: ``parse_hunt_number("B001")`` is None because
+    the default prefix is ``H``. Pass ``prefix="B"`` to read Embers stems.
+    """
+    match = re.match(rf"^{re.escape(prefix)}(\d+)$", stem)
     return int(match.group(1)) if match else None
 
 
-def existing_numbers(names: Iterable[str]) -> set[int]:
-    """Collect the numeric IDs from an iterable of ``HNNN(.md)`` names/paths."""
+def existing_numbers(names: Iterable[str], prefix: str = "H") -> set[int]:
+    """Collect the numeric IDs from an iterable of ``<prefix>NNN(.md)`` names."""
     nums: set[int] = set()
     for name in names:
-        num = parse_hunt_number(Path(name).stem)
+        num = parse_hunt_number(Path(name).stem, prefix)
         if num is not None:
             nums.add(num)
     return nums
@@ -39,8 +55,8 @@ def next_free_number(existing: set[int]) -> int:
     return max(existing) + 1 if existing else 1
 
 
-def format_hunt_id(num: int) -> str:
-    return f"H{num:03d}"
+def format_hunt_id(num: int, prefix: str = "H") -> str:
+    return f"{prefix}{num:03d}"
 
 
 def rewrite_hunt_id(path: Path, new_id: str) -> Path:

--- a/scripts/reassign_hunt_id.py
+++ b/scripts/reassign_hunt_id.py
@@ -2,11 +2,15 @@
 """Reassign a draft hunt's ID if it collides with one already taken.
 
 Run on a checked-out draft branch with ``origin/main`` fetched. A draft's ID
-collides if the same ``HNNN`` number is already on ``main`` OR is claimed by
-another open ``draft/issue-*`` branch belonging to a lower-numbered issue
-(lower issue == earlier submission == priority). Colliding files are renamed to
-the next free number — considering main and every other draft branch — and the
-rename is staged.
+collides if the same number is already on ``main`` OR is claimed by another
+open ``draft/issue-*`` branch belonging to a lower-numbered issue (lower issue
+== earlier submission == priority). Colliding files are renamed to the next
+free number — considering main and every other draft branch — and the rename is
+staged.
+
+Covers all three categories (Flames ``HNNN``, Embers ``BNNN``, Alchemy
+``MNNN``). Each is an independent number space, so a draft's ``B035`` is only
+blocked by other Embers IDs; ``H035`` on main is irrelevant to it.
 
 Tiebreak by issue number makes a batch of approvals collision-free regardless
 of the order they run in: the earliest issue keeps the contested number and
@@ -30,6 +34,7 @@ if _REPO_ROOT not in sys.path:
     sys.path.insert(0, _REPO_ROOT)
 
 from scripts.hunt_ids import (
+    CATEGORY_PREFIXES,
     existing_numbers,
     format_hunt_id,
     next_free_number,
@@ -37,7 +42,6 @@ from scripts.hunt_ids import (
     rewrite_hunt_id,
 )
 
-FLAMES = "Flames"
 _DRAFT_RE = re.compile(r"draft/issue-(\d+)$")
 
 
@@ -47,39 +51,58 @@ def _git(*args: str) -> str:
     ).stdout
 
 
-def _added_numbers(ref: str) -> set[int]:
-    """Hunt numbers a ref ADDS under Flames/ relative to main."""
+def _added_numbers(ref: str, category: str, prefix: str) -> set[int]:
+    """Hunt numbers a ref ADDS under ``category/`` relative to main."""
     out = _git(
-        "diff", "--diff-filter=A", "--name-only", f"origin/main...{ref}",
-        "--", f"{FLAMES}/",
+        "diff",
+        "--diff-filter=A",
+        "--name-only",
+        f"origin/main...{ref}",
+        "--",
+        f"{category}/",
     )
-    return existing_numbers(p for p in out.splitlines() if p.endswith(".md"))
+    return existing_numbers((p for p in out.splitlines() if p.endswith(".md")), prefix)
 
 
-def _main_numbers() -> set[int]:
-    out = _git("ls-tree", "-r", "--name-only", "origin/main", "--", f"{FLAMES}/")
-    return existing_numbers(out.splitlines())
+def _main_numbers(category: str, prefix: str) -> set[int]:
+    out = _git("ls-tree", "-r", "--name-only", "origin/main", "--", f"{category}/")
+    return existing_numbers(out.splitlines(), prefix)
 
 
-def _added_files() -> list[Path]:
+def _added_files(category: str) -> list[Path]:
     out = _git(
-        "diff", "--diff-filter=A", "--name-only", "origin/main...HEAD",
-        "--", f"{FLAMES}/",
+        "diff",
+        "--diff-filter=A",
+        "--name-only",
+        "origin/main...HEAD",
+        "--",
+        f"{category}/",
     )
     return [Path(p) for p in out.splitlines() if p.endswith(".md")]
 
 
-def _other_draft_claims(current_issue: int) -> dict[int, int]:
-    """Map each hunt number claimed by another open draft branch to the lowest
-    issue number claiming it. Empty/offline is a safe no-op."""
+def _fetch_draft_refs() -> None:
+    """Mirror every draft branch locally. Offline/empty is a safe no-op."""
     subprocess.run(
         ["git", "fetch", "origin", "refs/heads/draft/*:refs/remotes/origin/draft/*"],
-        check=False, capture_output=True, text=True,
+        check=False,
+        capture_output=True,
+        text=True,
     )
+
+
+def _other_draft_claims(
+    current_issue: int, category: str, prefix: str
+) -> dict[int, int]:
+    """Map each hunt number claimed by another open draft branch to the lowest
+    issue number claiming it. Scoped to one category. Assumes draft refs are
+    already fetched."""
     claims: dict[int, int] = {}
     out = subprocess.run(
         ["git", "for-each-ref", "--format=%(refname)", "refs/remotes/origin/draft/"],
-        check=False, capture_output=True, text=True,
+        check=False,
+        capture_output=True,
+        text=True,
     ).stdout
     for ref in out.splitlines():
         match = _DRAFT_RE.search(ref)
@@ -88,7 +111,7 @@ def _other_draft_claims(current_issue: int) -> dict[int, int]:
         issue = int(match.group(1))
         if issue == current_issue:
             continue
-        for num in _added_numbers(ref):
+        for num in _added_numbers(ref, category, prefix):
             if num not in claims or issue < claims[num]:
                 claims[num] = issue
     return claims
@@ -105,38 +128,46 @@ def _set_output(changed: bool, hunt_id: str) -> None:
 
 def main() -> int:
     current_issue = int(os.environ.get("ISSUE_NUMBER", "0") or "0")
-    main_nums = _main_numbers()
-    other_claims = _other_draft_claims(current_issue)
-
-    # Must not KEEP a number on main or held by a lower-numbered issue.
-    blocked = set(main_nums) | {
-        num for num, issue in other_claims.items() if issue < current_issue
-    }
-    # When allocating a fresh number, avoid everything known to be claimed.
-    claimed = set(main_nums) | set(other_claims)
+    _fetch_draft_refs()
 
     changed = False
     final_id = ""
 
-    for path in _added_files():
-        num = parse_hunt_number(path.stem)
-        if num is None:
+    # Each category is an independent number space, so state is per-category.
+    for category, prefix in CATEGORY_PREFIXES.items():
+        added = _added_files(category)
+        if not added:
             continue
-        final_id = path.stem
-        if num in blocked:
-            new_num = next_free_number(claimed)
-            new_id = format_hunt_id(new_num)
-            new_path = rewrite_hunt_id(path, new_id)
-            _git("add", "-A", "--", FLAMES)
-            claimed.add(new_num)
-            blocked.add(new_num)
-            final_id = new_id
-            changed = True
-            print(f"Reassigned {path.name} -> {new_path.name} (id already claimed)")
-        else:
-            claimed.add(num)
-            blocked.add(num)
-            print(f"{path.name}: ID free, no change")
+
+        main_nums = _main_numbers(category, prefix)
+        other_claims = _other_draft_claims(current_issue, category, prefix)
+
+        # Must not KEEP a number on main or held by a lower-numbered issue.
+        blocked = set(main_nums) | {
+            num for num, issue in other_claims.items() if issue < current_issue
+        }
+        # When allocating a fresh number, avoid everything known to be claimed.
+        claimed = set(main_nums) | set(other_claims)
+
+        for path in added:
+            num = parse_hunt_number(path.stem, prefix)
+            if num is None:
+                continue
+            final_id = path.stem
+            if num in blocked:
+                new_num = next_free_number(claimed)
+                new_id = format_hunt_id(new_num, prefix)
+                new_path = rewrite_hunt_id(path, new_id)
+                _git("add", "-A", "--", category)
+                claimed.add(new_num)
+                blocked.add(new_num)
+                final_id = new_id
+                changed = True
+                print(f"Reassigned {path.name} -> {new_path.name} (id already claimed)")
+            else:
+                claimed.add(num)
+                blocked.add(num)
+                print(f"{path.name}: ID free, no change")
 
     if not changed:
         print("No hunt-ID collisions to fix.")

--- a/scripts/tests/test_hunt_ids.py
+++ b/scripts/tests/test_hunt_ids.py
@@ -1,10 +1,13 @@
 from pathlib import Path
 
 from scripts.hunt_ids import (
+    CATEGORY_PREFIXES,
+    existing_numbers,
     find_id_problems,
     format_hunt_id,
     next_free_number,
     parse_hunt_number,
+    prefix_for_category,
     rewrite_hunt_id,
 )
 
@@ -20,6 +23,24 @@ def test_parse_hunt_number():
     assert parse_hunt_number("not-an-id") is None
 
 
+def test_parse_hunt_number_honours_prefix():
+    # Regression for #380: Embers/Alchemy stems were unparseable, so the
+    # reassigner skipped them and their collisions survived to CI.
+    assert parse_hunt_number("B035", "B") == 35
+    assert parse_hunt_number("M007", "M") == 7
+    # A prefix reads only its own namespace.
+    assert parse_hunt_number("H035", "B") is None
+    assert parse_hunt_number("B035", "H") is None
+
+
+def test_prefix_for_category():
+    assert prefix_for_category("Flames") == "H"
+    assert prefix_for_category("Embers") == "B"
+    assert prefix_for_category("Alchemy") == "M"
+    assert prefix_for_category("Unknown") == "H"  # safe default
+    assert CATEGORY_PREFIXES == {"Flames": "H", "Embers": "B", "Alchemy": "M"}
+
+
 def test_next_free_number():
     assert next_free_number(set()) == 1
     assert next_free_number({1, 2}) == 3
@@ -30,6 +51,20 @@ def test_next_free_number():
 def test_format_hunt_id():
     assert format_hunt_id(3) == "H003"
     assert format_hunt_id(200) == "H200"
+
+
+def test_format_hunt_id_honours_prefix():
+    assert format_hunt_id(36, "B") == "B036"
+    assert format_hunt_id(7, "M") == "M007"
+
+
+def test_existing_numbers_is_namespaced():
+    # Mixed listing: each prefix sees only its own IDs, so an Embers draft is
+    # never blocked by a Flames number that happens to match.
+    names = ["Flames/H035.md", "Embers/B035.md", "Alchemy/M002.md", "README.md"]
+    assert existing_numbers(names, "H") == {35}
+    assert existing_numbers(names, "B") == {35}
+    assert existing_numbers(names, "M") == {2}
 
 
 def _write_hunt(path: Path, hunt_id: str, hunt_cell: str = "") -> None:
@@ -63,6 +98,19 @@ def test_rewrite_hunt_id_updates_populated_table_cell(tmp_path):
     text = new_path.read_text()
     assert "| H203 |" in text
     assert "H201" not in text
+
+
+def test_rewrite_hunt_id_renames_an_embers_hunt(tmp_path):
+    # Regression for #380: the B035 -> B036 rename that had to be done by hand.
+    src = tmp_path / "B035.md"
+    _write_hunt(src, "B035", hunt_cell="B035")
+    new_path = rewrite_hunt_id(src, "B036")
+    assert new_path.name == "B036.md"
+    assert not src.exists()
+    text = new_path.read_text()
+    assert text.splitlines()[0] == "# B036"
+    assert "| B036 |" in text
+    assert "B035" not in text
 
 
 def test_find_id_problems_flags_main_collision():


### PR DESCRIPTION
Fixes #380.

## Problem

`scripts/reassign_hunt_id.py` hardcoded `FLAMES = "Flames"` and scoped every git call to that one directory. Embers and Alchemy drafts kept their colliding ID straight through approval.

`scripts/check_hunt_id_collisions.py` already covered all three dirs (`DIRS = ("Flames", "Embers", "Alchemy")`), so the two scripts disagreed on scope: the collision was **detected** at PR time but never **resolved** — a guaranteed red `validate` check and a manual rename.

Hit live on #374, where the draft claimed `Embers/B035.md` while `B035` had been taken on main by an unrelated hunt. Renamed to `B036` by hand to unblock it.

## Change

`hunt_ids.py` gains a category map and threads a prefix through the helpers:

```python
CATEGORY_PREFIXES = {"Flames": "H", "Embers": "B", "Alchemy": "M"}
```

`parse_hunt_number`, `existing_numbers`, and `format_hunt_id` take `prefix` defaulting to `"H"`, so every existing Flames-only caller reads unchanged.

`reassign_hunt_id.py` loops the three categories, rebuilding `blocked`/`claimed` per category. **Each is an independent number space** — main's `H035` no longer blocks a draft's `B035`.

The tiebreak-by-issue-number and concurrency-group logic carry over untouched; this is a scope widening, not a redesign. One small cleanup: the draft-ref `git fetch` is hoisted out of `_other_draft_claims` so it runs once rather than once per category.

## Verification

- **pytest 106/106**, flake8 clean at CI's exact settings (`--select=E9,F63,F7,F82`)
- 5 new cases in `test_hunt_ids.py`: prefix-aware parse/format, namespace isolation, and the `B035` → `B036` rename that had to be done by hand
- **End-to-end against throwaway git repos**, reproducing the real history shape (draft branches, then main independently takes the ID):
  - colliding Embers **and** Flames draft → both reassigned (`B035`→`B036`, `H262`→`H263`), headings and table cells rewritten
  - `B035` on a draft with only `H035` on main → correctly left alone

## Not addressed

`rewrite_hunt_id` still only rewrites the legacy `# <id>` heading and table cell, not a YAML `id:` field. That's fine today — `process_hunt_submission.py` emits legacy format for every draft — but it will need updating if the generator is migrated to frontmatter. Worth a follow-up issue rather than speculative code here.
