### PR TITLE
feat: CTI pipeline hunts — 2026-08-31

### DIFF
--- a/Alchemy/M038.md
+++ b/Alchemy/M038.md
@@ -1,0 +1,150 @@
+---
+id: M038
+category: Alchemy
+title: Scoring LDAP sessions on object-class breadth and visited-to-returned ratio to surface EDR-evading directory collectors
+hypothesis: >-
+  A directory collector is not distinguishable from administration by any single query it issues.
+  Enumerating group policy objects, users, computers, groups, OUs and ACLs are all ordinary operations,
+  and an operator running a recompiled BloodHound collector — modified specifically to defeat static EDR
+  signatures, as in the source report — presents no binary, no command line and no filter string worth
+  matching on. What separates the collector is the shape of its session: it asks for every object class
+  in the directory rather than one, it returns near-total result sets rather than targeted ones, it
+  completes in a burst rather than across a working day, and it requests `nTSecurityDescriptor` with
+  SDFlags set to include Owner. Score each LDAP session per source host and account on breadth,
+  visited-to-returned ratio, burst rate and attribute selection, and rank sessions rather than alerting
+  on queries.
+tactics:
+  - Discovery
+techniques:
+  - T1615
+  - T1087.002
+  - T1069.002
+tags:
+  - discovery
+  - windows
+  - active_directory
+  - alchemy
+  - t1615
+  - t1087_002
+  - t1069_002
+  - ldap
+  - bloodhound
+  - sharphound
+  - group_policy_discovery
+  - anomaly_detection
+  - edr_evasion
+  - cisa_red_team
+submitter:
+  name: Lauren Proehl
+  link: https://x.com/jotunvillur
+required_data_sources:
+  - 'Microsoft-Windows-ActiveDirectory_DomainService Event ID 1644 from every domain controller — the richest source, carrying the search filter, the attribute selection, visited entry count and returned entry count. It is NOT enabled by default; set the Expensive and Inefficient Search Results Threshold values under HKLM\SYSTEM\CurrentControlSet\Services\NTDS\Parameters low enough to capture the traffic you want, and validate DC performance impact before estate-wide rollout'
+  - 'The visited-entries and returned-entries fields on 1644 specifically — these two numbers are the core feature. Targeted administrative queries visit few objects; collectors visit the directory'
+  - 'SDFlags on 1644 where nTSecurityDescriptor is requested — SDFlags 0x5 requests Owner in addition to DACL, which SharpHound uses for group enumeration and which legitimate administrative tooling essentially never sets. High-weight feature, low base rate'
+  - 'Windows Security Event ID 4662 (Audit Directory Service Access) — object accessed, per session. A dense burst of 4662 across many object classes from one identity is the coarse-grained version of the same signal where 1644 is unavailable'
+  - 'Defender for Identity IdentityQueryEvents — DC-side LDAP query telemetry via Advanced Hunting, the practical alternative when 1644 collection is not viable'
+  - 'Microsoft-Windows-LDAP-Client ETW provider on endpoints — client-side attribution of which process issued the queries, collectable via SilkETW. Complements DC-side data, which tells you the source host but not the source binary'
+  - 'Active Directory Web Services telemetry on port 9389 — ADWS-based collectors such as SOAPHound proxy queries locally, so 1644 records Client [::1] and DC-side attribution breaks. Treat ADWS session volume as a separate feature stream'
+  - 'Asset and identity context — host role, whether the source is an administrative workstation, account type, and normal working hours. The scoring model needs a denominator per source, not a global threshold'
+  - 'Optional AD decoy objects — honey users, groups and GPOs with auditing enabled, whose access is near-conclusive since no legitimate process has reason to read them'
+false_positive_notes: >-
+  The legitimate population that performs broad directory reads is real and must be modelled rather than
+  excluded by hand. Expect high-breadth, high-volume sessions from AD management and reporting tools,
+  identity governance and IAM synchronization (including Entra Connect), backup and disaster recovery
+  products, vulnerability scanners, asset inventory systems, PKI and certificate management, and
+  security tooling — including your own AD assessment products, which by design behave almost exactly
+  like the collector you are hunting. Suppress these by source host and service account BEFORE scoring,
+  not by adjusting thresholds afterwards, and re-derive that allowlist on a schedule because it drifts.
+  Administrators running Get-ADUser, Get-GPO or ADUC against wide scopes will also score, so use TTY and
+  session context alongside identity. Three collection caveats materially affect the model. String
+  matching on filters is fragile: Impacket transforms OID-based filters into bitwise operations in 1644,
+  whitespace variation changes identical queries, and SDFlags alters how the DC processes and logs a
+  query — so weight structural features over filter text. ADWS-based tooling breaks source attribution
+  entirely, recording the DC itself as the client. And lowering the 1644 thresholds increases DC logging
+  volume, so tune and measure in one site before deploying broadly.
+---
+
+# M038
+
+Both CISA assessments opened the same way, and in both cases the directory was fully enumerated before
+anyone had a chance to react.
+
+In Organization A the red team used a BloodHound collector "customized to avoid static endpoint detection
+and response (EDR) signatures" to scrape users, computers, groups, ACLs, organizational units and group
+policy objects. In Organization B the defenders were genuinely good — three payloads, three
+medium-severity alerts, three workstations isolated in ten, two and twenty minutes. That is about as fast
+as detection and response gets. It was still too slow: before the SOC isolated the first host, the
+operators had already run LDAP queries through the callback and collected all users, groups, computers,
+domains, GPOs and the relationships between them for the entire domain.
+
+Two things follow from that. First, the collector was explicitly recompiled to defeat signature-based
+detection, so binary and command-line detections are the wrong layer to rely on. Second, twenty minutes
+of dwell is enough to lose the whole directory, so the detection has to key on the queries themselves
+rather than on anything that happens afterwards.
+
+This is a model-assisted hunt rather than a rule because every constituent query is legitimate. Reading
+group policy objects is what `Get-GPO` does. Enumerating users is what every IAM sync does. The technique
+is only visible in aggregate, and the aggregate features are unusually good ones. Event ID 1644 records
+both how many objects a query *visited* and how many it *returned* — a targeted administrative lookup
+visits a handful of objects, while a collector visits the directory to return the directory. Breadth
+across object classes in a single session is similarly discriminating: administrators ask about one
+thing, collectors ask about everything, in order, in minutes.
+
+There is one feature with an unusually low base rate worth weighting heavily. SharpHound requests
+`nTSecurityDescriptor` with SDFlags set to 0x5 — Owner plus DACL — because group ownership is a common
+source of attack paths. Legitimate administrative tooling does not set that flag; in production
+monitoring it has been observed essentially only from SharpHound and security research tools. It is not
+sufficient alone, and a determined operator can avoid it, but as a term in a scoring model it is close to
+free signal.
+
+Group Policy discovery specifically is the piece HEARTH has not covered. [[H267]] hunts the SYSVOL side
+of the same interest — the recursive walk for `cpassword` in Group Policy Preferences XML — but that is
+the credential-harvesting half. This is the enumeration half, and it happens first. [[B034]] takes the
+comparable baseline approach to host-level discovery commands.
+
+Deploy this as a ranked queue, not an alert. The output should be the top-scoring LDAP sessions per day
+per source, reviewed against an allowlist that you expect to be mostly right and occasionally wrong.
+
+| Hunt # | Idea / Hypothesis | Tactic | Notes | Tags | Submitter |
+|--------------|-------------------------------------------------------------------------|----------------|------------------------------------------------------------------------------------|--------------------------------|---------------------|
+| M038 | An EDR-evading directory collector is invisible per query but distinctive per session: score each LDAP session by source host and account on object-class breadth (users, computers, groups, OUs, ACLs and `groupPolicyContainer` together), visited-to-returned entry ratio, burst rate, and whether `nTSecurityDescriptor` was requested with SDFlags including Owner — then rank sessions rather than alerting on any single query. | Discovery | Windows / Active Directory. Primary feature source is EID 1644 (Microsoft-Windows-ActiveDirectory_DomainService), which is OFF by default — lower the Expensive/Inefficient Search Results Thresholds under NTDS\Parameters and measure DC impact first. Core features: visited vs returned entry counts, distinct objectCategory count per session (include `objectCategory=groupPolicyContainer`), inter-query interval, and SDFlags 0x5 as a low-base-rate term. Fall back to EID 4662 density or Defender for Identity IdentityQueryEvents where 1644 is unavailable; add Microsoft-Windows-LDAP-Client ETW for process attribution. Weight structural features over filter strings — Impacket rewrites OID filters to bitwise form and whitespace varies. ADWS collectors (SOAPHound) log Client [::1], breaking attribution; stream ADWS/9389 separately. Suppress IAM sync, backup, scanners and AD assessment tooling by source before scoring. Cross-ref [[H267]] for the SYSVOL credential-harvesting half. | #discovery #T1615 #T1087.002 #T1069.002 #ldap #bloodhound #sharphound #group_policy_discovery #anomaly_detection | [Lauren Proehl](https://x.com/jotunvillur) |
+
+## Why
+
+- **The collector was purpose-built to defeat the detection layer most organizations rely on.** The source
+  report is explicit that the BloodHound collector was customized to evade static EDR signatures. Any
+  approach anchored to a known binary, hash or command line is a known-quantity control against an
+  adversary who has already accounted for it. Query-shape modelling does not care what the binary is
+  called or whether it was recompiled.
+- **Twenty minutes of dwell was enough to lose the entire directory.** Organization B's response was
+  genuinely fast by any operational standard, and the domain was still fully enumerated first. This sets
+  the detection budget: the signal has to be present in the enumeration itself, because everything
+  downstream is too late.
+- **The two numbers on Event ID 1644 are close to a purpose-built feature pair.** Visited-versus-returned
+  is a direct measure of how indiscriminate a query is, which is precisely the difference between a lookup
+  and a collection. Few detection problems come with a native telemetry field that encodes the concept
+  you actually want to measure. The cost is that 1644 must be deliberately enabled and tuned, which is
+  the real work of adopting this hunt.
+- **Volume-only thresholds fail in both directions, which is what makes this Alchemy rather than Flames.**
+  Set a static query-count threshold and IAM sync, backup and vulnerability scanners cross it every night
+  while a paced collector stays under it. Normal LDAP volume varies by orders of magnitude between a
+  branch office and a datacentre. The comparison has to be per-source and multi-feature, which is a model,
+  not a rule.
+- **SDFlags 0x5 is a rare, cheap, high-weight term.** Requesting the Owner component of the security
+  descriptor is something SharpHound does structurally and administrative tooling does not. It is
+  avoidable by a careful operator and so cannot stand alone, but it costs nothing to include and sharply
+  separates the default tooling case.
+- **Group Policy Discovery had no primary coverage in HEARTH.** T1615 appeared only as a cross-reference
+  in [[H267]], despite GPO enumeration being a standard early step in AD attack-path collection and a
+  direct precursor to the SYSVOL credential sweep that hunt covers.
+
+## References
+
+- [MITRE ATT&CK T1615: Group Policy Discovery](https://attack.mitre.org/techniques/T1615/)
+- [CISA AA26-237A: A Tale of Two SOCs — Insights From Two Red Team Assessments (source report)](https://www.cisa.gov/news-events/cybersecurity-advisories/aa26-237a)
+- [Huntress: From code to coverage (part 3) — SDFlags, the log field I could not ignore](https://www.huntress.com/blog/ldap-active-directory-detection-part-three)
+- [Huntress: Hunting SOAPHound — the (!FALSE) pattern](https://www.huntress.com/blog/ldap-active-directory-detection-part-four)
+- [Unit 42: LDAP enumeration — unveiling the double-edged sword of Active Directory](https://unit42.paloaltonetworks.com/lightweight-directory-access-protocol-based-attacks/)
+- [Securonix: Detecting LDAP enumeration and BloodHound's SharpHound collector using AD decoys](https://medium.com/securonix-tech-blog/detecting-ldap-enumeration-and-bloodhound-s-sharphound-collector-using-active-directory-decoys-dfc840f2f644)
+- [Wazuh: Detecting SharpHound Active Directory activities](https://wazuh.com/blog/detecting-sharphound-active-directory-activities/)
+- [iPurple Team: SharpHound detection](https://ipurple.team/2024/07/15/sharphound-detection/)

--- a/Embers/B043.md
+++ b/Embers/B043.md
@@ -1,0 +1,228 @@
+---
+id: B043
+category: Embers
+title: Baseline of Entra ID service principals holding mail and chat application permissions — who owns them, what they read, and from where
+hypothesis: >-
+  Application-permission Graph access cannot be hunted without a baseline, because the malicious shape
+  and the legitimate shape are the same shape: an application reading mail or Teams messages across the
+  entire tenant, continuously, with no user context. Backup, eDiscovery, DLP, ITSM and chatbot
+  integrations all do exactly this. What is stable about a legitimate integration is not its volume but
+  its identity — a fixed AppId, a fixed permission set, a small credential set with known expiries, a
+  narrow source IP range and a consistent user agent. Build a 30-day profile of every service principal
+  holding `Chat.Read.All`, `Mail.Read`, `Mail.ReadWrite`, `Files.Read.All`, `Application.ReadWrite.All`
+  or `AppRoleAssignment.ReadWrite.All`, capturing owner, permissions, credentials, call pattern and
+  source, so that a new secret on an old app, a first-ever use of a dormant permission, or a familiar
+  AppId calling from a new ASN becomes immediately visible.
+tactics:
+  - Collection
+  - Persistence
+techniques:
+  - T1213.005
+  - T1098.001
+  - T1550.001
+tags:
+  - collection
+  - persistence
+  - m365
+  - saas
+  - entra_id
+  - embers
+  - baseline
+  - t1213_005
+  - t1098_001
+  - t1550_001
+  - service_principal
+  - microsoft_graph
+  - application_permissions
+  - workload_identity
+  - cisa_red_team
+submitter:
+  name: Lauren Proehl
+  link: https://x.com/jotunvillur
+related_hunt_ids:
+  - H286
+  - H288
+required_data_sources:
+  - 'Microsoft Graph `/servicePrincipals` and `/applications` via the Graph PowerShell SDK with Application.Read.All — AppId, object ID, display name, owner, creation date, sign-in audience, and whether the object is an app registration service principal or a managed identity. Enumerate BOTH, since managed identities hold permissions too'
+  - 'Graph `/servicePrincipals/{id}/appRoleAssignments` — the granted APPLICATION permissions (app roles) per service principal. This is the permission set that matters; read it from the service principal, not the app registration, because shadow permissions persist on the service principal after the registration appears tightened'
+  - 'Graph `/servicePrincipals/{id}/oauth2PermissionGrants` — delegated permissions, collected alongside so the two models can be told apart during triage'
+  - 'Credential inventory per service principal — passwordCredentials and keyCredentials with displayName, start and end datetimes, and key ID. The count and the expiry pattern are the baseline; a new entry is the alert'
+  - 'Service principal owners — the owning user or group per application, and critically each owner accountEnabled state in Entra ID and in on-prem AD for synced accounts'
+  - 'MicrosoftGraphActivityLogs over the full 30 days — per AppId, capture request count, distinct RequestUri path shapes, the Roles claim on app-only tokens, ResponseStatusCode distribution, ResponseSizeBytes totals, IPAddress and UserAgent'
+  - 'AADServicePrincipalSignInLogs — token issuance per service principal with source IP, resource, and result. Derive the normal source ASN and IP range per AppId here'
+  - 'Entra ID audit logs for the baseline window — Add service principal, Add service principal credentials, Add app role assignment to service principal, Consent to application, and owner changes. These are both a baseline input and the ongoing tripwire'
+  - 'Unified Audit Log MailItemsAccessed and Teams message read records attributed to an AppId, to tie declared permissions to actual observed use'
+  - 'A maintained Microsoft first-party AppId reference list — required to separate first-party noise from third-party and in-house applications before any of the above is interpretable'
+false_positive_notes: >-
+  This baseline is unusual in that its hardest problem is not noise but completeness. Tenants routinely
+  contain hundreds of service principals, most undocumented, many created years earlier by people who
+  have left, and the first run typically surfaces more unknown-but-legitimate applications than anything
+  else — that inventory gap IS the finding, and it should be worked as such rather than treated as an
+  obstacle to the detection. Three specific traps. First, read permissions from the service principal
+  rather than the app registration: the two drift, and reviewing only the registration leaves shadow
+  permissions in place. Second, include managed identities; they are service principals with permissions
+  and are commonly omitted from manual reviews. Third, permission scope does not equal permission use —
+  many applications hold `Mail.Read` and have never called a mail endpoint, and that dormancy is itself
+  valuable baseline data, because first-ever use of a long-dormant permission is a strong signal. Note
+  that MicrosoftGraphActivityLogs cannot be enriched via IdentityInfo for service principals, so this
+  inventory is the only thing that makes that table readable. Expect legitimate change from vendor
+  releases, certificate rotation on a documented cadence, and cloud provider IP range changes — record
+  the cadence during the baseline window so that off-cadence change stands out.
+---
+
+# B043
+
+The clearest lesson in CISA's advisory is not a technique. It is that Organization A had every alert it
+needed and could not use any of them, because it had no baseline. Thousands of false positives from
+normal business operations, many at higher severity than the real ones, meant the red team's activity was
+visible and invisible at the same time. Organization B had an established baseline and tuned alerting, so
+anomalies stood out and defenders acted within minutes.
+
+Nowhere is that gap wider than in workload identity. Both assessed organizations were compromised through
+Entra ID applications with excessive application permissions, and CISA's finding is blunt: neither had
+Conditional Access for workload identities, and the red team has never observed an organization using it.
+So the compensating control is knowing what your applications are — and most tenants do not.
+
+The specific permissions the red team hunted for are worth naming, because they form the collection
+target list for this baseline. `Mail.Read` and `Mail.ReadWrite` to read and write mail in any mailbox.
+`Chat.Read.All` for Teams messages. `Files.Read.All` for OneDrive. And two that are worse than they look:
+`Application.ReadWrite.All`, which allows adding client secrets to any application or service principal,
+and `AppRoleAssignment.ReadWrite.All`, which lets a service principal grant *itself* powerful Graph
+permissions such as `Chat.Read.All` or `RoleManagement.ReadWrite.Directory`. Those last two are
+privilege-escalation primitives inside the tenant, and an application holding either should be treated
+as Tier 0 regardless of what it was built for.
+
+The attack path in both organizations ran through the application's *owner*, not the application. In
+Organization A the operators identified the owner of an app with `Mail.ReadWrite`, moved to that person's
+machine, stole their primary refresh token, and used it to add a client secret. In Organization B the
+owner was an AD-synced account that had been disabled — they re-enabled it, DCSynced it, and used
+Kerberos tickets to authenticate. Ownership is a privilege, it is rarely inventoried, and a disabled
+owner is not a safe owner. Collecting owner identity and owner account state is therefore not
+supplementary to this baseline; it is one of the primary fields.
+
+This baseline is what makes [[H288]] executable — that hunt reads Graph telemetry keyed entirely on
+GUIDs, and without this inventory the results are unreadable. [[H286]] covers the on-prem-to-cloud
+crossing that precedes it.
+
+## Baseline data to collect
+
+For every service principal in the tenant — app registrations and managed identities alike — collect:
+
+**Identity and ownership**
+- AppId, service principal object ID, display name, description, creation date
+- Object type (application service principal vs managed identity), sign-in audience
+- Owner user or group, owner UPN, owner `accountEnabled` state in Entra ID, and for synced owners the
+  corresponding on-prem AD account state
+- Business owner and documented purpose, where one can be established
+
+**Permissions**
+- App role assignments (application permissions) with resource, role value and grant date
+- OAuth2 permission grants (delegated permissions), recorded separately
+- Directory roles assigned to the service principal
+- A flag for the high-priority set: `Chat.Read.All`, `Mail.Read`, `Mail.ReadWrite`, `Mail.Send`,
+  `Files.Read.All`, `Sites.Read.All`, `Application.ReadWrite.All`, `AppRoleAssignment.ReadWrite.All`,
+  `RoleManagement.ReadWrite.Directory`, `Directory.ReadWrite.All`
+
+**Credentials**
+- Count of password credentials and key credentials, with displayName, key ID, start and end datetime
+- Credential lifetime and rotation cadence
+- Any credential with no expiry, or an expiry beyond policy
+
+**Observed behaviour over the window**
+- Requests per day per AppId, and the distribution across days
+- Distinct Graph endpoint path shapes called, and which declared permissions were actually exercised
+- The `Roles` claim observed on app-only tokens
+- Source IP addresses, ASNs and geographies; user agent strings
+- Total ResponseSizeBytes and, for mail and chat endpoints, distinct mailboxes or chats touched
+- Whether the application uses `getAllMessages` or other tenant-wide export endpoints
+
+**Change events during the window**
+- Credential additions, permission grants, owner changes, and consent operations, with actor and cadence
+
+## Collection window
+
+Thirty days, which captures monthly batch jobs, month-end reporting and at least one typical
+certificate or secret rotation for most vendors. Extend to sixty or ninety days for the permission and
+credential inventory specifically if your rotation policy runs on a quarterly cadence — the goal there is
+to observe a full rotation cycle so that off-cycle credential additions are distinguishable.
+
+## Deliverable
+
+A service principal register, refreshed monthly, containing one row per service principal with: AppId,
+display name, owner and owner account state, granted application permissions, high-priority permission
+flag, credential count and expiries, observed daily request volume band, permissions declared but never
+exercised, expected source ASN and user agent set, and an owner-confirmed disposition of
+approved / approved-with-reduction / decommission. The register is the allowlist [[H288]] scores against,
+and the unresolved rows are a standing remediation backlog.
+
+## Flag immediately — do not wait for the baseline to complete
+
+- Any application permission granted to a service principal whose owner account is **disabled** in Entra
+  ID or in on-prem AD
+- Any service principal holding `Application.ReadWrite.All` or `AppRoleAssignment.ReadWrite.All` — these
+  permit self-escalation and secret injection into other applications, and warrant Tier 0 handling now
+- A new client secret or certificate added to an existing application, particularly one holding any
+  high-priority permission
+- A service principal credential with **no expiry**, or an expiry more than a year out
+- First-ever use of a permission the application has held but never exercised
+- App-only calls to `/users/*/chats/getAllMessages` or bulk mail export endpoints from any AppId not on
+  the known backup and compliance vendor list
+- A known AppId authenticating from a new ASN, hosting provider, or geography
+- Any application permission granted without a corresponding admin consent audit record
+- Service principals owned by no one, or owned by a departed employee
+
+## Cross-references
+
+- [[H288]] — Teams messages read tenant-wide by a service principal after a client secret is added; this
+  baseline supplies its allowlist and its GUID-to-name resolution
+- [[H286]] — the Seamless SSO Kerberos path the operators used to reach Entra ID before touching any
+  application
+- [[H234]] and [[H227]] — OAuth application abuse in adjacent SaaS contexts
+
+| Hunt # | Idea / Hypothesis | Tactic | Notes | Tags | Submitter |
+|--------------|-------------------------------------------------------------------------|----------------|------------------------------------------------------------------------------------|--------------------------------|---------------------|
+| B043 | Malicious and legitimate application-permission Graph access are the same shape — tenant-wide, continuous, no user context — so build a 30-day per-service-principal profile of owner and owner account state, granted application permissions, credential set and expiries, exercised-versus-dormant permissions, request volume, source ASN and user agent, making a new secret on an old app, first use of a dormant permission, or a familiar AppId from a new ASN immediately visible. | Collection, Persistence | M365 / Entra ID. Enumerate via Graph `/servicePrincipals`, `/appRoleAssignments` and `/oauth2PermissionGrants` with Application.Read.All — read permissions from the SERVICE PRINCIPAL, not the app registration, or shadow permissions are missed, and include managed identities. Behaviour from MicrosoftGraphActivityLogs (Roles claim, RequestUri shapes, ResponseSizeBytes, IPAddress, UserAgent) and AADServicePrincipalSignInLogs; change events from Entra audit (Add service principal credentials, Add app role assignment). 30-day window, extend to 90 for credential rotation cadence. Deliverable is a monthly service principal register with owner-confirmed disposition. Flag immediately: disabled-owner apps, `Application.ReadWrite.All` / `AppRoleAssignment.ReadWrite.All` holders, new secrets on existing apps, non-expiring credentials, first use of dormant permissions, `getAllMessages` from unknown AppIds. Enables [[H288]]; cross-ref [[H286]]. | #collection #persistence #T1213.005 #T1098.001 #T1550.001 #service_principal #application_permissions #workload_identity #microsoft_graph #baseline | [Lauren Proehl](https://x.com/jotunvillur) |
+
+## Why
+
+- **Both compromises in the source report ran through applications, and neither organization could see
+  them.** CISA's finding is that both tenants used broad application permissions for most apps and that
+  neither had Conditional Access for workload identities — a control the red team reports never having
+  seen deployed anywhere. When the preventive control is effectively absent industry-wide, the inventory
+  is the control.
+- **Detection here is a change-detection problem, and change detection requires a prior state.** Volume,
+  endpoint and permission scope all look identical between a compliance product and an operator reading
+  the tenant. What differs is that the operator's access is *new*: new secret, newly exercised permission,
+  new source. None of those are computable without a recorded baseline, which is why this must be an
+  Ember rather than a rule.
+- **Two permissions in the collection set are tenant-level escalation primitives.** `Application.ReadWrite.All`
+  allows adding credentials to any other application, and `AppRoleAssignment.ReadWrite.All` allows a
+  service principal to grant itself `Chat.Read.All` or `RoleManagement.ReadWrite.Directory`. An
+  application holding either is equivalent to a privileged account, and most inventories do not treat it
+  that way. Simply enumerating who holds them is often the highest-value hour in this exercise.
+- **Ownership is an unmonitored privilege, and disabled owners are not safe owners.** Both organizations
+  were reached through the application's owner rather than the application, and in one case the owner was
+  a disabled AD-synced account that the operators re-enabled and DCSynced. Owner identity and owner
+  account state belong in the register as first-class fields, not as metadata.
+- **Dormant permissions are the cheapest high-signal feature available.** Applications routinely hold
+  permissions they have never used. Recording which of a service principal's declared permissions were
+  actually exercised during the window converts a static permission list into a behavioural expectation,
+  and makes first-use of a dormant permission a near-conclusive event at effectively zero cost.
+- **Without this register, Graph telemetry is unreadable.** MicrosoftGraphActivityLogs is keyed on AppId
+  and ServicePrincipalId GUIDs, and Microsoft's own IdentityInfo enrichment does not cover service
+  principals. Any team attempting to triage app-only Graph access without a local name-and-owner mapping
+  is reading hex during an incident.
+- **Token revocation depends on knowing what to revoke.** Both organizations lacked processes for
+  revoking compromised access and refresh tokens, so cloud access outlived on-prem eviction. The credential
+  inventory in this register is the eviction checklist.
+
+## References
+
+- [MITRE ATT&CK T1213.005: Data from Information Repositories — Messaging Applications](https://attack.mitre.org/techniques/T1213/005/)
+- [MITRE ATT&CK T1098.001: Account Manipulation — Additional Cloud Credentials](https://attack.mitre.org/techniques/T1098/001/)
+- [CISA AA26-237A: A Tale of Two SOCs — Insights From Two Red Team Assessments (source report)](https://www.cisa.gov/news-events/cybersecurity-advisories/aa26-237a)
+- [Practical365: Detect and report high-priority permissions in Entra ID apps](https://practical365.com/entra-id-apps-review-permissions/)
+- [Quarkslab: Auditing application permissions in Microsoft Entra ID — hidden risks and pitfalls](https://blog.quarkslab.com/auditing-application-permissions-in-microsoft-entra-id-hidden-risks-pitfalls-and-quarkslabs-qazpt-tool.html)
+- [Red Canary: Entra ID service principals in business email compromise schemes](https://redcanary.com/blog/threat-detection/entra-id-service-principals/)
+- [Invictus IR: MicrosoftGraphActivityLogs — the complete guide](https://www.invictus-ir.com/news/everything-you-need-to-know-about-the-microsoftgraphactivitylogs)
+- [Microsoft: Conditional Access for workload identities](https://learn.microsoft.com/en-us/entra/identity/conditional-access/workload-identity)

--- a/Flames/H286.md
+++ b/Flames/H286.md
@@ -1,0 +1,152 @@
+---
+id: H286
+category: Flames
+title: Kerberos service ticket requested for the Entra ID Seamless SSO computer account and replayed from proxied infrastructure
+hypothesis: >-
+  An operator who already owns on-prem Active Directory crosses into Entra ID without ever learning a
+  cleartext password. They DCSync the AES256 key of a synced target account, use it to request a TGT,
+  then request a Kerberos service ticket for the Seamless SSO computer account — the `AZUREADSSOACC$`
+  object whose SPNs back `https://autologon.microsoftazuread-sso.com` — export the ticket, and import
+  it on their own Windows VM. Traffic to `https://portal.azure.com` is then tunnelled through a SOCKS
+  proxy on a compromised internal host, so Entra ID sees a valid Kerberos ticket arriving from a
+  trusted corporate egress IP. Only MFA stops the second phase, and the accounts that lack MFA are
+  usually the synced service accounts. Hunt for Event ID 4769 where the service is `AZUREADSSOACC$`,
+  requested by an account or from a source host that has no history of it, and correlate each one
+  against the Entra ID sign-in it should — and often does not — line up with.
+tactics:
+  - Credential Access
+  - Lateral Movement
+  - Defense Evasion
+techniques:
+  - T1558
+  - T1550.003
+  - T1003.006
+tags:
+  - credential_access
+  - lateral_movement
+  - defense_evasion
+  - windows
+  - flames
+  - t1558
+  - t1550_003
+  - t1003_006
+  - kerberos
+  - seamless_sso
+  - entra_id
+  - hybrid_identity
+  - azureadssoacc
+  - cisa_red_team
+submitter:
+  name: Lauren Proehl
+  link: https://x.com/jotunvillur
+required_data_sources:
+  - 'Windows Security Event ID 4769 from EVERY domain controller — ServiceName `AZUREADSSOACC$`, plus TargetUserName, TicketEncryptionType, TicketOptions, IpAddress and Status. 4769 is written only to the Security channel of the DC that issued the ticket, so partial DC coverage means partial visibility'
+  - 'Windows Security Event ID 4768 — the TGT request that should precede each 4769 for the same account and source. A 4769 with no matching 4768 in the ticket-lifetime window is the pass-the-ticket tell'
+  - 'Windows Security Event ID 4662 on domain controllers — Object Type `domainDNS` with the directory replication control access rights (GUIDs 1131f6aa-9c07-11d1-f79f-00c04fc2dcd2, 1131f6ad-9c07-11d1-f79f-00c04fc2dcd2, 89e95b76-444d-4c62-991a-0facbeda640c). This is the DCSync that supplies the AES256 key one step earlier'
+  - 'Entra ID sign-in logs / AADSignInEventsBeta — Seamless SSO sign-ins for the impersonated account. Join on user and time against the on-prem 4769; also inspect IPAddress, UserAgent, DeviceDetail and AuthenticationRequirement'
+  - 'Defender for Identity IdentityLogonEvents and IdentityDirectoryEvents — DC-side Kerberos and replication telemetry without needing raw 4769 forwarding'
+  - 'Sysmon Event ID 1 / Security Event ID 4688 — process creation for Rubeus and its arguments (`asktgs`, `asktgt`, `/service:`, `/ticket:`, `/ptt`, `/nowrap`, `/enctype:aes256`), and for the ticket-cache tooling around it'
+  - 'Sysmon Event ID 3 and firewall/proxy telemetry — outbound SOCKS or tunnelled sessions from a workstation or member server that then carries traffic destined for login.microsoftonline.com and portal.azure.com. The internal host is the pivot that launders the source IP'
+  - 'Entra Connect configuration inventory — which on-prem computer object implements Seamless SSO, when its password was last rotated, and which accounts are synced without MFA'
+false_positive_notes: >-
+  Legitimate Seamless SSO produces 4769 events for `AZUREADSSOACC$` constantly — every domain-joined,
+  corporate-network user signing in to an Entra-integrated app generates one. Volume alone is
+  meaningless here, so do not alert on the service name by itself. The discriminators are all
+  relational. First, WHO: the requesting account should be a normal interactive user on their own
+  workstation. A request on behalf of a service account, a disabled-then-re-enabled account, or an
+  account whose ticket is requested from a host that is not the device it normally logs into is
+  the anomaly. Second, WHERE: the IpAddress on the 4769 should be the user's own workstation, not a
+  server, a jump box, or the handful of hosts an operator has footholds on. Third, WHAT HAPPENS NEXT:
+  a legitimate ticket is consumed immediately by that same user's browser session on that same device;
+  a stolen one is consumed from a VM on attacker infrastructure whose traffic is proxied, so the Entra
+  sign-in shows an internal egress IP but the device, user agent and browser fingerprint do not match
+  any known asset. Note two important collection caveats. Encryption type is a weak signal for this
+  specific tradecraft — the CISA red team used AES256, not RC4, so the classic `0x17` kerberoast
+  heuristic will not fire. More seriously, most published 4769 rules explicitly exclude service names
+  ending in `$` to suppress machine-account noise, which excludes `AZUREADSSOACC$` outright; check your
+  existing rule set for that filter before assuming this is covered.
+---
+
+# H286
+
+The interesting thing about the way CISA's red team reached Entra ID is that nothing they did was
+forged.
+
+The well-documented attack on Seamless SSO is a silver ticket: dump the `AZUREADSSOACC$` password
+hash, forge a service ticket for the SSO SPN, impersonate anyone. AADInternals automates it, DSInternals
+described it years ago, and the standard detection is a correlation rule that looks for an Entra sign-in
+with no corresponding ticket issuance on a domain controller — because a forged ticket never touches the
+KDC, so there is no 4769 to find.
+
+That detection does not fire on what actually happened. The red team had already DCSynced the domain.
+They took a target user's AES256 key, requested a real TGT with it, and used Rubeus `asktgs` to request
+a real service ticket from a real domain controller. The KDC issued it. There is a 4769. The absence-of-
+KDC-event logic — the detection most organizations have built for this technique, if they have built one
+at all — sees a perfectly ordinary Seamless SSO ticket and says nothing.
+
+What is anomalous is not the ticket's existence but its provenance and its destination. The ticket was
+requested on behalf of a user by an operator sitting on a foothold host, exported, and imported into a
+Windows VM on red team infrastructure. That VM then proxied its traffic through a SOCKS tunnel on a
+compromised internal host, so the browse to `portal.azure.com` arrived at Entra ID from a trusted IP
+address carrying a legitimate Kerberos ticket. Every individual element looks correct. The relationships
+between them do not.
+
+There is a second reason this deserves its own hunt: the SSO account is a computer account, and
+essentially every published 4769 detection filters out service names ending in `$`. That exclusion
+exists for good reason — machine-account tickets are the bulk of Kerberos volume — but it means
+`AZUREADSSOACC$` sits in a blind spot created by the standard tuning advice. A hunt that starts from
+the service name rather than from the encryption type inverts that.
+
+This is also the point in the chain where the on-prem blast radius becomes a cloud blast radius. In both
+CISA assessments the operators used cloud access the same way: find an application with `Mail.ReadWrite`
+or `Chat.Read.All` application permissions, add a client secret to it, and read the tenant's mail and
+Teams messages from the public internet. [[H288]] covers that read stage and [[B043]] the permission
+baseline underneath it; this hunt covers the door they came in through. Notably, both organizations
+lacked any process for revoking access and refresh tokens, so eviction from on-prem did not evict them
+from the tenant.
+
+| Hunt # | Idea / Hypothesis | Tactic | Notes | Tags | Submitter |
+|--------------|-------------------------------------------------------------------------|----------------|------------------------------------------------------------------------------------|--------------------------------|---------------------|
+| H286 | An operator with DCSync rights requests a legitimate Kerberos service ticket for the Seamless SSO computer account (`AZUREADSSOACC$`) using a synced user's DCSynced AES256 key, imports the ticket on external infrastructure, and proxies traffic through a compromised internal host so the Entra ID sign-in arrives from a trusted IP — reaching the cloud tenant without a cleartext password and without tripping forged-ticket detections. | Credential Access, Lateral Movement, Defense Evasion | Windows / hybrid identity. Hunt Security EID 4769 where ServiceName is `AZUREADSSOACC$`, pivoting on requesting account and source IpAddress rather than TicketEncryptionType — the operator used AES256, so `0x17` heuristics miss it. CHECK YOUR RULES: most published 4769 detections exclude ServiceName ending in `$`, which excludes this account entirely. Correlate each 4769 to the matching Entra sign-in (SigninLogs / AADSignInEventsBeta) and flag tickets whose sign-in device, user agent or auth method does not match a known asset for that user. Walk back one stage to EID 4662 replication GUIDs for the DCSync, and one stage forward to a client-secret add on an over-permissioned app. Cross-ref T1550.003 (Pass the Ticket), T1003.006 (DCSync), [[H288]] and [[B043]]. | #credential_access #lateral_movement #defense_evasion #T1558 #T1550.003 #T1003.006 #seamless_sso #entra_id #hybrid_identity #azureadssoacc | [Lauren Proehl](https://x.com/jotunvillur) |
+
+## Why
+
+- **The published detection for this technique does not cover the way it was actually used.** Nearly all
+  Seamless SSO abuse guidance targets the forged-ticket variant and keys on the *absence* of a KDC event.
+  An operator who already holds DCSync does not need to forge anything — they request a genuine ticket
+  with a stolen key, producing exactly the KDC event the detection expects to be missing. Building the
+  hunt around ticket provenance rather than ticket forgery closes a gap that a correlation rule alone
+  leaves open.
+- **`AZUREADSSOACC$` falls inside the standard 4769 tuning exclusion.** The near-universal advice for
+  making 4769 tractable is to drop machine accounts by filtering `ServiceName` ending in `$`. That single
+  filter removes the Seamless SSO account from view, which means many environments that believe they
+  monitor Kerberos service ticket activity have no coverage of the one SPN that bridges on-prem AD to the
+  cloud. This is worth checking as a standalone exercise even before running the hunt.
+- **It is the hinge between an on-prem compromise and a tenant compromise.** Seamless SSO exists
+  specifically to let a Kerberos ticket serve as the first factor for Entra ID. That makes the SSO
+  computer account a Tier 0 asset with cloud reach, and it means an AD compromise is a cloud compromise
+  by default unless MFA covers the second phase. CISA's red team found MFA coverage gaps concentrated
+  precisely where they mattered least to users and most to attackers: synced service accounts.
+- **The proxied source IP defeats location-based conditional access and analyst intuition.** By tunnelling
+  through a SOCKS proxy on an internal host, the operator makes the sign-in appear to originate from
+  trusted corporate space. Any control or triage habit that treats "came from our IP range" as
+  reassurance is inverted here. The durable signal is device and user-agent mismatch against a known
+  asset inventory, not network location.
+- **The stage is cheap to instrument relative to what it prevents.** Compared to broad Kerberos anomaly
+  detection, scoping to one service name yields a small, reviewable event set in most environments, and
+  the account/source-host pivot needs only a few weeks of history to become meaningful. Pairing it with
+  the 4662 replication check gives two independent tripwires on the same kill chain.
+- **HEARTH had no T1558 coverage.** Existing Kerberos-adjacent hunts address NTLM relay and
+  post-NTDS-dump credential reuse ([[M035]]), not Kerberos ticket theft and reuse as an identity-boundary
+  crossing.
+
+## References
+
+- [MITRE ATT&CK T1558: Steal or Forge Kerberos Tickets](https://attack.mitre.org/techniques/T1558/)
+- [CISA AA26-237A: A Tale of Two SOCs — Insights From Two Red Team Assessments (source report)](https://www.cisa.gov/news-events/cybersecurity-advisories/aa26-237a)
+- [DSInternals: Impersonating Office 365 users with Mimikatz (the original Seamless SSO ticket research)](https://www.dsinternals.com/en/impersonating-office-365-users-mimikatz/)
+- [SpecterOps Rubeus documentation: the asktgs command and its detection considerations](https://docs.specterops.io/ghostpack-docs/Rubeus-mdx/commands/ticket-requests/asktgs)
+- [Splunk: Detecting Active Directory Kerberos attacks — threat research release](https://www.splunk.com/en_us/blog/security/detecting-active-directory-kerberos-attacks-threat-research-release-march-2022.html)
+- [Microsoft: Understanding the Primary Refresh Token (PRT) in Microsoft Entra ID](https://learn.microsoft.com/en-us/entra/identity/devices/concept-primary-refresh-token)
+- [Microsoft: Entra Connect Seamless SSO — technical deep dive and AZUREADSSOACC$ key rollover](https://learn.microsoft.com/en-us/entra/identity/hybrid/connect/how-to-connect-sso-how-it-works)
+- [Ultimate Windows Security: Event ID 4769 — a Kerberos service ticket was requested](https://www.ultimatewindowssecurity.com/securitylog/encyclopedia/event.aspx?eventid=4769)

--- a/Flames/H287.md
+++ b/Flames/H287.md
@@ -1,0 +1,137 @@
+---
+id: H287
+category: Flames
+title: SCCM user-device affinity queried to map privileged users to their workstations before lateral movement
+hypothesis: >-
+  An operator who needs to find one specific person's workstation does not scan the network for it —
+  they ask the endpoint management platform, which already knows. Configuration Manager maintains
+  user-device affinity precisely so that IT can answer "which machines does this user work on," and
+  that mapping is an ideal targeting list for an operator who has identified a privileged user in
+  BloodHound data and now needs somewhere to go. The query joins `SMS_R_System`, `SMS_R_User` and
+  `SMS_UserMachineRelationship`, and it reaches the SMS Provider either over WMI against
+  `root\SMS\site_<code>` or over the AdminService REST API on the site server. Hunt for those class
+  names appearing in WMI queries or AdminService request URIs from a host that is not a Configuration
+  Manager console, under an identity that is not a Configuration Manager operator.
+tactics:
+  - Discovery
+techniques:
+  - T1033
+  - T1018
+tags:
+  - discovery
+  - windows
+  - flames
+  - t1033
+  - t1018
+  - sccm
+  - configuration_manager
+  - adminservice
+  - wmi
+  - tier_zero
+  - user_device_affinity
+  - sharpsccm
+  - cisa_red_team
+submitter:
+  name: Lauren Proehl
+  link: https://x.com/jotunvillur
+required_data_sources:
+  - 'Microsoft-Windows-WMI-Activity/Operational Event ID 11 and 5857/5858/5860/5861 on SMS Provider and site servers — the WQL text is the payload. Hunt for `SMS_UserMachineRelationship`, `SMS_R_User`, `SMS_R_System` and `SMS_UserMachineRelationship.Types` against the `root\SMS\site_<code>` namespace, and record the calling process and user'
+  - 'AdminService IIS logs on the SMS Provider — OData request URIs under `/AdminService/wmi/` referencing SMS_R_User, SMS_R_System or SMS_UserMachineRelationship. Unbounded enumeration (no `$filter`) and high-volume `$skip` paging are the shapes worth flagging, along with non-console user agents'
+  - 'Sysmon Event ID 1 / Security Event ID 4688 — process creation for SharpSCCM, sccmhunter and PowerShell invoking `Get-CMUserDeviceAffinity`, `Get-WmiObject -Namespace root\SMS`, or `Get-CimInstance` against the provider namespace. Capture full command line and parent process'
+  - 'Sysmon Event ID 3 / DeviceNetworkEvents — connections to the SMS Provider on 135/DCOM, on the AdminService port (443/tcp by default), and to management points, sourced from hosts with no administrative role'
+  - 'Defender XDR DeviceProcessEvents and DeviceNetworkEvents — FileName, ProcessCommandLine, InitiatingProcessFileName, RemoteUrl for the same activity where Sysmon is not deployed'
+  - 'Windows Security Event ID 4624 and 4672 on the SMS Provider and site server — logon type, source host and privilege assignment for every session that subsequently issues provider queries'
+  - 'SMS Admins local group membership on every SMS Provider, plus the RBAC_Admins table in the site database — the authorization list the query activity should be reconciled against, and an object worth monitoring for change in its own right'
+  - 'Configuration Manager console inventory — which hosts legitimately run the console, and which accounts are assigned Configuration Manager RBAC roles. Without this list the hunt has no denominator'
+false_positive_notes: >-
+  Every Configuration Manager console session and every scheduled report generates queries that look
+  structurally identical to this one — the class names are the same because the intent (find this user's
+  devices) is the same. Query text alone will not separate them, so the hunt has to be built on source
+  host and identity: a small, enumerable set of console workstations and RBAC-assigned operators is the
+  allowlist, and anything outside it is the finding. Expect legitimate noise from the site server machine
+  account, which is a member of SMS Admins by default, from reporting services, from OSD and application
+  deployment workflows, and from third-party asset-management or software-metering integrations that
+  query the provider on a schedule. Break the AdminService and WMI paths out separately: most legitimate
+  console traffic is WMI, so unusual AdminService REST usage is often the higher-signal half. Where UDA
+  is manually approved rather than auto-populated (`Automatically configure user device affinity from
+  usage data` set to False), legitimate query volume is lower still and the baseline tightens further.
+  One collection caveat worth resolving before running this: WMI-Activity operational logging is
+  frequently disabled or not forwarded from site servers, and AdminService IIS logs are often not
+  collected centrally at all, so a null result may mean no telemetry rather than no activity.
+---
+
+# H287
+
+Discovery hunts are usually a losing proposition because the adversary's commands are the administrator's
+commands. `whoami`, `net user`, `systeminfo` — hunting the generic form of T1033 mostly produces a list
+of your own IT staff doing their jobs. This one is different, because of where the operator asks the
+question.
+
+CISA's red team had already scraped Active Directory with a modified BloodHound collector and knew which
+users mattered. What they did not know was where those users actually worked. Their stated plan for
+reaching each sensitive business system was explicit about this: use the AD data to identify users
+related to the target system, then "query system center configuration manager (SCCM) servers to
+enumerate user-device relationships and identify the workstations assigned to each user," then move
+laterally from the SCCM server to those workstations, then find credential material there.
+
+SCCM answers that question better than any scan could, because answering it is its purpose. User-device
+affinity is a maintained, authoritative mapping between people and the machines they use. For an operator
+it is a targeting list with no noise and no discovery footprint on the endpoints themselves — the
+enumeration happens entirely against the management infrastructure.
+
+That infrastructure is Tier 0, and CISA called this out as a distinct issue: endpoint management systems
+like SCCM, Jamf and BigFix have broad administrative reach across the estate, and compromising one gives
+an operator both an escalation path and a lateral movement platform. In Organization A the red team moved
+from the SCCM server directly to users' workstations. There is a bleak detail in the same report about
+what happened next: defenders did receive an alert relating to that SCCM activity, tried and failed to
+determine the system's owner and normal function, and eventually closed it as a false positive. The
+detection worked. The context to act on it did not exist.
+
+That is the practical argument for hunting this narrowly rather than broadly. The query shape here is
+specific enough to enumerate, the legitimate population that issues it is small enough to allowlist, and
+the asset involved is important enough to justify knowing its baseline in advance rather than
+reconstructing it under pressure. [[B041]] covers the adjacent inventory problem for RMM and UEM agents
+generally.
+
+| Hunt # | Idea / Hypothesis | Tactic | Notes | Tags | Submitter |
+|--------------|-------------------------------------------------------------------------|----------------|------------------------------------------------------------------------------------|--------------------------------|---------------------|
+| H287 | An operator queries Configuration Manager's user-device affinity data — joining `SMS_R_System`, `SMS_R_User` and `SMS_UserMachineRelationship` over WMI against `root\SMS\site_<code>` or over the AdminService REST API — to map previously identified privileged users to the workstations they use, producing a lateral movement target list without touching the endpoints themselves. | Discovery | Windows. Hunt WMI-Activity/Operational EID 11 and 5857–5861 on SMS Providers for those three class names, and AdminService IIS logs for `/AdminService/wmi/` OData URIs referencing them — particularly unbounded queries with no `$filter` or heavy `$skip` paging. Separate by source host and identity against the console/RBAC allowlist rather than by query text, which is identical for benign use. Pivot on Sysmon EID 1 / 4688 for SharpSCCM, sccmhunter and `Get-CMUserDeviceAffinity`, and on 4624/4672 sessions on the provider. Treat SMS Admins group membership change as a related tripwire. SCCM is Tier 0 — cross-ref T1018 and [[B041]]. | #discovery #T1033 #T1018 #sccm #configuration_manager #adminservice #wmi #tier_zero #user_device_affinity | [Lauren Proehl](https://x.com/jotunvillur) |
+
+## Why
+
+- **This is the rare form of T1033 that is genuinely huntable.** Generic system-owner discovery is
+  unhuntable because the commands are indistinguishable from administration and the population issuing
+  them is everyone. Scoping to the SCCM provider inverts both properties: the query shape is narrow and
+  named, and the set of hosts and identities that should ever issue it is small enough to write down.
+  The technique becomes actionable only because of where it is asked.
+- **It sits at a decision point in the intrusion, before lateral movement rather than after.** The
+  operator queries affinity specifically to choose where to go next. Catching it means catching them
+  between owning the management plane and owning the target user's workstation — one of the few moments
+  in a modern intrusion where detection buys real time rather than confirming a completed step.
+- **Endpoint management platforms are Tier 0 and are rarely monitored like it.** SCCM can execute code on
+  every managed endpoint, holds credentials in policies, task sequences and collection variables, and
+  publishes its own location in AD via the System Management container. CISA flagged exactly this class
+  of system as an under-secured escalation path. Most organizations instrument domain controllers
+  carefully and site servers not at all.
+- **The report shows what happens when the alert has no owner.** The SOC in Organization A saw SCCM-related
+  activity, could not establish what the system was for or who ran it, and closed the ticket. Building the
+  console/RBAC allowlist this hunt requires produces that missing context as a durable artifact — the
+  denominator is as valuable as the detection.
+- **The AdminService path is newer than most detection content.** Published SCCM tradecraft has moved
+  toward the AdminService REST API, and offensive tooling (SharpSCCM, sccmhunter) supports it directly,
+  but IIS logs from the SMS Provider are frequently not collected. Adding that one log source covers a
+  path that WMI-based monitoring cannot see at all.
+- **HEARTH had no hunt with SCCM as its primary subject** — Configuration Manager appears only
+  incidentally in existing hunts, despite being a standard objective in current red team and ransomware
+  tradecraft alike.
+
+## References
+
+- [MITRE ATT&CK T1033: System Owner/User Discovery](https://attack.mitre.org/techniques/T1033/)
+- [CISA AA26-237A: A Tale of Two SOCs — Insights From Two Red Team Assessments (source report)](https://www.cisa.gov/news-events/cybersecurity-advisories/aa26-237a)
+- [SpecterOps Misconfiguration Manager: SCCM attack technique catalog (RECON-1 through RECON-5)](https://github.com/subat0mik/Misconfiguration-Manager/blob/main/attack-techniques/README.md)
+- [SpecterOps SharpSCCM documentation: device/user discovery and AdminService abuse](https://docs.specterops.io/sharpsccm-docs/overview)
+- [Microsoft: Link users and devices with user device affinity in Configuration Manager](https://learn.microsoft.com/en-us/intune/configmgr/apps/deploy-use/link-users-and-devices-with-user-device-affinity)
+- [Microsoft: Configuration Manager AdminService REST API overview](https://learn.microsoft.com/en-us/intune/configmgr/develop/adminservice/overview)
+- [Microsoft: WMI-Activity operational log and WMI event tracing](https://learn.microsoft.com/en-us/windows/win32/wmisdk/tracing-wmi-activity)
+- [Icex0: SCCM recon — enumerating site systems, users and device relationships](https://ice0.blog/docs/sccm-2-recon)

--- a/Flames/H288.md
+++ b/Flames/H288.md
@@ -1,0 +1,151 @@
+---
+id: H288
+category: Flames
+title: Service principal reading Teams chat messages tenant-wide via Microsoft Graph after a client secret is added
+hypothesis: >-
+  Having reached Entra ID, an operator does not need to compromise a mailbox or a chat account — they
+  need an application that already can. They locate a registered application holding application
+  permissions such as `Chat.Read.All`, `Mail.Read` or `Mail.ReadWrite`, add a new client secret to it,
+  authenticate as the application, and read the tenant's Teams messages and mail from the public
+  internet. Because app-only access carries no user context, it is outside the reach of ordinary
+  Conditional Access policies, survives password resets and MFA enrolment, and leaves no interactive
+  sign-in. In the CISA assessments this was used to read the SOC's own Teams messages and email to
+  watch whether the intrusion had been noticed. Hunt for a credential being added to a service
+  principal, followed by app-only Graph calls to `/chats`, `/chats/{id}/messages` or
+  `/users/{id}/chats/getAllMessages` from an AppId with no history of that access pattern.
+tactics:
+  - Collection
+  - Persistence
+  - Defense Evasion
+techniques:
+  - T1213.005
+  - T1550.001
+  - T1098.001
+tags:
+  - collection
+  - persistence
+  - defense_evasion
+  - m365
+  - saas
+  - flames
+  - t1213_005
+  - t1550_001
+  - t1098_001
+  - microsoft_teams
+  - microsoft_graph
+  - service_principal
+  - oauth
+  - chat_read_all
+  - counter_incident_response
+  - cisa_red_team
+submitter:
+  name: Lauren Proehl
+  link: https://x.com/jotunvillur
+required_data_sources:
+  - 'MicrosoftGraphActivityLogs — the primary source. Filter RequestMethod GET against RequestUri matching `/chats`, `/chats/*/messages` and `/getAllMessages`, with ResponseStatusCode 200. The `Roles` column carries the granted application permissions on an app-only token, so `Roles has "Chat.Read.All"` is a more reliable pivot than URI matching alone. Also project AppId, ServicePrincipalId, IPAddress, UserAgent and ResponseSizeBytes'
+  - 'MicrosoftGraphActivityLogs where ServicePrincipalId is populated and UserId is empty — this is the app-only shape. Exclude Microsoft first-party AppIds with a maintained lookup list or the noise floor will bury everything'
+  - 'Entra ID audit logs — the operations `Add service principal credentials`, `Update application – Certificates and secrets management`, and `Add app role assignment to service principal`. This is the credential-add that precedes the reads and the strongest single alerting opportunity in the chain'
+  - 'Defender XDR CloudAppEvents — Teams activity including ChatCreated and MessageRead style records, plus RawEventData for participant and chat identifiers, to corroborate which conversations were touched'
+  - 'Unified Audit Log MessagesListed / MessageRead and MailItemsAccessed records — the Exchange and Teams read events themselves, with the AppId attribution that ties them to a service principal rather than a user'
+  - 'AADServicePrincipalSignInLogs — app-only token issuance for the AppId, including source IP and resource. A service principal that has only ever authenticated from one cloud egress range and now authenticates from a hosting provider is the finding'
+  - 'Service principal inventory — AppId to display name, owner, granted application permissions, credential list with expiry, and creation date. Needed to make GUID-keyed Graph telemetry readable, and maintained by [[B043]]'
+  - 'Entra ID sign-in logs for the application OWNER account — the CISA red team reached the app by compromising its owner, including one owner account that was disabled in AD and re-enabled to be used'
+false_positive_notes: >-
+  Application-permission Graph access is legitimate and constant. Backup and archiving vendors,
+  eDiscovery and compliance platforms, DLP tools, chatbots, HR and ITSM integrations, and Microsoft's own
+  first-party services all read Teams and mail data at scale — and they read it tenant-wide, which is
+  exactly the shape of the malicious access. Excluding Microsoft first-party AppIds against a maintained
+  reference list is the single highest-value tuning step and should be done before anything else. Beyond
+  that, do not try to distinguish this by volume or endpoint: distinguish it by CHANGE. The stable
+  properties of a legitimate integration are its AppId, its permission set, its credential set, its source
+  IP range and its user agent, and those change on a release cadence, not hourly. New client secret on an
+  existing app, first-ever use of a permission the app has held unused for months, a new source ASN, or a
+  new user agent for a known AppId are each individually rare and jointly close to conclusive. Two
+  specific caveats. `getAllMessages` is a tenant-wide export endpoint and is rarely legitimate outside
+  known backup and compliance vendors, so treat it as a much higher-signal URI than `/chats`. And
+  MicrosoftGraphActivityLogs cannot be enriched from IdentityInfo for service principals — the standard
+  UserId join covers users only — so service principal naming has to come from your own inventory.
+---
+
+# H288
+
+The detail worth sitting with from CISA's advisory is not that the red team read email. It is whose
+email they read, and why.
+
+In Organization A the operators used compromised application permissions to retrieve and review the
+security operations centre's own messages — mail first, then Teams messages pulled from SOC personnel's
+workstations — specifically to determine whether the SOC had noticed them. Detection had, in fact,
+partly worked: medium- and low-severity EDR alerts fired on red team activity. They were never actioned,
+drowned in thousands of higher-severity false positives from normal business operations. The operators
+were able to confirm that from inside the defenders' own conversations.
+
+That reframes this technique. `Chat.Read.All` is usually filed under collection, and it is that, but in
+an active intrusion it is counter-incident-response: real-time intelligence on whether the defenders
+know, what they think, and whether containment is coming. Any incident that involves a compromised
+service principal with mail or chat permissions should be worked on the assumption that the response
+itself is being read.
+
+The access path is the same in both organizations CISA assessed, and it is worth stating plainly because
+each step is individually mundane. Find an application with application permissions — not delegated
+permissions, which need a user to consent, but application permissions, which do not. Compromise its
+owner. Add a client secret. Authenticate as the application. Read everything. In Organization B the
+application's owner was an AD-synced account that had been *disabled*; the operators re-enabled it,
+DCSynced its credentials, requested Kerberos tickets, authenticated to Entra ID, and added the secret.
+A disabled account is not a decommissioned one.
+
+Application permissions operate outside traditional Conditional Access, and CISA notes that Conditional
+Access for workload identities — the control that would have covered this — was not in use at either
+organization, and that they have never observed an organization using it. Both also lacked any process
+for revoking access and refresh tokens after a compromise, which is why cloud access survived on-prem
+eviction.
+
+[[H286]] covers how the operators crossed from AD into the tenant in the first place. [[B043]] builds the
+service principal permission baseline this hunt reads against, and without it the Graph telemetry here is
+a wall of GUIDs. [[M037]] covers a different Teams-based intrusion path, and [[H234]] and [[H227]] cover
+OAuth application abuse in adjacent SaaS contexts.
+
+| Hunt # | Idea / Hypothesis | Tactic | Notes | Tags | Submitter |
+|--------------|-------------------------------------------------------------------------|----------------|------------------------------------------------------------------------------------|--------------------------------|---------------------|
+| H288 | An operator adds a client secret to an existing Entra ID application that holds `Chat.Read.All` / `Mail.ReadWrite` application permissions, authenticates as that application, and reads Teams messages and mail tenant-wide over Microsoft Graph from the public internet — bypassing Conditional Access, producing no interactive sign-in, and in the source report being used to read the SOC's own conversations to check whether the intrusion had been detected. | Collection, Persistence, Defense Evasion | M365 / Entra ID. Primary source MicrosoftGraphActivityLogs: `Roles has "Chat.Read.All"` is a stronger pivot than URI matching; hunt GET to `/chats`, `/chats/*/messages` and especially `/users/*/chats/getAllMessages` (tenant-wide export, rarely legitimate outside backup/compliance vendors). Isolate app-only calls where ServicePrincipalId is set and UserId is empty, and exclude first-party Microsoft AppIds via a maintained lookup or the signal is buried. Alert on the precursor: Entra audit `Add service principal credentials` / `Add app role assignment to service principal`. Corroborate with AADServicePrincipalSignInLogs source IP/ASN drift and UAL MessagesListed / MailItemsAccessed. Note IdentityInfo enrichment does NOT cover service principals — name them from [[B043]]. Check whether the app's owner account is disabled in AD; the source report's operators re-enabled one. Cross-ref T1550.001, T1098.001, [[H286]], [[M037]]. | #collection #persistence #defense_evasion #T1213.005 #T1550.001 #T1098.001 #microsoft_graph #chat_read_all #service_principal #counter_incident_response | [Lauren Proehl](https://x.com/jotunvillur) |
+
+## Why
+
+- **Reading the SOC's messages changes the incident, not just the impact assessment.** This is
+  collection used as counter-response. If an operator can read the defenders' Teams channels and mail,
+  they know when containment is being planned and can move first — and the defenders' own
+  coordination becomes an attacker data source. The practical consequence is that any confirmed
+  compromise of a service principal with chat or mail permissions should trigger out-of-band incident
+  communications immediately, which makes this hunt worth running proactively rather than after the fact.
+- **Application permissions sit outside the controls people believe cover them.** App-only access has no
+  user, so no MFA, no user risk policy, and no ordinary Conditional Access. The control that does cover
+  it — Conditional Access for workload identities — CISA reports having never seen deployed at an
+  assessed organization. That gap is systemic rather than incidental, which makes detection the load-
+  bearing control rather than the backstop.
+- **The credential-add is a small, rare, high-fidelity event that precedes the damage.** Reading chat
+  messages is high volume and hard to distinguish from a compliance product. Adding a client secret to an
+  existing application is low volume, discrete, appears cleanly in the Entra audit log, and happens
+  *before* any data is read. Hunting the reads finds the collection; alerting on the credential-add finds
+  it in time to matter.
+- **`getAllMessages` is a tenant-wide export endpoint with a small legitimate population.** Unlike
+  `/chats`, which any integration touches, the export API is used almost exclusively by backup and
+  compliance vendors. Enumerating that population once turns a broad collection technique into a
+  narrow allowlist question.
+- **Token revocation gaps make this persist past eviction.** Both assessed organizations lacked processes
+  to revoke access and refresh tokens after a cloud compromise. An operator removed from the on-prem
+  estate retains tenant access through the application until its credentials are explicitly rotated —
+  which means detecting the reads is also how you discover what still needs revoking.
+- **The disabled-account assumption fails here.** The application owner in Organization B was disabled in
+  AD and simply re-enabled by the operators, who then DCSynced it. Disabled synced accounts that own
+  privileged applications are a live attack surface, and enumerating them is a cheap by-product of this
+  hunt.
+
+## References
+
+- [MITRE ATT&CK T1213.005: Data from Information Repositories — Messaging Applications](https://attack.mitre.org/techniques/T1213/005/)
+- [CISA AA26-237A: A Tale of Two SOCs — Insights From Two Red Team Assessments (source report)](https://www.cisa.gov/news-events/cybersecurity-advisories/aa26-237a)
+- [Microsoft Security Experts: Threat hunting with Microsoft Graph activity logs](https://techcommunity.microsoft.com/blog/microsoftsecurityexperts/cloud-forensics-why-enabling-microsoft-azure-graph-activity-logs-matters/4234632)
+- [Invictus IR: MicrosoftGraphActivityLogs — the complete guide (app-only isolation and the Roles column)](https://www.invictus-ir.com/news/everything-you-need-to-know-about-the-microsoftgraphactivitylogs)
+- [Red Canary: Entra ID service principals in business email compromise schemes](https://redcanary.com/blog/threat-detection/entra-id-service-principals/)
+- [Practical365: Investigating OAuth app abuse with the Graph activity log](https://practical365.com/investigating-oauth-app-abuse-with-the-graph-activity-log/)
+- [Thomas Naunheim: Analyzing workload identity activity through token-based hunting](https://www.cloud-architekt.net/token-hunting-workload-identity-activity/)
+- [Microsoft: Conditional Access for workload identities](https://learn.microsoft.com/en-us/entra/identity/conditional-access/workload-identity)

--- a/hunts-data.js
+++ b/hunts-data.js
@@ -1376,6 +1376,52 @@ const HUNTS_DATA = [
     "created": "2026-08-30T23:14:05-05:00"
   },
   {
+    "id": "B043",
+    "category": "Embers",
+    "title": "Baseline of Entra ID service principals holding mail and chat application permissions — who owns them, what they read, and from where",
+    "tactic": "Collection, Persistence",
+    "notes": "",
+    "tags": [
+      "collection",
+      "persistence",
+      "m365",
+      "saas",
+      "entra_id",
+      "embers",
+      "baseline",
+      "t1213_005",
+      "t1098_001",
+      "t1550_001",
+      "service_principal",
+      "microsoft_graph",
+      "application_permissions",
+      "workload_identity",
+      "cisa_red_team",
+      "T1213.005",
+      "T1098.001",
+      "T1550.001"
+    ],
+    "techniques": [
+      "T1213.005",
+      "T1098.001",
+      "T1550.001"
+    ],
+    "severity": null,
+    "status": "current",
+    "related_hunt_ids": [
+      "H286",
+      "H288"
+    ],
+    "submitter": {
+      "name": "Lauren Proehl",
+      "link": "https://x.com/jotunvillur"
+    },
+    "why": "- **Both compromises in the source report ran through applications, and neither organization could see\n  them.** CISA's finding is that both tenants used broad application permissions for most apps and that\n  neither had Conditional Access for workload identities — a control the red team reports never having\n  seen deployed anywhere. When the preventive control is effectively absent industry-wide, the inventory\n  is the control.\n- **Detection here is a change-detection problem, and change detection requires a prior state.** Volume,\n  endpoint and permission scope all look identical between a compliance product and an operator reading\n  the tenant. What differs is that the operator's access is *new*: new secret, newly exercised permission,\n  new source. None of those are computable without a recorded baseline, which is why this must be an\n  Ember rather than a rule.\n- **Two permissions in the collection set are tenant-level escalation primitives.** `Application.ReadWrite.All`\n  allows adding credentials to any other application, and `AppRoleAssignment.ReadWrite.All` allows a\n  service principal to grant itself `Chat.Read.All` or `RoleManagement.ReadWrite.Directory`. An\n  application holding either is equivalent to a privileged account, and most inventories do not treat it\n  that way. Simply enumerating who holds them is often the highest-value hour in this exercise.\n- **Ownership is an unmonitored privilege, and disabled owners are not safe owners.** Both organizations\n  were reached through the application's owner rather than the application, and in one case the owner was\n  a disabled AD-synced account that the operators re-enabled and DCSynced. Owner identity and owner\n  account state belong in the register as first-class fields, not as metadata.\n- **Dormant permissions are the cheapest high-signal feature available.** Applications routinely hold\n  permissions they have never used. Recording which of a service principal's declared permissions were\n  actually exercised during the window converts a static permission list into a behavioural expectation,\n  and makes first-use of a dormant permission a near-conclusive event at effectively zero cost.\n- **Without this register, Graph telemetry is unreadable.** MicrosoftGraphActivityLogs is keyed on AppId\n  and ServicePrincipalId GUIDs, and Microsoft's own IdentityInfo enrichment does not cover service\n  principals. Any team attempting to triage app-only Graph access without a local name-and-owner mapping\n  is reading hex during an incident.\n- **Token revocation depends on knowing what to revoke.** Both organizations lacked processes for\n  revoking compromised access and refresh tokens, so cloud access outlived on-prem eviction. The credential\n  inventory in this register is the eviction checklist.",
+    "references": "- [MITRE ATT&CK T1213.005: Data from Information Repositories — Messaging Applications](https://attack.mitre.org/techniques/T1213/005/)\n- [MITRE ATT&CK T1098.001: Account Manipulation — Additional Cloud Credentials](https://attack.mitre.org/techniques/T1098/001/)\n- [CISA AA26-237A: A Tale of Two SOCs — Insights From Two Red Team Assessments (source report)](https://www.cisa.gov/news-events/cybersecurity-advisories/aa26-237a)\n- [Practical365: Detect and report high-priority permissions in Entra ID apps](https://practical365.com/entra-id-apps-review-permissions/)\n- [Quarkslab: Auditing application permissions in Microsoft Entra ID — hidden risks and pitfalls](https://blog.quarkslab.com/auditing-application-permissions-in-microsoft-entra-id-hidden-risks-pitfalls-and-quarkslabs-qazpt-tool.html)\n- [Red Canary: Entra ID service principals in business email compromise schemes](https://redcanary.com/blog/threat-detection/entra-id-service-principals/)\n- [Invictus IR: MicrosoftGraphActivityLogs — the complete guide](https://www.invictus-ir.com/news/everything-you-need-to-know-about-the-microsoftgraphactivitylogs)\n- [Microsoft: Conditional Access for workload identities](https://learn.microsoft.com/en-us/entra/identity/conditional-access/workload-identity)",
+    "file_path": "Embers/B043.md",
+    "created": null
+  },
+  {
     "id": "H001",
     "category": "Flames",
     "title": "An adversary is attempting to brute force the admin account on the externally facing VPN gateway.",
@@ -10491,6 +10537,131 @@ const HUNTS_DATA = [
     "created": "2026-08-30T21:38:29-07:00"
   },
   {
+    "id": "H286",
+    "category": "Flames",
+    "title": "Kerberos service ticket requested for the Entra ID Seamless SSO computer account and replayed from proxied infrastructure",
+    "tactic": "Credential Access, Lateral Movement, Defense Evasion",
+    "notes": "",
+    "tags": [
+      "credential_access",
+      "lateral_movement",
+      "defense_evasion",
+      "windows",
+      "flames",
+      "t1558",
+      "t1550_003",
+      "t1003_006",
+      "kerberos",
+      "seamless_sso",
+      "entra_id",
+      "hybrid_identity",
+      "azureadssoacc",
+      "cisa_red_team",
+      "T1558",
+      "T1550.003",
+      "T1003.006"
+    ],
+    "techniques": [
+      "T1558",
+      "T1550.003",
+      "T1003.006"
+    ],
+    "severity": null,
+    "status": "current",
+    "related_hunt_ids": [],
+    "submitter": {
+      "name": "Lauren Proehl",
+      "link": "https://x.com/jotunvillur"
+    },
+    "why": "- **The published detection for this technique does not cover the way it was actually used.** Nearly all\n  Seamless SSO abuse guidance targets the forged-ticket variant and keys on the *absence* of a KDC event.\n  An operator who already holds DCSync does not need to forge anything — they request a genuine ticket\n  with a stolen key, producing exactly the KDC event the detection expects to be missing. Building the\n  hunt around ticket provenance rather than ticket forgery closes a gap that a correlation rule alone\n  leaves open.\n- **`AZUREADSSOACC$` falls inside the standard 4769 tuning exclusion.** The near-universal advice for\n  making 4769 tractable is to drop machine accounts by filtering `ServiceName` ending in `$`. That single\n  filter removes the Seamless SSO account from view, which means many environments that believe they\n  monitor Kerberos service ticket activity have no coverage of the one SPN that bridges on-prem AD to the\n  cloud. This is worth checking as a standalone exercise even before running the hunt.\n- **It is the hinge between an on-prem compromise and a tenant compromise.** Seamless SSO exists\n  specifically to let a Kerberos ticket serve as the first factor for Entra ID. That makes the SSO\n  computer account a Tier 0 asset with cloud reach, and it means an AD compromise is a cloud compromise\n  by default unless MFA covers the second phase. CISA's red team found MFA coverage gaps concentrated\n  precisely where they mattered least to users and most to attackers: synced service accounts.\n- **The proxied source IP defeats location-based conditional access and analyst intuition.** By tunnelling\n  through a SOCKS proxy on an internal host, the operator makes the sign-in appear to originate from\n  trusted corporate space. Any control or triage habit that treats \"came from our IP range\" as\n  reassurance is inverted here. The durable signal is device and user-agent mismatch against a known\n  asset inventory, not network location.\n- **The stage is cheap to instrument relative to what it prevents.** Compared to broad Kerberos anomaly\n  detection, scoping to one service name yields a small, reviewable event set in most environments, and\n  the account/source-host pivot needs only a few weeks of history to become meaningful. Pairing it with\n  the 4662 replication check gives two independent tripwires on the same kill chain.\n- **HEARTH had no T1558 coverage.** Existing Kerberos-adjacent hunts address NTLM relay and\n  post-NTDS-dump credential reuse ([[M035]]), not Kerberos ticket theft and reuse as an identity-boundary\n  crossing.",
+    "references": "- [MITRE ATT&CK T1558: Steal or Forge Kerberos Tickets](https://attack.mitre.org/techniques/T1558/)\n- [CISA AA26-237A: A Tale of Two SOCs — Insights From Two Red Team Assessments (source report)](https://www.cisa.gov/news-events/cybersecurity-advisories/aa26-237a)\n- [DSInternals: Impersonating Office 365 users with Mimikatz (the original Seamless SSO ticket research)](https://www.dsinternals.com/en/impersonating-office-365-users-mimikatz/)\n- [SpecterOps Rubeus documentation: the asktgs command and its detection considerations](https://docs.specterops.io/ghostpack-docs/Rubeus-mdx/commands/ticket-requests/asktgs)\n- [Splunk: Detecting Active Directory Kerberos attacks — threat research release](https://www.splunk.com/en_us/blog/security/detecting-active-directory-kerberos-attacks-threat-research-release-march-2022.html)\n- [Microsoft: Understanding the Primary Refresh Token (PRT) in Microsoft Entra ID](https://learn.microsoft.com/en-us/entra/identity/devices/concept-primary-refresh-token)\n- [Microsoft: Entra Connect Seamless SSO — technical deep dive and AZUREADSSOACC$ key rollover](https://learn.microsoft.com/en-us/entra/identity/hybrid/connect/how-to-connect-sso-how-it-works)\n- [Ultimate Windows Security: Event ID 4769 — a Kerberos service ticket was requested](https://www.ultimatewindowssecurity.com/securitylog/encyclopedia/event.aspx?eventid=4769)",
+    "file_path": "Flames/H286.md",
+    "created": null
+  },
+  {
+    "id": "H287",
+    "category": "Flames",
+    "title": "SCCM user-device affinity queried to map privileged users to their workstations before lateral movement",
+    "tactic": "Discovery",
+    "notes": "",
+    "tags": [
+      "discovery",
+      "windows",
+      "flames",
+      "t1033",
+      "t1018",
+      "sccm",
+      "configuration_manager",
+      "adminservice",
+      "wmi",
+      "tier_zero",
+      "user_device_affinity",
+      "sharpsccm",
+      "cisa_red_team",
+      "T1033",
+      "T1018"
+    ],
+    "techniques": [
+      "T1033",
+      "T1018"
+    ],
+    "severity": null,
+    "status": "current",
+    "related_hunt_ids": [],
+    "submitter": {
+      "name": "Lauren Proehl",
+      "link": "https://x.com/jotunvillur"
+    },
+    "why": "- **This is the rare form of T1033 that is genuinely huntable.** Generic system-owner discovery is\n  unhuntable because the commands are indistinguishable from administration and the population issuing\n  them is everyone. Scoping to the SCCM provider inverts both properties: the query shape is narrow and\n  named, and the set of hosts and identities that should ever issue it is small enough to write down.\n  The technique becomes actionable only because of where it is asked.\n- **It sits at a decision point in the intrusion, before lateral movement rather than after.** The\n  operator queries affinity specifically to choose where to go next. Catching it means catching them\n  between owning the management plane and owning the target user's workstation — one of the few moments\n  in a modern intrusion where detection buys real time rather than confirming a completed step.\n- **Endpoint management platforms are Tier 0 and are rarely monitored like it.** SCCM can execute code on\n  every managed endpoint, holds credentials in policies, task sequences and collection variables, and\n  publishes its own location in AD via the System Management container. CISA flagged exactly this class\n  of system as an under-secured escalation path. Most organizations instrument domain controllers\n  carefully and site servers not at all.\n- **The report shows what happens when the alert has no owner.** The SOC in Organization A saw SCCM-related\n  activity, could not establish what the system was for or who ran it, and closed the ticket. Building the\n  console/RBAC allowlist this hunt requires produces that missing context as a durable artifact — the\n  denominator is as valuable as the detection.\n- **The AdminService path is newer than most detection content.** Published SCCM tradecraft has moved\n  toward the AdminService REST API, and offensive tooling (SharpSCCM, sccmhunter) supports it directly,\n  but IIS logs from the SMS Provider are frequently not collected. Adding that one log source covers a\n  path that WMI-based monitoring cannot see at all.\n- **HEARTH had no hunt with SCCM as its primary subject** — Configuration Manager appears only\n  incidentally in existing hunts, despite being a standard objective in current red team and ransomware\n  tradecraft alike.",
+    "references": "- [MITRE ATT&CK T1033: System Owner/User Discovery](https://attack.mitre.org/techniques/T1033/)\n- [CISA AA26-237A: A Tale of Two SOCs — Insights From Two Red Team Assessments (source report)](https://www.cisa.gov/news-events/cybersecurity-advisories/aa26-237a)\n- [SpecterOps Misconfiguration Manager: SCCM attack technique catalog (RECON-1 through RECON-5)](https://github.com/subat0mik/Misconfiguration-Manager/blob/main/attack-techniques/README.md)\n- [SpecterOps SharpSCCM documentation: device/user discovery and AdminService abuse](https://docs.specterops.io/sharpsccm-docs/overview)\n- [Microsoft: Link users and devices with user device affinity in Configuration Manager](https://learn.microsoft.com/en-us/intune/configmgr/apps/deploy-use/link-users-and-devices-with-user-device-affinity)\n- [Microsoft: Configuration Manager AdminService REST API overview](https://learn.microsoft.com/en-us/intune/configmgr/develop/adminservice/overview)\n- [Microsoft: WMI-Activity operational log and WMI event tracing](https://learn.microsoft.com/en-us/windows/win32/wmisdk/tracing-wmi-activity)\n- [Icex0: SCCM recon — enumerating site systems, users and device relationships](https://ice0.blog/docs/sccm-2-recon)",
+    "file_path": "Flames/H287.md",
+    "created": null
+  },
+  {
+    "id": "H288",
+    "category": "Flames",
+    "title": "Service principal reading Teams chat messages tenant-wide via Microsoft Graph after a client secret is added",
+    "tactic": "Collection, Persistence, Defense Evasion",
+    "notes": "",
+    "tags": [
+      "collection",
+      "persistence",
+      "defense_evasion",
+      "m365",
+      "saas",
+      "flames",
+      "t1213_005",
+      "t1550_001",
+      "t1098_001",
+      "microsoft_teams",
+      "microsoft_graph",
+      "service_principal",
+      "oauth",
+      "chat_read_all",
+      "counter_incident_response",
+      "cisa_red_team",
+      "T1213.005",
+      "T1550.001",
+      "T1098.001"
+    ],
+    "techniques": [
+      "T1213.005",
+      "T1550.001",
+      "T1098.001"
+    ],
+    "severity": null,
+    "status": "current",
+    "related_hunt_ids": [],
+    "submitter": {
+      "name": "Lauren Proehl",
+      "link": "https://x.com/jotunvillur"
+    },
+    "why": "- **Reading the SOC's messages changes the incident, not just the impact assessment.** This is\n  collection used as counter-response. If an operator can read the defenders' Teams channels and mail,\n  they know when containment is being planned and can move first — and the defenders' own\n  coordination becomes an attacker data source. The practical consequence is that any confirmed\n  compromise of a service principal with chat or mail permissions should trigger out-of-band incident\n  communications immediately, which makes this hunt worth running proactively rather than after the fact.\n- **Application permissions sit outside the controls people believe cover them.** App-only access has no\n  user, so no MFA, no user risk policy, and no ordinary Conditional Access. The control that does cover\n  it — Conditional Access for workload identities — CISA reports having never seen deployed at an\n  assessed organization. That gap is systemic rather than incidental, which makes detection the load-\n  bearing control rather than the backstop.\n- **The credential-add is a small, rare, high-fidelity event that precedes the damage.** Reading chat\n  messages is high volume and hard to distinguish from a compliance product. Adding a client secret to an\n  existing application is low volume, discrete, appears cleanly in the Entra audit log, and happens\n  *before* any data is read. Hunting the reads finds the collection; alerting on the credential-add finds\n  it in time to matter.\n- **`getAllMessages` is a tenant-wide export endpoint with a small legitimate population.** Unlike\n  `/chats`, which any integration touches, the export API is used almost exclusively by backup and\n  compliance vendors. Enumerating that population once turns a broad collection technique into a\n  narrow allowlist question.\n- **Token revocation gaps make this persist past eviction.** Both assessed organizations lacked processes\n  to revoke access and refresh tokens after a cloud compromise. An operator removed from the on-prem\n  estate retains tenant access through the application until its credentials are explicitly rotated —\n  which means detecting the reads is also how you discover what still needs revoking.\n- **The disabled-account assumption fails here.** The application owner in Organization B was disabled in\n  AD and simply re-enabled by the operators, who then DCSynced it. Disabled synced accounts that own\n  privileged applications are a live attack surface, and enumerating them is a cheap by-product of this\n  hunt.",
+    "references": "- [MITRE ATT&CK T1213.005: Data from Information Repositories — Messaging Applications](https://attack.mitre.org/techniques/T1213/005/)\n- [CISA AA26-237A: A Tale of Two SOCs — Insights From Two Red Team Assessments (source report)](https://www.cisa.gov/news-events/cybersecurity-advisories/aa26-237a)\n- [Microsoft Security Experts: Threat hunting with Microsoft Graph activity logs](https://techcommunity.microsoft.com/blog/microsoftsecurityexperts/cloud-forensics-why-enabling-microsoft-azure-graph-activity-logs-matters/4234632)\n- [Invictus IR: MicrosoftGraphActivityLogs — the complete guide (app-only isolation and the Roles column)](https://www.invictus-ir.com/news/everything-you-need-to-know-about-the-microsoftgraphactivitylogs)\n- [Red Canary: Entra ID service principals in business email compromise schemes](https://redcanary.com/blog/threat-detection/entra-id-service-principals/)\n- [Practical365: Investigating OAuth app abuse with the Graph activity log](https://practical365.com/investigating-oauth-app-abuse-with-the-graph-activity-log/)\n- [Thomas Naunheim: Analyzing workload identity activity through token-based hunting](https://www.cloud-architekt.net/token-hunting-workload-identity-activity/)\n- [Microsoft: Conditional Access for workload identities](https://learn.microsoft.com/en-us/entra/identity/conditional-access/workload-identity)",
+    "file_path": "Flames/H288.md",
+    "created": null
+  },
+  {
     "id": "M001",
     "category": "Alchemy",
     "title": "A machine learning model can detect anomalies in user login patterns that indicate compromised accounts.",
@@ -11546,5 +11717,47 @@ const HUNTS_DATA = [
     "references": "- [MITRE ATT&CK T1684.001: Social Engineering — Impersonation](https://attack.mitre.org/techniques/T1684/001/)\n- [MITRE ATT&CK T1566.003: Phishing — Spearphishing via Service](https://attack.mitre.org/techniques/T1566/003/)\n- [Unit 42: Identity abuse through trusted communication channels (source report)](https://unit42.paloaltonetworks.com/communication-channel-identity-risks/)\n- [Microsoft Security Blog: Cross-tenant helpdesk impersonation to data exfiltration — a human-operated intrusion playbook](https://www.microsoft.com/en-us/security/blog/2026/04/18/crosstenant-helpdesk-impersonation-data-exfiltration-human-operated-intrusion-playbook/)\n- [Microsoft Security Blog: Disrupting threats targeting Microsoft Teams](https://www.microsoft.com/en-us/security/blog/2025/10/07/disrupting-threats-targeting-microsoft-teams/)\n- [Sergio Albea: Hunting one-on-one Teams chats by domains (CloudAppEvents KQL)](https://github.com/Sergio-Albea-Git/Threat-Hunting-KQL-Queries/blob/main/Microsoft_DefenderXDR/CloudAppEvents/Teams/Hunting%20OneOnOne%20chats%20by%20Domains.md)\n- [Hunters: Detecting Microsoft Teams phishing — hunting the fake IT helpdesk threat](https://www.hunters.security/en/blog/microsoft-teams-phishing-fake-it-helpdesk)\n- [Microsoft: CloudAppEvents table schema (Defender XDR advanced hunting)](https://learn.microsoft.com/en-us/defender-xdr/advanced-hunting-cloudappevents-table)\n- [Microsoft: Set-CsTenantFederationConfiguration (-BlockAllSubdomains)](https://learn.microsoft.com/en-us/powershell/module/teams/set-cstenantfederationconfiguration)",
     "file_path": "Alchemy/M037.md",
     "created": "2026-08-30T23:14:05-05:00"
+  },
+  {
+    "id": "M038",
+    "category": "Alchemy",
+    "title": "Scoring LDAP sessions on object-class breadth and visited-to-returned ratio to surface EDR-evading directory collectors",
+    "tactic": "Discovery",
+    "notes": "",
+    "tags": [
+      "discovery",
+      "windows",
+      "active_directory",
+      "alchemy",
+      "t1615",
+      "t1087_002",
+      "t1069_002",
+      "ldap",
+      "bloodhound",
+      "sharphound",
+      "group_policy_discovery",
+      "anomaly_detection",
+      "edr_evasion",
+      "cisa_red_team",
+      "T1615",
+      "T1087.002",
+      "T1069.002"
+    ],
+    "techniques": [
+      "T1615",
+      "T1087.002",
+      "T1069.002"
+    ],
+    "severity": null,
+    "status": "current",
+    "related_hunt_ids": [],
+    "submitter": {
+      "name": "Lauren Proehl",
+      "link": "https://x.com/jotunvillur"
+    },
+    "why": "- **The collector was purpose-built to defeat the detection layer most organizations rely on.** The source\n  report is explicit that the BloodHound collector was customized to evade static EDR signatures. Any\n  approach anchored to a known binary, hash or command line is a known-quantity control against an\n  adversary who has already accounted for it. Query-shape modelling does not care what the binary is\n  called or whether it was recompiled.\n- **Twenty minutes of dwell was enough to lose the entire directory.** Organization B's response was\n  genuinely fast by any operational standard, and the domain was still fully enumerated first. This sets\n  the detection budget: the signal has to be present in the enumeration itself, because everything\n  downstream is too late.\n- **The two numbers on Event ID 1644 are close to a purpose-built feature pair.** Visited-versus-returned\n  is a direct measure of how indiscriminate a query is, which is precisely the difference between a lookup\n  and a collection. Few detection problems come with a native telemetry field that encodes the concept\n  you actually want to measure. The cost is that 1644 must be deliberately enabled and tuned, which is\n  the real work of adopting this hunt.\n- **Volume-only thresholds fail in both directions, which is what makes this Alchemy rather than Flames.**\n  Set a static query-count threshold and IAM sync, backup and vulnerability scanners cross it every night\n  while a paced collector stays under it. Normal LDAP volume varies by orders of magnitude between a\n  branch office and a datacentre. The comparison has to be per-source and multi-feature, which is a model,\n  not a rule.\n- **SDFlags 0x5 is a rare, cheap, high-weight term.** Requesting the Owner component of the security\n  descriptor is something SharpHound does structurally and administrative tooling does not. It is\n  avoidable by a careful operator and so cannot stand alone, but it costs nothing to include and sharply\n  separates the default tooling case.\n- **Group Policy Discovery had no primary coverage in HEARTH.** T1615 appeared only as a cross-reference\n  in [[H267]], despite GPO enumeration being a standard early step in AD attack-path collection and a\n  direct precursor to the SYSVOL credential sweep that hunt covers.",
+    "references": "- [MITRE ATT&CK T1615: Group Policy Discovery](https://attack.mitre.org/techniques/T1615/)\n- [CISA AA26-237A: A Tale of Two SOCs — Insights From Two Red Team Assessments (source report)](https://www.cisa.gov/news-events/cybersecurity-advisories/aa26-237a)\n- [Huntress: From code to coverage (part 3) — SDFlags, the log field I could not ignore](https://www.huntress.com/blog/ldap-active-directory-detection-part-three)\n- [Huntress: Hunting SOAPHound — the (!FALSE) pattern](https://www.huntress.com/blog/ldap-active-directory-detection-part-four)\n- [Unit 42: LDAP enumeration — unveiling the double-edged sword of Active Directory](https://unit42.paloaltonetworks.com/lightweight-directory-access-protocol-based-attacks/)\n- [Securonix: Detecting LDAP enumeration and BloodHound's SharpHound collector using AD decoys](https://medium.com/securonix-tech-blog/detecting-ldap-enumeration-and-bloodhound-s-sharphound-collector-using-active-directory-decoys-dfc840f2f644)\n- [Wazuh: Detecting SharpHound Active Directory activities](https://wazuh.com/blog/detecting-sharphound-active-directory-activities/)\n- [iPurple Team: SharpHound detection](https://ipurple.team/2024/07/15/sharphound-detection/)",
+    "file_path": "Alchemy/M038.md",
+    "created": null
   }
 ];

--- a/public/hunts-data.json
+++ b/public/hunts-data.json
@@ -1375,6 +1375,52 @@
     "created": "2026-08-30T23:14:05-05:00"
   },
   {
+    "id": "B043",
+    "category": "Embers",
+    "title": "Baseline of Entra ID service principals holding mail and chat application permissions — who owns them, what they read, and from where",
+    "tactic": "Collection, Persistence",
+    "notes": "",
+    "tags": [
+      "collection",
+      "persistence",
+      "m365",
+      "saas",
+      "entra_id",
+      "embers",
+      "baseline",
+      "t1213_005",
+      "t1098_001",
+      "t1550_001",
+      "service_principal",
+      "microsoft_graph",
+      "application_permissions",
+      "workload_identity",
+      "cisa_red_team",
+      "T1213.005",
+      "T1098.001",
+      "T1550.001"
+    ],
+    "techniques": [
+      "T1213.005",
+      "T1098.001",
+      "T1550.001"
+    ],
+    "severity": null,
+    "status": "current",
+    "related_hunt_ids": [
+      "H286",
+      "H288"
+    ],
+    "submitter": {
+      "name": "Lauren Proehl",
+      "link": "https://x.com/jotunvillur"
+    },
+    "why": "- **Both compromises in the source report ran through applications, and neither organization could see\n  them.** CISA's finding is that both tenants used broad application permissions for most apps and that\n  neither had Conditional Access for workload identities — a control the red team reports never having\n  seen deployed anywhere. When the preventive control is effectively absent industry-wide, the inventory\n  is the control.\n- **Detection here is a change-detection problem, and change detection requires a prior state.** Volume,\n  endpoint and permission scope all look identical between a compliance product and an operator reading\n  the tenant. What differs is that the operator's access is *new*: new secret, newly exercised permission,\n  new source. None of those are computable without a recorded baseline, which is why this must be an\n  Ember rather than a rule.\n- **Two permissions in the collection set are tenant-level escalation primitives.** `Application.ReadWrite.All`\n  allows adding credentials to any other application, and `AppRoleAssignment.ReadWrite.All` allows a\n  service principal to grant itself `Chat.Read.All` or `RoleManagement.ReadWrite.Directory`. An\n  application holding either is equivalent to a privileged account, and most inventories do not treat it\n  that way. Simply enumerating who holds them is often the highest-value hour in this exercise.\n- **Ownership is an unmonitored privilege, and disabled owners are not safe owners.** Both organizations\n  were reached through the application's owner rather than the application, and in one case the owner was\n  a disabled AD-synced account that the operators re-enabled and DCSynced. Owner identity and owner\n  account state belong in the register as first-class fields, not as metadata.\n- **Dormant permissions are the cheapest high-signal feature available.** Applications routinely hold\n  permissions they have never used. Recording which of a service principal's declared permissions were\n  actually exercised during the window converts a static permission list into a behavioural expectation,\n  and makes first-use of a dormant permission a near-conclusive event at effectively zero cost.\n- **Without this register, Graph telemetry is unreadable.** MicrosoftGraphActivityLogs is keyed on AppId\n  and ServicePrincipalId GUIDs, and Microsoft's own IdentityInfo enrichment does not cover service\n  principals. Any team attempting to triage app-only Graph access without a local name-and-owner mapping\n  is reading hex during an incident.\n- **Token revocation depends on knowing what to revoke.** Both organizations lacked processes for\n  revoking compromised access and refresh tokens, so cloud access outlived on-prem eviction. The credential\n  inventory in this register is the eviction checklist.",
+    "references": "- [MITRE ATT&CK T1213.005: Data from Information Repositories — Messaging Applications](https://attack.mitre.org/techniques/T1213/005/)\n- [MITRE ATT&CK T1098.001: Account Manipulation — Additional Cloud Credentials](https://attack.mitre.org/techniques/T1098/001/)\n- [CISA AA26-237A: A Tale of Two SOCs — Insights From Two Red Team Assessments (source report)](https://www.cisa.gov/news-events/cybersecurity-advisories/aa26-237a)\n- [Practical365: Detect and report high-priority permissions in Entra ID apps](https://practical365.com/entra-id-apps-review-permissions/)\n- [Quarkslab: Auditing application permissions in Microsoft Entra ID — hidden risks and pitfalls](https://blog.quarkslab.com/auditing-application-permissions-in-microsoft-entra-id-hidden-risks-pitfalls-and-quarkslabs-qazpt-tool.html)\n- [Red Canary: Entra ID service principals in business email compromise schemes](https://redcanary.com/blog/threat-detection/entra-id-service-principals/)\n- [Invictus IR: MicrosoftGraphActivityLogs — the complete guide](https://www.invictus-ir.com/news/everything-you-need-to-know-about-the-microsoftgraphactivitylogs)\n- [Microsoft: Conditional Access for workload identities](https://learn.microsoft.com/en-us/entra/identity/conditional-access/workload-identity)",
+    "file_path": "Embers/B043.md",
+    "created": null
+  },
+  {
     "id": "H001",
     "category": "Flames",
     "title": "An adversary is attempting to brute force the admin account on the externally facing VPN gateway.",
@@ -10490,6 +10536,131 @@
     "created": "2026-08-30T21:38:29-07:00"
   },
   {
+    "id": "H286",
+    "category": "Flames",
+    "title": "Kerberos service ticket requested for the Entra ID Seamless SSO computer account and replayed from proxied infrastructure",
+    "tactic": "Credential Access, Lateral Movement, Defense Evasion",
+    "notes": "",
+    "tags": [
+      "credential_access",
+      "lateral_movement",
+      "defense_evasion",
+      "windows",
+      "flames",
+      "t1558",
+      "t1550_003",
+      "t1003_006",
+      "kerberos",
+      "seamless_sso",
+      "entra_id",
+      "hybrid_identity",
+      "azureadssoacc",
+      "cisa_red_team",
+      "T1558",
+      "T1550.003",
+      "T1003.006"
+    ],
+    "techniques": [
+      "T1558",
+      "T1550.003",
+      "T1003.006"
+    ],
+    "severity": null,
+    "status": "current",
+    "related_hunt_ids": [],
+    "submitter": {
+      "name": "Lauren Proehl",
+      "link": "https://x.com/jotunvillur"
+    },
+    "why": "- **The published detection for this technique does not cover the way it was actually used.** Nearly all\n  Seamless SSO abuse guidance targets the forged-ticket variant and keys on the *absence* of a KDC event.\n  An operator who already holds DCSync does not need to forge anything — they request a genuine ticket\n  with a stolen key, producing exactly the KDC event the detection expects to be missing. Building the\n  hunt around ticket provenance rather than ticket forgery closes a gap that a correlation rule alone\n  leaves open.\n- **`AZUREADSSOACC$` falls inside the standard 4769 tuning exclusion.** The near-universal advice for\n  making 4769 tractable is to drop machine accounts by filtering `ServiceName` ending in `$`. That single\n  filter removes the Seamless SSO account from view, which means many environments that believe they\n  monitor Kerberos service ticket activity have no coverage of the one SPN that bridges on-prem AD to the\n  cloud. This is worth checking as a standalone exercise even before running the hunt.\n- **It is the hinge between an on-prem compromise and a tenant compromise.** Seamless SSO exists\n  specifically to let a Kerberos ticket serve as the first factor for Entra ID. That makes the SSO\n  computer account a Tier 0 asset with cloud reach, and it means an AD compromise is a cloud compromise\n  by default unless MFA covers the second phase. CISA's red team found MFA coverage gaps concentrated\n  precisely where they mattered least to users and most to attackers: synced service accounts.\n- **The proxied source IP defeats location-based conditional access and analyst intuition.** By tunnelling\n  through a SOCKS proxy on an internal host, the operator makes the sign-in appear to originate from\n  trusted corporate space. Any control or triage habit that treats \"came from our IP range\" as\n  reassurance is inverted here. The durable signal is device and user-agent mismatch against a known\n  asset inventory, not network location.\n- **The stage is cheap to instrument relative to what it prevents.** Compared to broad Kerberos anomaly\n  detection, scoping to one service name yields a small, reviewable event set in most environments, and\n  the account/source-host pivot needs only a few weeks of history to become meaningful. Pairing it with\n  the 4662 replication check gives two independent tripwires on the same kill chain.\n- **HEARTH had no T1558 coverage.** Existing Kerberos-adjacent hunts address NTLM relay and\n  post-NTDS-dump credential reuse ([[M035]]), not Kerberos ticket theft and reuse as an identity-boundary\n  crossing.",
+    "references": "- [MITRE ATT&CK T1558: Steal or Forge Kerberos Tickets](https://attack.mitre.org/techniques/T1558/)\n- [CISA AA26-237A: A Tale of Two SOCs — Insights From Two Red Team Assessments (source report)](https://www.cisa.gov/news-events/cybersecurity-advisories/aa26-237a)\n- [DSInternals: Impersonating Office 365 users with Mimikatz (the original Seamless SSO ticket research)](https://www.dsinternals.com/en/impersonating-office-365-users-mimikatz/)\n- [SpecterOps Rubeus documentation: the asktgs command and its detection considerations](https://docs.specterops.io/ghostpack-docs/Rubeus-mdx/commands/ticket-requests/asktgs)\n- [Splunk: Detecting Active Directory Kerberos attacks — threat research release](https://www.splunk.com/en_us/blog/security/detecting-active-directory-kerberos-attacks-threat-research-release-march-2022.html)\n- [Microsoft: Understanding the Primary Refresh Token (PRT) in Microsoft Entra ID](https://learn.microsoft.com/en-us/entra/identity/devices/concept-primary-refresh-token)\n- [Microsoft: Entra Connect Seamless SSO — technical deep dive and AZUREADSSOACC$ key rollover](https://learn.microsoft.com/en-us/entra/identity/hybrid/connect/how-to-connect-sso-how-it-works)\n- [Ultimate Windows Security: Event ID 4769 — a Kerberos service ticket was requested](https://www.ultimatewindowssecurity.com/securitylog/encyclopedia/event.aspx?eventid=4769)",
+    "file_path": "Flames/H286.md",
+    "created": null
+  },
+  {
+    "id": "H287",
+    "category": "Flames",
+    "title": "SCCM user-device affinity queried to map privileged users to their workstations before lateral movement",
+    "tactic": "Discovery",
+    "notes": "",
+    "tags": [
+      "discovery",
+      "windows",
+      "flames",
+      "t1033",
+      "t1018",
+      "sccm",
+      "configuration_manager",
+      "adminservice",
+      "wmi",
+      "tier_zero",
+      "user_device_affinity",
+      "sharpsccm",
+      "cisa_red_team",
+      "T1033",
+      "T1018"
+    ],
+    "techniques": [
+      "T1033",
+      "T1018"
+    ],
+    "severity": null,
+    "status": "current",
+    "related_hunt_ids": [],
+    "submitter": {
+      "name": "Lauren Proehl",
+      "link": "https://x.com/jotunvillur"
+    },
+    "why": "- **This is the rare form of T1033 that is genuinely huntable.** Generic system-owner discovery is\n  unhuntable because the commands are indistinguishable from administration and the population issuing\n  them is everyone. Scoping to the SCCM provider inverts both properties: the query shape is narrow and\n  named, and the set of hosts and identities that should ever issue it is small enough to write down.\n  The technique becomes actionable only because of where it is asked.\n- **It sits at a decision point in the intrusion, before lateral movement rather than after.** The\n  operator queries affinity specifically to choose where to go next. Catching it means catching them\n  between owning the management plane and owning the target user's workstation — one of the few moments\n  in a modern intrusion where detection buys real time rather than confirming a completed step.\n- **Endpoint management platforms are Tier 0 and are rarely monitored like it.** SCCM can execute code on\n  every managed endpoint, holds credentials in policies, task sequences and collection variables, and\n  publishes its own location in AD via the System Management container. CISA flagged exactly this class\n  of system as an under-secured escalation path. Most organizations instrument domain controllers\n  carefully and site servers not at all.\n- **The report shows what happens when the alert has no owner.** The SOC in Organization A saw SCCM-related\n  activity, could not establish what the system was for or who ran it, and closed the ticket. Building the\n  console/RBAC allowlist this hunt requires produces that missing context as a durable artifact — the\n  denominator is as valuable as the detection.\n- **The AdminService path is newer than most detection content.** Published SCCM tradecraft has moved\n  toward the AdminService REST API, and offensive tooling (SharpSCCM, sccmhunter) supports it directly,\n  but IIS logs from the SMS Provider are frequently not collected. Adding that one log source covers a\n  path that WMI-based monitoring cannot see at all.\n- **HEARTH had no hunt with SCCM as its primary subject** — Configuration Manager appears only\n  incidentally in existing hunts, despite being a standard objective in current red team and ransomware\n  tradecraft alike.",
+    "references": "- [MITRE ATT&CK T1033: System Owner/User Discovery](https://attack.mitre.org/techniques/T1033/)\n- [CISA AA26-237A: A Tale of Two SOCs — Insights From Two Red Team Assessments (source report)](https://www.cisa.gov/news-events/cybersecurity-advisories/aa26-237a)\n- [SpecterOps Misconfiguration Manager: SCCM attack technique catalog (RECON-1 through RECON-5)](https://github.com/subat0mik/Misconfiguration-Manager/blob/main/attack-techniques/README.md)\n- [SpecterOps SharpSCCM documentation: device/user discovery and AdminService abuse](https://docs.specterops.io/sharpsccm-docs/overview)\n- [Microsoft: Link users and devices with user device affinity in Configuration Manager](https://learn.microsoft.com/en-us/intune/configmgr/apps/deploy-use/link-users-and-devices-with-user-device-affinity)\n- [Microsoft: Configuration Manager AdminService REST API overview](https://learn.microsoft.com/en-us/intune/configmgr/develop/adminservice/overview)\n- [Microsoft: WMI-Activity operational log and WMI event tracing](https://learn.microsoft.com/en-us/windows/win32/wmisdk/tracing-wmi-activity)\n- [Icex0: SCCM recon — enumerating site systems, users and device relationships](https://ice0.blog/docs/sccm-2-recon)",
+    "file_path": "Flames/H287.md",
+    "created": null
+  },
+  {
+    "id": "H288",
+    "category": "Flames",
+    "title": "Service principal reading Teams chat messages tenant-wide via Microsoft Graph after a client secret is added",
+    "tactic": "Collection, Persistence, Defense Evasion",
+    "notes": "",
+    "tags": [
+      "collection",
+      "persistence",
+      "defense_evasion",
+      "m365",
+      "saas",
+      "flames",
+      "t1213_005",
+      "t1550_001",
+      "t1098_001",
+      "microsoft_teams",
+      "microsoft_graph",
+      "service_principal",
+      "oauth",
+      "chat_read_all",
+      "counter_incident_response",
+      "cisa_red_team",
+      "T1213.005",
+      "T1550.001",
+      "T1098.001"
+    ],
+    "techniques": [
+      "T1213.005",
+      "T1550.001",
+      "T1098.001"
+    ],
+    "severity": null,
+    "status": "current",
+    "related_hunt_ids": [],
+    "submitter": {
+      "name": "Lauren Proehl",
+      "link": "https://x.com/jotunvillur"
+    },
+    "why": "- **Reading the SOC's messages changes the incident, not just the impact assessment.** This is\n  collection used as counter-response. If an operator can read the defenders' Teams channels and mail,\n  they know when containment is being planned and can move first — and the defenders' own\n  coordination becomes an attacker data source. The practical consequence is that any confirmed\n  compromise of a service principal with chat or mail permissions should trigger out-of-band incident\n  communications immediately, which makes this hunt worth running proactively rather than after the fact.\n- **Application permissions sit outside the controls people believe cover them.** App-only access has no\n  user, so no MFA, no user risk policy, and no ordinary Conditional Access. The control that does cover\n  it — Conditional Access for workload identities — CISA reports having never seen deployed at an\n  assessed organization. That gap is systemic rather than incidental, which makes detection the load-\n  bearing control rather than the backstop.\n- **The credential-add is a small, rare, high-fidelity event that precedes the damage.** Reading chat\n  messages is high volume and hard to distinguish from a compliance product. Adding a client secret to an\n  existing application is low volume, discrete, appears cleanly in the Entra audit log, and happens\n  *before* any data is read. Hunting the reads finds the collection; alerting on the credential-add finds\n  it in time to matter.\n- **`getAllMessages` is a tenant-wide export endpoint with a small legitimate population.** Unlike\n  `/chats`, which any integration touches, the export API is used almost exclusively by backup and\n  compliance vendors. Enumerating that population once turns a broad collection technique into a\n  narrow allowlist question.\n- **Token revocation gaps make this persist past eviction.** Both assessed organizations lacked processes\n  to revoke access and refresh tokens after a cloud compromise. An operator removed from the on-prem\n  estate retains tenant access through the application until its credentials are explicitly rotated —\n  which means detecting the reads is also how you discover what still needs revoking.\n- **The disabled-account assumption fails here.** The application owner in Organization B was disabled in\n  AD and simply re-enabled by the operators, who then DCSynced it. Disabled synced accounts that own\n  privileged applications are a live attack surface, and enumerating them is a cheap by-product of this\n  hunt.",
+    "references": "- [MITRE ATT&CK T1213.005: Data from Information Repositories — Messaging Applications](https://attack.mitre.org/techniques/T1213/005/)\n- [CISA AA26-237A: A Tale of Two SOCs — Insights From Two Red Team Assessments (source report)](https://www.cisa.gov/news-events/cybersecurity-advisories/aa26-237a)\n- [Microsoft Security Experts: Threat hunting with Microsoft Graph activity logs](https://techcommunity.microsoft.com/blog/microsoftsecurityexperts/cloud-forensics-why-enabling-microsoft-azure-graph-activity-logs-matters/4234632)\n- [Invictus IR: MicrosoftGraphActivityLogs — the complete guide (app-only isolation and the Roles column)](https://www.invictus-ir.com/news/everything-you-need-to-know-about-the-microsoftgraphactivitylogs)\n- [Red Canary: Entra ID service principals in business email compromise schemes](https://redcanary.com/blog/threat-detection/entra-id-service-principals/)\n- [Practical365: Investigating OAuth app abuse with the Graph activity log](https://practical365.com/investigating-oauth-app-abuse-with-the-graph-activity-log/)\n- [Thomas Naunheim: Analyzing workload identity activity through token-based hunting](https://www.cloud-architekt.net/token-hunting-workload-identity-activity/)\n- [Microsoft: Conditional Access for workload identities](https://learn.microsoft.com/en-us/entra/identity/conditional-access/workload-identity)",
+    "file_path": "Flames/H288.md",
+    "created": null
+  },
+  {
     "id": "M001",
     "category": "Alchemy",
     "title": "A machine learning model can detect anomalies in user login patterns that indicate compromised accounts.",
@@ -11545,5 +11716,47 @@
     "references": "- [MITRE ATT&CK T1684.001: Social Engineering — Impersonation](https://attack.mitre.org/techniques/T1684/001/)\n- [MITRE ATT&CK T1566.003: Phishing — Spearphishing via Service](https://attack.mitre.org/techniques/T1566/003/)\n- [Unit 42: Identity abuse through trusted communication channels (source report)](https://unit42.paloaltonetworks.com/communication-channel-identity-risks/)\n- [Microsoft Security Blog: Cross-tenant helpdesk impersonation to data exfiltration — a human-operated intrusion playbook](https://www.microsoft.com/en-us/security/blog/2026/04/18/crosstenant-helpdesk-impersonation-data-exfiltration-human-operated-intrusion-playbook/)\n- [Microsoft Security Blog: Disrupting threats targeting Microsoft Teams](https://www.microsoft.com/en-us/security/blog/2025/10/07/disrupting-threats-targeting-microsoft-teams/)\n- [Sergio Albea: Hunting one-on-one Teams chats by domains (CloudAppEvents KQL)](https://github.com/Sergio-Albea-Git/Threat-Hunting-KQL-Queries/blob/main/Microsoft_DefenderXDR/CloudAppEvents/Teams/Hunting%20OneOnOne%20chats%20by%20Domains.md)\n- [Hunters: Detecting Microsoft Teams phishing — hunting the fake IT helpdesk threat](https://www.hunters.security/en/blog/microsoft-teams-phishing-fake-it-helpdesk)\n- [Microsoft: CloudAppEvents table schema (Defender XDR advanced hunting)](https://learn.microsoft.com/en-us/defender-xdr/advanced-hunting-cloudappevents-table)\n- [Microsoft: Set-CsTenantFederationConfiguration (-BlockAllSubdomains)](https://learn.microsoft.com/en-us/powershell/module/teams/set-cstenantfederationconfiguration)",
     "file_path": "Alchemy/M037.md",
     "created": "2026-08-30T23:14:05-05:00"
+  },
+  {
+    "id": "M038",
+    "category": "Alchemy",
+    "title": "Scoring LDAP sessions on object-class breadth and visited-to-returned ratio to surface EDR-evading directory collectors",
+    "tactic": "Discovery",
+    "notes": "",
+    "tags": [
+      "discovery",
+      "windows",
+      "active_directory",
+      "alchemy",
+      "t1615",
+      "t1087_002",
+      "t1069_002",
+      "ldap",
+      "bloodhound",
+      "sharphound",
+      "group_policy_discovery",
+      "anomaly_detection",
+      "edr_evasion",
+      "cisa_red_team",
+      "T1615",
+      "T1087.002",
+      "T1069.002"
+    ],
+    "techniques": [
+      "T1615",
+      "T1087.002",
+      "T1069.002"
+    ],
+    "severity": null,
+    "status": "current",
+    "related_hunt_ids": [],
+    "submitter": {
+      "name": "Lauren Proehl",
+      "link": "https://x.com/jotunvillur"
+    },
+    "why": "- **The collector was purpose-built to defeat the detection layer most organizations rely on.** The source\n  report is explicit that the BloodHound collector was customized to evade static EDR signatures. Any\n  approach anchored to a known binary, hash or command line is a known-quantity control against an\n  adversary who has already accounted for it. Query-shape modelling does not care what the binary is\n  called or whether it was recompiled.\n- **Twenty minutes of dwell was enough to lose the entire directory.** Organization B's response was\n  genuinely fast by any operational standard, and the domain was still fully enumerated first. This sets\n  the detection budget: the signal has to be present in the enumeration itself, because everything\n  downstream is too late.\n- **The two numbers on Event ID 1644 are close to a purpose-built feature pair.** Visited-versus-returned\n  is a direct measure of how indiscriminate a query is, which is precisely the difference between a lookup\n  and a collection. Few detection problems come with a native telemetry field that encodes the concept\n  you actually want to measure. The cost is that 1644 must be deliberately enabled and tuned, which is\n  the real work of adopting this hunt.\n- **Volume-only thresholds fail in both directions, which is what makes this Alchemy rather than Flames.**\n  Set a static query-count threshold and IAM sync, backup and vulnerability scanners cross it every night\n  while a paced collector stays under it. Normal LDAP volume varies by orders of magnitude between a\n  branch office and a datacentre. The comparison has to be per-source and multi-feature, which is a model,\n  not a rule.\n- **SDFlags 0x5 is a rare, cheap, high-weight term.** Requesting the Owner component of the security\n  descriptor is something SharpHound does structurally and administrative tooling does not. It is\n  avoidable by a careful operator and so cannot stand alone, but it costs nothing to include and sharply\n  separates the default tooling case.\n- **Group Policy Discovery had no primary coverage in HEARTH.** T1615 appeared only as a cross-reference\n  in [[H267]], despite GPO enumeration being a standard early step in AD attack-path collection and a\n  direct precursor to the SYSVOL credential sweep that hunt covers.",
+    "references": "- [MITRE ATT&CK T1615: Group Policy Discovery](https://attack.mitre.org/techniques/T1615/)\n- [CISA AA26-237A: A Tale of Two SOCs — Insights From Two Red Team Assessments (source report)](https://www.cisa.gov/news-events/cybersecurity-advisories/aa26-237a)\n- [Huntress: From code to coverage (part 3) — SDFlags, the log field I could not ignore](https://www.huntress.com/blog/ldap-active-directory-detection-part-three)\n- [Huntress: Hunting SOAPHound — the (!FALSE) pattern](https://www.huntress.com/blog/ldap-active-directory-detection-part-four)\n- [Unit 42: LDAP enumeration — unveiling the double-edged sword of Active Directory](https://unit42.paloaltonetworks.com/lightweight-directory-access-protocol-based-attacks/)\n- [Securonix: Detecting LDAP enumeration and BloodHound's SharpHound collector using AD decoys](https://medium.com/securonix-tech-blog/detecting-ldap-enumeration-and-bloodhound-s-sharphound-collector-using-active-directory-decoys-dfc840f2f644)\n- [Wazuh: Detecting SharpHound Active Directory activities](https://wazuh.com/blog/detecting-sharphound-active-directory-activities/)\n- [iPurple Team: SharpHound detection](https://ipurple.team/2024/07/15/sharphound-detection/)",
+    "file_path": "Alchemy/M038.md",
+    "created": null
   }
 ]


### PR DESCRIPTION
## Source articles
- [A Tale of Two SOCs: Insights From Two Red Team Assessments](https://www.cisa.gov/news-events/cybersecurity-advisories/aa26-237a) — CISA (AA26-237A), 2026-08-25

## New hunts

### From "A Tale of Two SOCs: Insights From Two Red Team Assessments"
- [H286](Flames/H286.md) — Kerberos service ticket requested for the Entra ID Seamless SSO computer account (`AZUREADSSOACC$`) using a DCSynced AES256 key, then replayed from proxied infrastructure to reach the cloud tenant (T1558)
- [H287](Flames/H287.md) — SCCM user-device affinity queried over WMI or the AdminService REST API to map privileged users to their workstations before lateral movement (T1033)
- [H288](Flames/H288.md) — Service principal reading Teams chat messages tenant-wide via Microsoft Graph after a client secret is added to an over-permissioned app (T1213.005)
- [M038](Alchemy/M038.md) — Scoring LDAP sessions on object-class breadth and visited-to-returned ratio to surface EDR-evading directory collectors enumerating GPOs (T1615)
- [B043](Embers/B043.md) — Baseline of Entra ID service principals holding mail and chat application permissions: owner, permissions, credentials, and source (T1213.005)

## Category breakdown
- Flames: 3 · Embers: 1 · Alchemy: 1

## Techniques not hunted from this report
Three of the seven manifest gaps were not turned into hunts. `T1588.002` (Obtain Capabilities: Tool), `T1589.001` (Gather Victim Identity Information: Credentials) and `T1589.002` (Email Addresses) are all `PRE`-platform techniques — they describe activity on adversary-controlled or public third-party infrastructure and produce no defender-side telemetry to hunt. The one victim-observable element of `T1588.002` in this report is the AzureHound/ROADrecon traffic against the tenant, which is Cloud Service Discovery (`T1526`) and already covered in HEARTH.