### PR TITLE
Add H294: Artifactory Admin Token Minting Without Prior Authenticated Session (CVE-2026-82329 Phantom Join Key Abuse)

### DIFF
--- a/Flames/H294.md
+++ b/Flames/H294.md
@@ -1,0 +1,62 @@
+---
+id: H294
+category: Flames
+title: "Artifactory Admin Token Minting Without Prior Authenticated Session (CVE-2026-82329 Phantom Join Key Abuse)"
+hypothesis: >-
+  Attackers exploiting CVE-2026-82329 against internet-exposed self-hosted Artifactory abuse a phantom join key in the JFrog Access service to mint administrator-scoped access tokens with no prior authenticated session from the requesting source, then immediately enumerate users, groups, credential sets, and federation topology to stage artifact tampering and downstream software supply chain compromise.
+tactics:
+  - Initial Access
+  - Credential Access
+  - Discovery
+  - Persistence
+  - Impact
+techniques:
+  - T1190
+  - T1195.002
+  - T1098.001
+  - T1087
+  - T1552
+  - T1059
+tags:
+  - artifactory
+  - jfrog
+  - cve_2026_82329
+  - supply_chain
+  - token_abuse
+  - authentication_bypass
+  - artifact_repository
+  - federation
+submitter:
+  name: Joshua Strickland
+  link: https://novasky.io
+required_data_sources:
+  - "Artifactory access logs (JFrog Access service request and token issuance events)"
+  - "Artifactory audit trail / security configuration change events (users, groups, permission targets, replication, federation)"
+  - "Reverse proxy or load balancer HTTP logs fronting Artifactory (URI, method, source IP, user agent, status)"
+  - "Host EDR process telemetry from the Artifactory server (Java service parent-child process lineage)"
+  - "Artifact repository write/overwrite events (deploy, delete, property change on existing artifacts)"
+false_positive_notes: |
+  Legitimate CI/CD and platform automation mints tokens constantly, so scope the anomaly to the join of three conditions: admin scope, no prior authenticated session from the same source, and immediate security-model enumeration. Known CI service principals show stable recurring identities, internal or allowlisted source IPs, narrow repository-scoped permissions, and predictable schedules; baseline these and suppress them explicitly rather than suppressing the token endpoint. Terraform/IaC providers and admin onboarding scripts will legitimately touch `/api/security/users` and `/api/security/groups` in bursts; correlate with change-management windows and the acting subject's provenance. Upgrades and node joins in HA or federated deployments generate join-key and access-service activity; verify against maintenance records. New replication targets are rare, high-signal events in most environments and deserve manual review even when other conditions look benign. Shell children of the Java service can occur from legitimate user plugins or backup scripts; baseline the small fixed set per host and alert on deviation.
+notes: |
+  Artifactory access service logs - Core filter: successful token creation requests to `/access/api/v1/tokens` where the requesting `source IP address` has no successful interactive login or existing session in the preceding lookback window, especially token records with `scope` containing `applied-permissions/admin` or a `subject` mapped to an admin group. Triage values: `source IP address`, `token subject`, `token scope`, `token expiry`, `user agent`, `request ID`. Strong red flags: external or never-before-seen source IP, non-CI user agent, admin scope with long or no expiry, and issuance outside change windows.
+  Reverse proxy / HTTP logs fronting Artifactory - Core filter: a burst from one `source IP address` or `request ID` chain hitting security-model enumeration endpoints such as `/api/security/users`, `/api/security/groups`, `/api/security/permissions`, and federation or credential-set paths under `/access/api/v1/` within minutes of the token mint. Pivot: join enumeration requests to the minting event by `source IP address`, `authorization subject`, and `user agent`. Correlation: enumeration followed by `PUT`/`POST` writes to permission targets, replication configuration, or existing artifact paths is the escalation chain that separates scanning from hands-on-keyboard staging.
+  Artifactory audit trail - Core filter: security configuration changes (new admin user, group membership change, new access token for another subject, new replication target, permission target edit) attributed to a `subject` whose credential was minted rather than issued through normal login. Triage values: `event type`, `acting subject`, `target object`, `source IP address`, `timestamp delta` from the token mint. Strong red flags: new replication or federation targets pointing at external hosts, and overwrites of previously stable release artifacts shortly after an anomalous token mint.
+  Host EDR process telemetry - Core filter: new child processes of the Artifactory Java service where `parent process command line` contains `java` with `artifactory` or `jf` service arguments and the child is a shell or network utility. Triage values: `process command line`, `parent process command line`, `file path`, `process user`. Strong red flags: shells such as `/bin/sh`, `bash`, or `cmd.exe` spawned by the service account, outbound connections from those children to untrusted hosts, or writes outside the Artifactory data directory. Pivot: tie process start times back to the token mint and enumeration window on the same host.
+---
+# H294
+
+On August 28, 2026 JFrog disclosed CVE-2026-82329 (CVSS 9.8), an authentication weakness in the JFrog Access component that, under default configuration, lets an unauthenticated attacker with network access obtain administrative privileges on self-hosted Artifactory. Instances without an additional join key configured receive a 'phantom' join key that can be abused to forge access and create administrator-level credentials. By September 1, watchTowr's honeypot telemetry showed in-the-wild exploitation: attackers minting admin tokens and enumerating users, groups, credential sets, and federated access topologies. Because Artifactory is the trust anchor for build and release pipelines, admin control converts an intrusion into a substitution risk: tampered artifacts, altered permission models, and new replication targets that push attacker-controlled content downstream. The durable defensive discriminator is not any exploit IOC but the sequence itself: an admin-scoped token or grant appearing with no preceding interactive authentication from the same source, followed within minutes by security-model enumeration and write actions against artifacts, permissions, or federation configuration. Fixed versions are 7.111.21, 7.117.28, 7.125.20, 7.133.29, 7.146.38, and 7.161.20; patched hosts still warrant retro-hunting because patching closes the door without evicting tokens already minted.
+
+## Why
+
+- Exploitation moved from disclosure (Aug 28) to observed in-the-wild admin token minting (Sep 1) in four days, and Artifactory sits upstream of build and release pipelines, so a missed intrusion becomes a substitution attack against every downstream consumer.
+- The hunt keys on an invariant chokepoint rather than rotating IOCs: to profit from the phantom join key the attacker must mint a privileged token without a preceding authenticated session and then touch the security model, a sequence legitimate workflows almost never produce in that order from one source.
+- Every stage is natively observable in telemetry defenders already have: JFrog Access logs record token issuance with subject/scope/source, the audit trail records security and replication changes, proxy logs capture the enumeration burst, and EDR captures anomalous children of the Java service.
+- False positives are controllable because legitimate CI minting is highly regular (stable service principals, recurring internal IPs, narrow scopes, scheduled cadence), letting hunters baseline and suppress automation identities instead of the endpoint, keeping the anomalous-provenance join high-precision.
+
+## References
+
+- [Exploited JFrog Artifactory bug puts software supply chain on alert (CSO Online, Sep 2, 2026)](https://www.csoonline.com/article/4217534/exploited-jfrog-artifactory-bug-puts-software-supply-chain-on-alert.html)
+- [JFrog Security Advisories (CVE-2026-82329 vendor advisory)](https://docs.jfrog.com/releases/docs/jfrog-security-advisories)
+- [Critical JFrog Artifactory Vulnerability Reportedly Exploited in the Wild (SecurityWeek)](https://www.securityweek.com/critical-jfrog-artifactory-vulnerability-reportedly-exploited-in-the-wild/)
+- [Attackers Exploit Critical JFrog Artifactory Flaw to Mint Admin Tokens Days After Disclosure (The Hacker News)](https://thehackernews.com/2026/09/attackers-exploit-critical-jfrog.html)


### PR DESCRIPTION
## Summary

Adds `H294`: Artifactory Admin Token Minting Without Prior Authenticated Session (CVE-2026-82329 Phantom Join Key Abuse).

## Sources

- https://www.csoonline.com/article/4217534/exploited-jfrog-artifactory-bug-puts-software-supply-chain-on-alert.html

## Validation

- Draft reviewed locally before submission.
- Source links are preserved in the hunt writeup.
