### PR TITLE
fix: accept CTI submission links that omit the URL scheme

### DIFF
--- a/.github/scripts/process_issue.py
+++ b/.github/scripts/process_issue.py
@@ -37,6 +37,34 @@ def get_user_agent():
     ]
     return random.choice(user_agents)
 
+# Scheme is OPTIONAL on purpose. Submitters routinely paste a bare
+# "example.com/post" — browsers and curl both accept it, so it does not look
+# wrong. Requiring "https?://" made process_issue return before issuing a single
+# HTTP request, and the downstream workflow then told the submitter "the website
+# is blocking automated access" — sending them off to hand-copy an article that
+# was in fact perfectly reachable (issue #395, ox.security, HTTP 200).
+# The optional <...> wrapper covers markdown autolinking.
+SOURCE_URL_RE = re.compile(
+    r'### Link to Original Source\s*\n\s*'
+    r'<?((?:https?://)?[^\s<>]+\.[a-zA-Z]{2,}(?:/[^\s<>]*)?)>?'
+)
+
+
+def parse_source_url(issue_body):
+    """Extract the submitted source URL, normalised to an absolute https URL.
+
+    Returns None when no URL can be parsed — a PARSE failure, which is a
+    different thing from a fetch failure and must not be reported as one.
+    """
+    m = SOURCE_URL_RE.search(issue_body or "")
+    if not m:
+        return None
+    url = m.group(1).strip()
+    if not url.lower().startswith(("http://", "https://")):
+        url = "https://" + url
+    return url
+
+
 def get_medium_content(url):
     """
     Special handling for Medium articles which often block scrapers.
@@ -373,12 +401,15 @@ def main():
         return
 
     # Find the URL in the issue body
-    url_match = re.search(r'### Link to Original Source\s*\n\s*(https?://[^\s]+)', issue_body)
-    if not url_match:
-        print("No CTI link found in the issue body.")
+    cti_url = parse_source_url(issue_body)
+    if not cti_url:
+        print(
+            "No CTI link found in the issue body — could not parse a URL from "
+            "the '### Link to Original Source' section. This is a PARSE failure, "
+            "not a fetch failure: no request was attempted."
+        )
         return
 
-    cti_url = url_match.group(1).strip()
     print(f"Processing CTI link: {cti_url}")
 
     # Check if the content has already been processed

--- a/.github/workflows/issue-generate-hunts.yml
+++ b/.github/workflows/issue-generate-hunts.yml
@@ -232,7 +232,14 @@ jobs:
           body: |
             ## 📋 Manual Content Required
 
-            The automatic download failed because the website is blocking automated access.
+            The automatic download didn't return usable article text. Common causes,
+            roughly in order:
+
+            - the link is malformed or points somewhere unexpected — worth re-checking first
+            - the site blocked the request
+            - the page renders its content with JavaScript and served no readable text
+
+            If the link looks correct, pasting the text manually is the quickest way forward.
 
             **Please manually paste the article content to proceed:**
 

--- a/scripts/tests/test_process_issue_url.py
+++ b/scripts/tests/test_process_issue_url.py
@@ -1,0 +1,94 @@
+"""Tests for parsing the source URL out of a CTI submission issue body.
+
+Regression guard for issue #395. A submitter pasted
+``ox.security/blog/research-clickfix-phishing-npm-packages/`` with no scheme.
+The parser required ``https?://``, so it matched nothing and process_issue.py
+returned before making a single HTTP request — and the workflow then told the
+submitter "the website is blocking automated access" and asked them to hand-copy
+the article. The page in fact returned HTTP 200. A scheme-less URL is normal
+(browsers and curl both accept it) and must be accepted and normalised.
+"""
+
+from __future__ import annotations
+
+import ast
+import re
+import types
+from pathlib import Path
+
+import pytest
+
+_PROCESS_ISSUE = (
+    Path(__file__).resolve().parents[2] / ".github" / "scripts" / "process_issue.py"
+)
+
+
+def _load_url_helper():
+    """Exec only the URL-parsing helper out of process_issue.py.
+
+    The module imports requests/bs4/pypdf/docx at import time, and this test job
+    does not install all of them. Pulling just the two names we exercise keeps
+    the test honest — it runs the code that will actually ship — without
+    dragging in that dependency surface.
+    """
+    tree = ast.parse(_PROCESS_ISSUE.read_text(encoding="utf-8"))
+    wanted = {"SOURCE_URL_RE", "parse_source_url"}
+    keep = [
+        node
+        for node in tree.body
+        if (
+            isinstance(node, ast.Assign)
+            and any(getattr(t, "id", None) in wanted for t in node.targets)
+        )
+        or (isinstance(node, ast.FunctionDef) and node.name in wanted)
+    ]
+    assert keep, "parse_source_url/SOURCE_URL_RE not found in process_issue.py"
+    module = types.ModuleType("process_issue_url_subset")
+    module.re = re
+    exec(compile(ast.Module(body=keep, type_ignores=[]), "<subset>", "exec"), module.__dict__)
+    return module.parse_source_url
+
+
+parse_source_url = _load_url_helper()
+
+
+def _body(link: str) -> str:
+    return f"### Link to Original Source\n\n{link}\n\n### Your Name / Handle\n\nSomeone"
+
+
+@pytest.mark.parametrize(
+    "link,expected",
+    [
+        # The exact issue #395 submission.
+        (
+            "ox.security/blog/research-clickfix-phishing-npm-packages/",
+            "https://ox.security/blog/research-clickfix-phishing-npm-packages/",
+        ),
+        # Already-absolute URLs must pass through byte-for-byte.
+        ("https://www.stepsecurity.io/blog/x", "https://www.stepsecurity.io/blog/x"),
+        # http:// is not silently upgraded — that would change the request.
+        ("http://example.com/a", "http://example.com/a"),
+        # Markdown autolinking can wrap the value in angle brackets.
+        ("<https://example.com/a>", "https://example.com/a"),
+        ("example.com", "https://example.com"),
+        ("sub.domain.co.uk/path/to/post", "https://sub.domain.co.uk/path/to/post"),
+    ],
+)
+def test_parses_and_normalises(link, expected):
+    assert parse_source_url(_body(link)) == expected
+
+
+@pytest.mark.parametrize(
+    "body",
+    [
+        _body("_No response_"),          # the form's empty-field placeholder
+        "### Your Name / Handle\n\nSomeone",  # section absent entirely
+        "",
+    ],
+)
+def test_returns_none_when_unparseable(body):
+    assert parse_source_url(body) is None
+
+
+def test_none_body_does_not_raise():
+    assert parse_source_url(None) is None


### PR DESCRIPTION
## What

CTI submission links pasted without `https://` were silently dropped. `process_issue.py` required a scheme, so it matched nothing and returned before making a single HTTP request.

Reported via #395, where the link was `ox.security/blog/research-clickfix-phishing-npm-packages/`.

## Why it mattered

The submitter was then told:

> The automatic download failed because the website is blocking automated access.

That was wrong on both counts — nothing was downloaded, because nothing was requested. The page returns **HTTP 200** (363KB). The contributor was asked to hand-copy a full article to work around eight missing characters.

A scheme-less URL is not a user error worth failing on: browsers and curl both accept it, so it looks perfectly correct to the person pasting it.

## Changes

- Extract `parse_source_url()` — optional scheme, tolerates markdown `<...>` autolinking, normalises to `https://`. `http://` is deliberately left alone rather than upgraded.
- The "no link found" log line now says explicitly that this is a **parse** failure and that no request was attempted, so the next person reading CI output isn't sent down the same wrong path.
- Reword the issue comment so it no longer asserts a cause it cannot know. It now lists likely causes with "check the link first", keeping manual paste as the fallback.
- Add `scripts/tests/test_process_issue_url.py`.

## Validation

- Replayed against **all 25 real `intel-submission` issue bodies**: 24 parse identically, 1 newly fixed (#395), **0 regressions**.
- 10 new tests; full suite `125 passed`.
- The test loads only the helper out of `process_issue.py` via AST rather than importing the module, since that module pulls in `requests`/`bs4`/`pypdf`/`docx` at import time and this CI job doesn't install all of them. It still exercises the exact shipped code.

## Note

#395 itself is already unblocked — I added the scheme to the link and re-triggered processing, so this PR is about the next submission, not that one.

Refs #395 (that submission is separately unblocked and should close when its hunt lands, not via this PR).
