### PR TITLE
feat(schema): preserve multiple submitter profile links, and migrate the last legacy hunt

### DIFF
--- a/Flames/H258.md
+++ b/Flames/H258.md
@@ -1,10 +1,34 @@
-# H258
+---
+category: Flames
+hypothesis: An activity cluster dubbed "O-UNC-037" by Okta Threat Intelligence has
+  successfully phished an employee and intercepted Okta credentials via an AitM toolkit.
+id: H258
+notes: Uses an SPL query against Okta Audit Logs to detect anomalous multi-IP, multi-operator
+  device enrollment activity indicative of AitM credential interception.
+submitter:
+  link: https://t.co/JHM8u3D9na
+  links:
+  - https://t.co/JHM8u3D9na
+  - https://github.com/Droogy
+  name: Twitter - 0xDroogy
+tactics:
+- Credential Access
+- Initial Access
+tags:
+- aitm
+- okta
+- o_unc_037
+- sms
+- smishing
+- phishing
+techniques:
+- T1566
+- T1557
+---
+
+## Summary
 
 An activity cluster dubbed "O-UNC-037" by Okta Threat Intelligence has successfully phished an employee and intercepted Okta credentials via an AitM toolkit.
-
-| Hunt #       | Idea / Hypothesis          | Tactic    | Notes                             | Tags      | Submitter |
-|--------------|----------------------------|-----------|-----------------------------------|-----------|-----------|
-| H258    | An activity cluster dubbed "O-UNC-037" by Okta Threat Intelligence has successfully phished an employee and intercepted Okta credentials via an AitM toolkit.    | Credential Access, Initial Access  | Uses an SPL query against Okta Audit Logs to detect anomalous multi-IP, multi-operator device enrollment activity indicative of AitM credential interception. | #AitM #Okta #O-UNC-037 #SMS #Smishing #Phishing #T1566 #T1557    | - [Twitter - 0xDroogy](https://t.co/JHM8u3D9na), [Github - Droogy](https://github.com/Droogy) |
 
 ## Why
 - This hunt addresses compromised Okta credentials that are highly likely to have been intercepted by an AitM toolkit. 

