### PR TITLE
Add H272: Device Code Redemption Followed by Rogue Entra Device Registration

### DIFF
--- a/Flames/H272.md
+++ b/Flames/H272.md
@@ -1,0 +1,58 @@
+---
+id: H272
+category: Flames
+title: Device Code Redemption Followed by Rogue Entra Device Registration
+hypothesis: >-
+  An adversary who obtains a victim-approved OAuth device code redeems it from separate infrastructure, uses the resulting session to register a rogue device under the compromised identity via the Entra Device Registration Service, and then leverages that device to satisfy Conditional Access and access Microsoft 365 mailboxes and files without any fresh interactive authentication by the victim.
+tactics:
+  - Credential Access
+  - Persistence
+  - Collection
+techniques:
+  - T1528
+  - T1098.005
+  - T1114.002
+  - T1078.004
+tags:
+  - entra_id
+  - device_code_phishing
+  - device_registration
+  - conditional_access_bypass
+  - oauth
+  - m365
+  - identity
+  - token_theft
+  - persistence
+submitter:
+  name: Joshua Strickland
+  link: https://novasky.io
+required_data_sources:
+  - "Entra ID sign-in logs (interactive and non-interactive, including device code authentication events)"
+  - "Entra ID audit logs (Device Registration Service activities)"
+  - Microsoft 365 unified audit log / Exchange Online mailbox and SharePoint access events
+  - "Microsoft Graph or equivalent device inventory (registered device metadata: device ID, name, trust type, registration timestamp, registered owner)"
+false_positive_notes: |
+  Legitimate device code flows exist: Teams room systems, conference-room hardware, CLI tools (Azure CLI, PowerShell), smart TVs, and kiosk enrollment all use device code authentication, and IT staff performing enrollments can legitimately authorize on one network and redeem on another (e.g., VPN split-tunnel or provisioning VLANs). Controls: (1) baseline which `application ID` values legitimately use device code in your tenant and alert on new ones; (2) require BOTH the authorization/redemption source mismatch AND a subsequent device registration before escalating — either signal alone is noisy, the joined sequence is rare; (3) whitelist known provisioning ranges and enrollment service accounts, but never whitelist on device name; (4) treat Intune-enrolled, compliant-marked devices registered through managed enrollment flows as lower priority than bare Entra-registered devices; (5) helpdesk-assisted enrollments can mimic the pattern — correlate with ticketing windows before closing as benign.
+notes: |
+  Entra ID sign-in logs - Core filter: sign-ins where `authentication protocol` is `Device Code` with a successful result, especially to broker/registration-capable clients such as `Microsoft Authentication Broker` (`29d9ed98-a469-4536-ade2-f981bc1d605e`) or `Microsoft Office`. Triage values: `user principal name`, `application ID`, `resource name`, `source IP address`, `autonomous system / ISP`, `user agent`, `session ID`, `correlation ID`, `conditional access status`. Strong red flags: redemption `source IP address` from hosting/VPS ASNs (Wiz cited `3.149.231.11` on AWS reused across multiple victims) while the same user's normal interactive sign-ins originate from corporate or residential ranges; the code was surfaced to the victim at `login.microsoftonline.com/common/oauth2/deviceauth` from one network while token redemption occurs from another.
+  Entra ID audit logs - Core filter: activity `Add device` or `Add registered owner to device` initiated by `Device Registration Service` (`01cb2876-7ebd-4aa4-9cc9-d28bd4d359a9`) within roughly `0-60 minutes` of a device code redemption for the same identity. Correlation: join on `user principal name`, `session ID`, `correlation ID`, or redemption `source IP address`. Triage values: `device display name`, `device trust type`, `operating system version`, initiating `user agent`. Strong red flags: registration `user agent` of `Dsreg/10.0 (Windows 10.0.19041.928)` from a non-Windows-looking network context; device names following `DESKTOP-XXXXXXXX` or `microsoft-XXXXXXXX` patterns; first-ever device registration for a long-tenured account minutes after an anomalous device code sign-in. Do not gate on the name pattern alone — Wiz shows attackers now use plausible names like `Work PC`, so treat naming as triage color, not the filter.
+  Microsoft 365 resource-access telemetry - Core filter: mailbox sync, `MailItemsAccessed`, eDiscovery/search, or SharePoint/OneDrive bulk file access where the presenting `device ID` matches a device registered in the prior `24 hours`. Pivot: from the rogue `device ID`, enumerate every access it satisfied under Conditional Access and every token refresh it anchored; from the redemption `source IP address`, sweep tenant-wide for other accounts with device code redemptions or device joins from the same infrastructure, since Wiz observed shared phishing/sign-in infrastructure across victims. Strong red flags: newly registered device accessing Exchange Online with no corresponding Intune enrollment, no interactive MFA claim after registration, or access continuing while the victim's known devices remain active elsewhere.
+  Containment validation - after triage, confirm scope by listing all sessions anchored to the rogue `device ID` and verifying that device deletion plus token revocation actually terminates resource access; attackers registered via this chain retain access through the device object, not the original code.
+---
+# H272
+
+Wiz reported on 2026-08-18 that rogue Entra device registration following device code phishing appeared in nearly one in seven observed Entra ID environments over a 90-day window. The chain is durable: static fingerprints such as device names like `DESKTOP-XXXXXXXX` or the user agent `Dsreg/10.0 (Windows 10.0.19041.928)` (historically tied to open-source Entra tooling such as ROADrecon) are trivially varied, and Wiz observed attackers shifting to benign-looking names like `Work PC` and `microsoft-XXXXXXXX`. What attackers cannot vary is the sequence itself: a device code flow authorized in one place and redeemed in another, followed shortly by a device-join event on the same identity, followed by resource access from the newly registered device. Because Conditional Access policies frequently require a joined/compliant device, device registration is a forced chokepoint for attackers who want persistent, policy-compliant access after token theft. Hunting the authorization/redemption source mismatch, the tight temporal join to `Add device`, and the downstream M365 access from the new device ID exposes the invariant behavior regardless of tooling, naming, or infrastructure rotation.
+
+## Why
+
+- Prevalence is measured, not anecdotal: Wiz observed this exact chain in nearly 1 in 7 Entra environments over 90 days, and the DESKTOP-pattern registration alone touched almost 1 in 10 customers — this is a current, high-frequency intrusion path, not a theoretical one.
+- The hunt targets an invariant chokepoint rather than rotating IOCs: attackers can freely vary device names, user agents, and infrastructure, but they cannot avoid the sequence of code redeemed from non-victim infrastructure, then device join on the same identity, then access anchored to that device — because Conditional Access itself forces the device registration step.
+- Every stage is natively observable in standard tenant telemetry: device code protocol is an explicit sign-in log attribute, `Add device` is a first-class audit activity attributable to the Device Registration Service, and M365 access events carry the presenting device ID, so the full chain can be joined on identity, session, and source IP without third-party sensors.
+- False positives are controllable by construction: legitimate device-code clients form a small, baselinable set per tenant, and the compound condition (source mismatch AND fresh registration AND new-device resource access) almost never occurs in benign enrollment workflows, keeping triage volume low enough for a weekly hunt cadence.
+
+## References
+
+- [Wiz - How to Spot and Stop Rogue Device Joins (Aug 18, 2026)](https://www.wiz.io/blog/detecting-entra-device-registration-abuse)
+- [Push Security - Analyzing the rise in device code phishing attacks in 2026](https://pushsecurity.com/blog/device-code-phishing)
+- [Huntress - We Need to Talk About Device Code Phishing](https://www.huntress.com/blog/tradecraft-tuesday-device-code-phishing-explained)
+- [Microsoft Learn - How Microsoft Entra device registration works](https://learn.microsoft.com/en-us/entra/identity/devices/device-registration-how-it-works)


### PR DESCRIPTION
## Summary

Adds `H272`: Device Code Redemption Followed by Rogue Entra Device Registration.

## Sources

- https://www.wiz.io/blog/detecting-entra-device-registration-abuse

## Validation

- Draft reviewed locally before submission.
- Source links are preserved in the hunt writeup.
