### PR TITLE
Add H273: Privileged Entra identity dismantles Azure recovery controls before destructive changes

### DIFF
--- a/Flames/H273.md
+++ b/Flames/H273.md
@@ -1,0 +1,57 @@
+---
+id: H273
+category: Flames
+title: Privileged Entra identity dismantles Azure recovery controls before destructive changes
+hypothesis: >-
+  An adversary operating a compromised privileged Entra ID identity is removing Azure resource locks and storage immutability policies, then deleting Recovery Services vaults, backup items, snapshots, or storage accounts, and introducing attacker-controlled encryption over surviving storage — all as an ordered control-plane sequence under the same principal and session.
+tactics:
+  - Defense Impairment
+  - Impact
+techniques:
+  - T1490
+  - T1486
+  - T1485
+  - T1078.004
+tags:
+  - azure
+  - entra_id
+  - cloud_ransomware
+  - storm_0501
+  - backup_destruction
+  - resource_locks
+  - immutability
+  - encryption_scopes
+  - control_plane
+submitter:
+  name: Joshua Strickland
+  link: https://novasky.io
+required_data_sources:
+  - "Azure Activity Logs (Azure Resource Manager control-plane operations)"
+  - Entra ID sign-in logs
+  - Entra ID audit logs
+  - Azure Key Vault audit/diagnostic logs
+  - Azure Storage resource configuration logs
+false_positive_notes: |
+  Individual operations here are routine: platform teams delete locks during sanctioned decommissioning, DevOps pipelines and IaC service principals (Terraform, Bicep deployments) remove and recreate locks and even vaults during environment rebuilds, and storage teams legitimately roll out customer-managed keys. Control the noise by (1) requiring the ordered multi-stage chain — guardrail removal AND recovery-resource destruction or encryption change — by the same caller within the window, not any single event; (2) baselining known IaC service principals, break-glass accounts, and change windows, and treating a match outside an approved change record as high priority; (3) weighting interactive or portal/CLI callers above pipeline identities, since Storm-0501-style activity runs under a hijacked human privileged identity; (4) down-ranking sequences confined to dev/test subscriptions while never fully excluding them; and (5) escalating immediately when the acting identity is a synced hybrid admin, when soft-delete/immutability settings are downgraded shortly before deletions, or when the referenced Key Vault was created by the same principal in the same session.
+notes: |
+  Azure Activity Logs (guardrail removal) - Core filter: successful operations `Microsoft.Authorization/locks/delete` or `Microsoft.Storage/storageAccounts/blobServices/containers/immutabilityPolicies/delete`, or Recovery Services vault security-setting downgrades (soft-delete or immutability disabled). Triage values: `caller identity`, `caller IP address`, `correlation ID`, `client request ID`, `subscription`, `resource ID`. Strong red flags: multiple locks or immutability policies removed across different resource groups by one principal within an hour, especially a hybrid/synced admin account or a principal that has never before performed authorization or backup-policy operations.
+  Azure Activity Logs (recovery destruction and encryption change) - Core filter: `Microsoft.RecoveryServices/vaults/delete`, `Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/delete`, `Microsoft.Compute/snapshots/delete`, `Microsoft.Compute/restorePointCollections/delete`, or `Microsoft.Storage/storageAccounts/delete`, plus `Microsoft.KeyVault/vaults/write` followed by `Microsoft.Storage/storageAccounts/encryptionScopes/write` binding storage to a newly created customer-managed key. Correlation: join to the guardrail-removal events on `caller identity`, `caller IP address`, and `subscription` within a 24-hour window; the invariant sequence is guardrail removal preceding destruction or encryption change on the same or related `resource ID`. Strong red flags: bulk snapshot/restore-point deletion at machine speed, a brand-new Key Vault immediately referenced by an encryption scope, or destruction that begins minutes after the first lock deletion.
+  Entra ID sign-in and audit logs (preceding access) - Core filter: for each flagged `caller identity`, review sign-ins in the preceding 24 hours. Triage values: `source IP address`, `user agent`, `conditional access status`, `MFA result`, `application ID`, `session ID`. Pivot: Entra audit events for role assignment changes, MFA method registration, or federation/domain-sync setting changes touching the same principal shortly before the control-plane activity. Strong red flags: first-seen ASN or hosting-provider IP, single-factor or freshly-registered-MFA sessions on a Global Administrator or Owner-equivalent identity, or a directory-sync service account performing interactive control-plane operations.
+  Azure Key Vault logs (attacker-key staging) - Core filter: vault creation plus key creation and immediate access-policy or RBAC grants to the same acting principal. Correlation: match the new key resource against subsequent `Microsoft.Storage/storageAccounts/encryptionScopes/write` payloads; legitimate customer-managed-key rollouts reference change-managed, pre-existing vaults rather than a vault created minutes earlier by the same caller.
+---
+# H273
+
+Tenable's August 2026 analysis of Storm-0501 describes cloud-first ransomware that no longer encrypts endpoints but hijacks the Azure tenant itself: after taking over a privileged hybrid identity, the actor systematically neutralizes resource locks, immutability policies, and backups before exfiltrating, mass-deleting, and encrypting data. Microsoft's underlying Storm-0501 reporting documents the concrete control-plane operations: lock removal and container immutability-policy deletion to clear guardrails, followed by deletion of snapshots, restore point collections, recovery vault protection containers, and storage accounts, and finally creation of a new Key Vault with a customer-managed key applied through storage encryption scopes so the victim's remaining data is readable only with the attacker's key. Each individual operation can be legitimate administration; the hunt value is the ordered chain — guardrail removal, then recovery destruction, then encryption change — performed by one principal in a compressed window, usually preceded by anomalous authentication to the privileged identity. Because these are Azure Resource Manager operations, every step lands in Azure Activity Logs with a caller, correlation identifiers, and source IP, giving hunters a durable chokepoint that survives rotation of infrastructure indicators.
+
+## Why
+
+- Storm-0501 shows ransomware crews moving impact fully into the Azure control plane — deleting backups and encrypting storage with their own key instead of dropping endpoint binaries — so hunts anchored on host telemetry miss the entire destructive phase.
+- The guardrail-removal-then-destroy ordering is an invariant chokepoint: locked immutable vaults and resource locks block deletion by design, so any actor intent on destroying recoverability must emit lock and immutability-policy delete operations first, regardless of which IPs, tools, or accounts they rotate through.
+- Every step is an Azure Resource Manager operation that lands in Azure Activity Logs with caller, source IP, correlation ID, and resource ID by default — no agent deployment or extra licensing is required to hunt this in most tenants.
+- False positives are tractable because the detection unit is a same-principal ordered sequence rather than a single event; legitimate decommissioning maps to change records and known IaC identities, letting hunters triage on chain shape, caller type, and change-window alignment rather than suppressing whole operation classes.
+
+## References
+
+- [Detecting cloud ransomware in Azure with Tenable One's cloud detection and response capabilities (Tenable, Aug 17 2026)](https://www.tenable.com/blog/detecting-cloud-ransomware-in-azure-with-tenable-ones-cloud-detection-and-response)
+- [Storm-0501's evolving techniques lead to cloud-based ransomware (Microsoft Security Blog)](https://www.microsoft.com/en-us/security/blog/2025/08/27/storm-0501s-evolving-techniques-lead-to-cloud-based-ransomware/)
+- [Azure Backup security overview — immutable vaults and soft delete (Microsoft Docs)](https://github.com/MicrosoftDocs/azure-docs/blob/main/articles/backup/security-overview.md)


### PR DESCRIPTION
## Summary

Adds `H273`: Privileged Entra identity dismantles Azure recovery controls before destructive changes.

## Sources

- https://www.tenable.com/blog/detecting-cloud-ransomware-in-azure-with-tenable-ones-cloud-detection-and-response

## Validation

- Draft reviewed locally before submission.
- Source links are preserved in the hunt writeup.