--- a/scripts/hunt_parser.py
+++ b/scripts/hunt_parser.py
@@ -160,9 +160,15 @@ def _parse_legacy_table(content: str, hunt_id: str, category: str) -> dict[str, 
     submitter_raw = cells[5]
 
     submitter = {"name": submitter_raw.strip(), "link": ""}
-    m = _SUBMITTER_LINK_RE.search(submitter_raw)
-    if m:
-        submitter = {"name": m.group(1).strip(), "link": m.group(2).strip()}
+    # A submitter cell may carry several profiles, e.g.
+    # "[Twitter - 0xDroogy](...), [Github - Droogy](...)". The first is primary
+    # so `link` stays a plain string for existing consumers; any extras are
+    # kept in `links` rather than dropped (see #386).
+    matches = _SUBMITTER_LINK_RE.findall(submitter_raw)
+    if matches:
+        submitter = {"name": matches[0][0].strip(), "link": matches[0][1].strip()}
+        if len(matches) > 1:
+            submitter["links"] = [url.strip() for _, url in matches]
 
     return {
         "id": cells[0].strip() or hunt_id,

--- a/scripts/hunt_schema.py
+++ b/scripts/hunt_schema.py
@@ -4,6 +4,7 @@ HEARTH hunt frontmatter schema.
 Canonical definition of the YAML frontmatter that every hunt markdown file
 must carry. Used by the parser at runtime and by the validator in CI.
 """
+
 from __future__ import annotations
 
 from jsonschema import Draft202012Validator, FormatChecker
@@ -49,6 +50,13 @@ HUNT_SCHEMA: dict = {
             "properties": {
                 "name": {"type": "string", "minLength": 1},
                 "link": {"type": "string"},
+                # Set only when a submitter listed more than one profile. `link`
+                # remains the primary so existing consumers are unaffected.
+                "links": {
+                    "type": "array",
+                    "items": {"type": "string"},
+                    "minItems": 2,
+                },
             },
         },
         "severity": {"enum": list(SEVERITIES)},

--- a/scripts/rebuild_hunts_data.py
+++ b/scripts/rebuild_hunts_data.py
@@ -15,7 +15,16 @@ HUNT_FILE_RE = re.compile(r"^[HBM]\d+\.md$")
 
 # Directories that legitimately contain no hunts; skipped when scanning for
 # hunt files that have been filed outside a category directory.
-NON_HUNT_DIRS = {".git", ".github", "node_modules", ".venv", "public", "scripts", "assets", "docs"}
+NON_HUNT_DIRS = {
+    ".git",
+    ".github",
+    "node_modules",
+    ".venv",
+    "public",
+    "scripts",
+    "assets",
+    "docs",
+}
 
 _REPO_ROOT = str(Path(__file__).resolve().parent.parent)
 if _REPO_ROOT not in sys.path:
@@ -120,7 +129,10 @@ def parse_submitter_from_dict(submitter):
         if override is None:
             return {"name": "Anonymous", "link": ""}
         return override
-    return {"name": name or "Anonymous", "link": submitter.get("link", "")}
+    result = {"name": name or "Anonymous", "link": submitter.get("link", "")}
+    if submitter.get("links"):
+        result["links"] = list(submitter["links"])
+    return result
 
 
 def find_stray_hunts(base, categories):
@@ -150,7 +162,9 @@ def main():
 
     stray = find_stray_hunts(base, categories)
     if stray:
-        print("ERROR: hunt files found outside the category directories:", file=sys.stderr)
+        print(
+            "ERROR: hunt files found outside the category directories:", file=sys.stderr
+        )
         for rel in stray:
             print(f"  {rel}", file=sys.stderr)
         print(

--- a/scripts/tests/test_hunt_parser.py
+++ b/scripts/tests/test_hunt_parser.py
@@ -231,3 +231,42 @@ def test_command_and_control_is_single_tactic(tmp_path):
     )
     hunt = parse_hunt_file(f, "Flames")
     assert hunt["tactics"] == ["Command and Control", "Exfiltration"]
+
+
+def test_multiple_submitter_links_are_preserved(tmp_path):
+    """A submitter listing several profiles keeps them all — see H258 / #386.
+
+    `link` stays the primary as a plain string so existing consumers are
+    unaffected; the full set lands in `links`.
+    """
+    f = tmp_path / "H997.md"
+    f.write_text(
+        "# H997\n\n"
+        "| Hunt # | Hypothesis | Tactic | Notes | Tags | Submitter |\n"
+        "|---|---|---|---|---|---|\n"
+        "| H997 | A hypothesis | Persistence | n | #persistence | "
+        "[Twitter - 0xDroogy](https://t.co/JHM8u3D9na), "
+        "[Github - Droogy](https://github.com/Droogy) |\n"
+    )
+    hunt = parse_hunt_file(f, "Flames")
+    assert hunt["submitter"]["name"] == "Twitter - 0xDroogy"
+    assert hunt["submitter"]["link"] == "https://t.co/JHM8u3D9na"
+    assert hunt["submitter"]["links"] == [
+        "https://t.co/JHM8u3D9na",
+        "https://github.com/Droogy",
+    ]
+
+
+def test_single_submitter_link_sets_no_links_key(tmp_path):
+    """The common case is unchanged — no empty `links` key on single-profile hunts."""
+    f = tmp_path / "H998.md"
+    f.write_text(
+        "# H998\n\n"
+        "| Hunt # | Hypothesis | Tactic | Notes | Tags | Submitter |\n"
+        "|---|---|---|---|---|---|\n"
+        "| H998 | A hypothesis | Persistence | n | #persistence | "
+        "[X](https://example.com/x) |\n"
+    )
+    hunt = parse_hunt_file(f, "Flames")
+    assert hunt["submitter"]["link"] == "https://example.com/x"
+    assert "links" not in hunt["submitter"]


### PR DESCRIPTION
Finishes the migration started in #387.

## Problem

`H258`'s submitter cell lists two profiles:

```
[Twitter - 0xDroogy](https://t.co/JHM8u3D9na), [Github - Droogy](https://github.com/Droogy)
```

`submitter` had a single `link` field, so migrating dropped one by construction. It was held back from #387 rather than ship the loss.

## Change

`_parse_legacy_table` now collects **every** `[name](url)` in the cell:

- the first stays in `link` as a plain string — **every existing consumer is unchanged**
- extras go to an optional `links` array

The schema gains `links` (it has `additionalProperties: False`, so the field had to be declared) with `minItems: 2`, so single-profile hunts get no key at all. `rebuild_hunts_data` carries it through to `hunts-data.json`.

Result for H258:

```yaml
submitter:
  link: https://t.co/JHM8u3D9na
  links:
  - https://t.co/JHM8u3D9na
  - https://github.com/Droogy
  name: Twitter - 0xDroogy
```

## This was the last legacy file

`migrate_to_frontmatter.py --dry-run` now reports `changed=0 skipped=329`. **All 329 hunts are frontmatter** and the `DeprecationWarning` path is dead.

I confirmed H258 is the only hunt in the repo with more than one submitter link, so this field starts and — unless a future submitter lists two — stays a single-file affordance. It is declared rather than special-cased because dropping contributor attribution is the thing this whole thread has been about.

## Verification

- **Zero link loss** on H258, diffed before and after
- **pytest 113/113** (2 new: the multi-link case and a guard that single-link hunts gain no `links` key)
- flake8 clean at CI's exact settings
- All 329 hunts parse **with legacy `DeprecationWarning` escalated to an error**
- H258 validates against the schema with the new field populated
