### PR TITLE
fix(parser): treat a raw pipe inside a code span as content, not a delimiter

### DIFF
--- a/scripts/hunt_parser.py
+++ b/scripts/hunt_parser.py
@@ -5,15 +5,16 @@ Single entry point for converting a hunt markdown file into a structured dict.
 Prefers YAML frontmatter (canonical). Falls back to the legacy 6-cell table
 format during the transition period — emits a DeprecationWarning when it does.
 """
+
 from __future__ import annotations
 
 import datetime as _dt
 import re
+import sys as _sys
 import warnings
 from pathlib import Path
 from typing import Any
 
-import sys as _sys
 _REPO_ROOT = str(Path(__file__).resolve().parent.parent)
 if _REPO_ROOT not in _sys.path:
     _sys.path.insert(0, _REPO_ROOT)
@@ -76,19 +77,38 @@ def _split_tactics(raw: str) -> list[str]:
 
 
 def _split_table_row(row: str) -> list[str]:
-    """Split a markdown table row on unescaped pipes; treat `\\|` as a literal pipe.
+    """Split a markdown table row on unescaped pipes outside code spans.
+
+    Two things are treated as literal pipes rather than delimiters:
+
+    * ``\\|`` — the conventional markdown escape.
+    * a raw ``|`` inside a backtick code span, e.g. ```a | b```. Authors write
+      these because they render correctly in a code span, but splitting on them
+      shifts every following cell and silently mangles the row (see #384 — it
+      moved Notes text into ``submitter.name`` on 12 hunts).
+
+    Code-span protection is skipped when the row has an odd number of backticks,
+    since an unbalanced span would otherwise swallow the rest of the row.
 
     Unlike the leaderboard helper, this one PRESERVES empty cells so positional
     alignment is maintained (we drop only the leading/trailing bookend cells).
     """
+    # Only honour code spans when they are balanced across the row.
+    protect_code = row.count("`") % 2 == 0
+
     cells: list[str] = []
     current: list[str] = []
+    in_code = False
     i = 0
     while i < len(row):
         if row[i] == "\\" and i + 1 < len(row) and row[i + 1] == "|":
             current.append("|")
             i += 2
-        elif row[i] == "|":
+        elif row[i] == "`" and protect_code:
+            in_code = not in_code
+            current.append("`")
+            i += 1
+        elif row[i] == "|" and not in_code:
             cells.append("".join(current).strip())
             current = []
             i += 1
