### PR TITLE
fix(scripts): rewrite the frontmatter id and heading when reassigning a hunt ID

### DIFF
--- a/scripts/hunt_ids.py
+++ b/scripts/hunt_ids.py
@@ -62,17 +62,30 @@ def format_hunt_id(num: int, prefix: str = "H") -> str:
 def rewrite_hunt_id(path: Path, new_id: str) -> Path:
     """Rename a hunt file to ``new_id`` and rewrite the ID embedded inside it.
 
-    Rewrites the line-1 ``# <old_id>`` heading and any populated ``| <old_id> |``
-    Hunt# table cell. The ID does not appear elsewhere in the body. Removes the
-    old file and returns the new path.
+    Rewrites the frontmatter ``id:`` field, the ``# <old_id>`` heading (line 1 in
+    legacy hunts, below the frontmatter in canonical ones), and any populated
+    ``| <old_id> |`` Hunt# table cell. The ID does not appear elsewhere in the
+    body. Removes the old file and returns the new path.
     """
     path = Path(path)
     old_id = path.stem
     text = path.read_text(encoding="utf-8")
 
     lines = text.split("\n")
-    if lines and lines[0].strip() == f"# {old_id}":
-        lines[0] = f"# {new_id}"
+    # Frontmatter `id:` — scoped to the block so prose that looks like a
+    # metadata line is left alone. Absent in legacy (table-format) hunts.
+    if lines and lines[0].strip() == "---":
+        for i, line in enumerate(lines[1:], start=1):
+            if line.strip() == "---":
+                break
+            if line.strip() == f"id: {old_id}":
+                lines[i] = f"id: {new_id}"
+                break
+
+    for i, line in enumerate(lines):
+        if line.strip() == f"# {old_id}":
+            lines[i] = f"# {new_id}"
+            break
     text = "\n".join(lines)
 
     # Replace a populated Hunt# cell (e.g. "| H200 |"); a no-op for the

--- a/scripts/tests/test_hunt_ids.py
+++ b/scripts/tests/test_hunt_ids.py
@@ -100,6 +100,54 @@ def test_rewrite_hunt_id_updates_populated_table_cell(tmp_path):
     assert "H201" not in text
 
 
+def _write_frontmatter_hunt(path: Path, hunt_id: str, category: str = "Flames") -> None:
+    path.write_text(
+        "---\n"
+        f"id: {hunt_id}\n"
+        f"category: {category}\n"
+        "title: A specific bad thing done to a specific target\n"
+        "hypothesis: >-\n"
+        "  An adversary does the thing, so hunt for the artifact it leaves.\n"
+        "tags:\n"
+        "  - collection\n"
+        "---\n\n"
+        f"# {hunt_id}\n\n"
+        "## Why\n- reason\n\n## References\n- link\n",
+        encoding="utf-8",
+    )
+
+
+def test_rewrite_hunt_id_updates_frontmatter_id_and_heading(tmp_path):
+    # Regression for #383: the canonical format carries the ID in frontmatter
+    # and in a heading below it, so neither the old line-1 check nor the table
+    # cell caught them — the renamed file kept declaring its old ID.
+    src = tmp_path / "H263.md"
+    _write_frontmatter_hunt(src, "H263")
+    new_path = rewrite_hunt_id(src, "H267")
+    assert new_path.name == "H267.md"
+    assert not src.exists()
+    text = new_path.read_text()
+    assert "\nid: H267\n" in text
+    assert "\n# H267\n" in text
+    assert "H263" not in text
+    assert "hypothesis: >-" in text  # YAML formatting preserved verbatim
+    assert "## Why" in text and "## References" in text
+
+
+def test_rewrite_hunt_id_leaves_a_matching_id_outside_frontmatter(tmp_path):
+    # The `id:` rewrite is scoped to the frontmatter block, so prose that
+    # happens to look like a metadata line is left alone.
+    src = tmp_path / "B035.md"
+    _write_frontmatter_hunt(src, "B035", category="Embers")
+    src.write_text(
+        src.read_text(encoding="utf-8") + "\nThe report labels this id: B035 too.\n",
+        encoding="utf-8",
+    )
+    text = rewrite_hunt_id(src, "B036").read_text()
+    assert "\nid: B036\n" in text
+    assert "The report labels this id: B035 too." in text
+
+
 def test_rewrite_hunt_id_renames_an_embers_hunt(tmp_path):
     # Regression for #380: the B035 -> B036 rename that had to be done by hand.
     src = tmp_path / "B035.md"


### PR DESCRIPTION
Closes #383

## Problem

`rewrite_hunt_id()` renames a hunt file and rewrites the ID inside it, but it only handled the legacy table format: a line-1 `# <id>` heading and a populated `| <id> |` Hunt# cell.

Canonical hunts carry the ID in two places it never touched — the frontmatter `id:` field, and a `# <id>` heading that sits *below* the frontmatter block rather than on line 1. So `scripts/reassign_hunt_id.py` renamed `H263.md` → `H267.md` while the file kept declaring `id: H263`, which `find_id_problems` then flags as *"declared ID 'H263' does not match filename 'H267'"*.

328 of 330 hunts are now in the canonical format (Flames 264/266, Embers 36/36, Alchemy 28/28), so this was the normal path, not an edge case.

## Fix

- Rewrite the frontmatter `id:` field, scoped to the block between the opening and closing `---`, so prose that happens to look like a metadata line is left alone.
- Match the `# <old_id>` heading wherever it sits instead of only on line 1.
- Substitution stays line-based rather than round-tripping through the YAML parser, so block scalars (`>-`, `|`) and existing formatting survive verbatim.
- Legacy table-format hunts behave exactly as before.

## Verification

- Two new tests in `scripts/tests/test_hunt_ids.py`: the frontmatter + heading rewrite, and the scoping guard that leaves an `id:`-shaped line in the body alone. Red before the change, green after.
- Full suite: 115 passed.
- End-to-end on a real copy of `Flames/H263.md` → `H999.md`: zero stale references, and the output is byte-identical to `sed 's/H263/H999/g'` on the original.
- `ruff check` and `ruff format --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)