@@ -120,7 +140,18 @@ def _parse_legacy_table(content: str, hunt_id: str, category: str) -> dict[str, 
     cells: list[str] = ["", "", "", "", "", ""]
     if table_start is not None and table_start + 2 < len(lines):
         raw = _split_table_row(lines[table_start + 2])
-        for j, c in enumerate(raw[:6]):
+        # A legacy row is exactly 6 cells. More means an unescaped delimiter
+        # split one of them; truncating to raw[:6] would silently shift every
+        # later field (#384 put Notes text into submitter.name on 12 hunts).
+        # Fail closed instead — a shifted row must not parse as a valid hunt.
+        if len(raw) > 6:
+            raise HuntValidationError(
+                f"{category}/{hunt_id}.md: legacy table row split into "
+                f"{len(raw)} cells, expected 6 — an unescaped '|' in one of "
+                f"them is shifting the later fields. Escape it as '\\|' or "
+                f"wrap the cell's pipes in a balanced code span."
+            )
+        for j, c in enumerate(raw):
             cells[j] = c
 
     tactics = _split_tactics(re.sub(r"\*\*", "", cells[2])) if cells[2] else []

--- a/scripts/tests/test_hunt_parser.py
+++ b/scripts/tests/test_hunt_parser.py
@@ -1,4 +1,6 @@
-from scripts.hunt_parser import parse_hunt_file
+import pytest
+
+from scripts.hunt_parser import HuntValidationError, parse_hunt_file
 
 
 def test_parses_frontmatter_format(fixtures_dir):
@@ -43,7 +45,9 @@ def test_raises_on_missing_required_frontmatter_field(tmp_path):
     f = tmp_path / "H998.md"
     f.write_text("---\nid: H998\ncategory: Flames\n---\n# body\n")
     import pytest
+
     from scripts.hunt_parser import HuntValidationError
+
     with pytest.raises(HuntValidationError) as exc:
         parse_hunt_file(f, "Flames")
     assert "hypothesis" in str(exc.value)
@@ -157,6 +161,62 @@ def test_escaped_pipe_in_notes_does_not_shift_cells(tmp_path):
     assert "execution" in hunt["tags"]
     assert "macos" in hunt["tags"]
     assert hunt["submitter"]["name"] == "X"
+
+
+def test_raw_pipe_inside_code_span_does_not_shift_cells(tmp_path):
+    """A raw | inside backticks is content, not a delimiter — see #384.
+
+    H148 and 11 others wrote KQL/shell inside a code span with an unescaped
+    pipe. The row split into 7-8 cells, raw[:6] truncated the overflow, and
+    Notes text landed in submitter.name — destroying attribution silently.
+    """
+    f = tmp_path / "H992.md"
+    f.write_text(
+        "# H992\n\n"
+        "| Hunt # | Hypothesis | Tactic | Notes | Tags | Submitter |\n"
+        "|---|---|---|---|---|---|\n"
+        "| H992 | A hypothesis | Persistence | Run "
+        "`launchctl list | grep -E '(com\\.apple|com\\.google)'` to check | "
+        "#persistence #macos | [Lauren Proehl](https://x.com/jotunvillur) |\n"
+    )
+    hunt = parse_hunt_file(f, "Flames")
+    assert hunt["id"] == "H992"
+    assert hunt["tactics"] == ["Persistence"]
+    assert "persistence" in hunt["tags"]
+    # The attribution that #384 destroyed.
+    assert hunt["submitter"]["name"] == "Lauren Proehl"
+    assert hunt["submitter"]["link"] == "https://x.com/jotunvillur"
+    # The pipes stay in Notes as content.
+    assert "grep -E" in hunt["notes"]
+
+
+def test_unbalanced_backtick_falls_back_to_pipe_splitting(tmp_path):
+    """An odd backtick count must not swallow the rest of the row."""
+    f = tmp_path / "H993.md"
+    f.write_text(
+        "# H993\n\n"
+        "| Hunt # | Hypothesis | Tactic | Notes | Tags | Submitter |\n"
+        "|---|---|---|---|---|---|\n"
+        "| H993 | A hypothesis | Execution | A stray ` backtick | "
+        "#execution | [X](https://example.com/x) |\n"
+    )
+    hunt = parse_hunt_file(f, "Flames")
+    assert hunt["submitter"]["name"] == "X"
+    assert "execution" in hunt["tags"]
+
+
+def test_overlong_legacy_row_fails_closed(tmp_path):
+    """A genuinely shifted row must raise, not silently truncate to 6 cells."""
+    f = tmp_path / "H994.md"
+    f.write_text(
+        "# H994\n\n"
+        "| Hunt # | Hypothesis | Tactic | Notes | Tags | Submitter |\n"
+        "|---|---|---|---|---|---|\n"
+        "| H994 | A hypothesis | Execution | an | unescaped | pipe | storm | "
+        "[X](https://example.com/x) |\n"
+    )
+    with pytest.raises(HuntValidationError, match="expected 6"):
+        parse_hunt_file(f, "Flames")
 
 
 def test_command_and_control_is_single_tactic(tmp_path):


### PR DESCRIPTION
Fixes #384.

## Problem

`_split_table_row` honoured the markdown escape `\|` but split on a **raw `|` inside a backtick code span**. Authors write those because they render correctly in a code span — H148's Notes cell contains:

```
`launchctl list | grep -E '(com\.apple|com\.google)'`
```

Those rows split into 7–8 cells instead of 6. `_parse_legacy_table` then truncated with `raw[:6]`, so every field after Notes shifted left: `submitter.name` picked up mid-Notes text or the entire tags cell, and `submitter.link` was emptied.

Running `migrate_to_frontmatter.py` on main reports `changed=66 failed=0` — no error — while destroying attribution on 12 hunts:

`H148 H182 H194 H195 H204 H206 H207 H208 H213 H214 H215 H216`

H148's `[Lauren Proehl](https://x.com/jotunvillur)` became a fragment of a `codesign` command.

## Change

**`_split_table_row`** tracks code spans, so a `|` between backticks is content. Protection is skipped when a row has an odd number of backticks, since an unbalanced span would otherwise swallow the rest of the row.

**`_parse_legacy_table`** raises `HuntValidationError` when a row yields more than 6 cells, instead of silently truncating. A shifted row now fails closed, and `failed=` becomes truthful.

## Verification

- All **66** legacy rows now split to exactly 6 cells. With the old splitter, 12 yielded 7–8 — precisely the 12 that were corrupted.
- Re-ran the migration with the fix: **corrupted submitter fields 12 → 0**, every name and link preserved.
- Section counts (`## Why` / `## References`) unchanged across all 66, before and after.
- **pytest 109/109**, flake8 clean at CI's exact settings, all 329 hunts still parse.

Three new tests: the raw-pipe-in-code-span case (asserting the exact attribution #384 destroyed), the unbalanced-backtick fallback, and the fail-closed guard.

## Scope — the migration is deliberately NOT in this PR

Verifying the fix surfaced a **second, unrelated defect**: `migrate_to_frontmatter.py` drops the legacy summary paragraph that sits between the `# HNNN` heading and the table. On **13 of 66 files** that paragraph carries information found nowhere else in the file — CVE numbers (`CVE-2026-35273`, `CVE-2022-42045`), registry paths (`HKLM\SOFTWARE\...\Image File Execution Options\vds.exe`), IOC filenames (`ManageEngine-OpManager.msi`, `G11.sys`), and API names (`NtUnmapViewOfSection`, `__NSGetExecutablePath`).

That is real hunting content and a separate bug. This PR fixes the pipe-splitting defect only; the bulk migration should wait until both are resolved.

One further blocker for the bulk migration, also out of scope here: `H258`'s submitter cell holds **two** links (`[Twitter - 0xDroogy](...)`, `[Github - Droogy](...)`) and the frontmatter schema has a single `submitter.link`, so one is lost by construction.
