### PR TITLE
fix(ci): catch hunt-ID collisions between open PRs, not just against main

### DIFF
--- a/.github/workflows/validate-hunt-schema.yml
+++ b/.github/workflows/validate-hunt-schema.yml
@@ -14,6 +14,8 @@ on:
 
 permissions:
   contents: read
+  # Required by the cross-PR hunt ID check, which lists open PRs via `gh`.
+  pull-requests: read
 
 jobs:
   validate:
@@ -30,6 +32,13 @@ jobs:
       - run: pip install -r requirements.txt
       - name: Check for hunt ID collisions
         if: github.event_name == 'pull_request'
+        env:
+          # Lets the check see hunt IDs claimed by other open PRs, including
+          # ones from forks. Without these it silently falls back to comparing
+          # against main only, and a cross-PR duplicate is not caught until the
+          # second PR conflicts at merge time.
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           git fetch origin main
           python scripts/check_hunt_id_collisions.py

--- a/scripts/check_hunt_id_collisions.py
+++ b/scripts/check_hunt_id_collisions.py
@@ -6,7 +6,9 @@ Run on a PR with the head checked out and ``origin/main`` fetched. Detects:
   2. an added or modified file whose declared ID disagrees with its filename,
   3. a hunt file MODIFIED in place whose submitter changed — i.e. one
      contributor's hunt overwritten by a different hunt under the same ID,
-  4. two files in the working tree sharing an ID.
+  4. two files in the working tree sharing an ID,
+  5. a hunt file ADDED by the PR whose ID is also claimed by an older open PR
+     (lower PR number == earlier claim == priority).
 
 Fails closed if ``origin/main`` yields no hunts, since an empty baseline (an
 unresolved base ref) would otherwise let every colliding ID pass.
@@ -16,6 +18,9 @@ Exits 1 (printing each problem) on any collision, else 0.
 
 from __future__ import annotations
 
+import json
+import os
+import re
 import subprocess
 import sys
 from pathlib import Path
@@ -26,10 +31,17 @@ if _REPO_ROOT not in sys.path:
 
 import frontmatter
 
-from scripts.hunt_ids import find_id_problems
+from scripts.hunt_ids import (
+    existing_numbers,
+    find_id_problems,
+    format_hunt_id,
+    next_free_number,
+    parse_hunt_number,
+)
 from scripts.hunt_parser import _parse_legacy_table
 
 DIRS = ("Flames", "Embers", "Alchemy")
+_HUNT_PATH_RE = re.compile(r"^(?:Flames|Embers|Alchemy)/([HBM]\d+)\.md$")
 
 
 def _git(*args: str) -> str:
@@ -80,6 +92,88 @@ def _show_main(path: str) -> str:
         return ""
 
 
+def open_pr_claims(current_pr: int) -> dict[str, int]:
+    """Map each hunt ID ADDED by another open PR to the lowest PR number
+    claiming it.
+
+    Read from the GitHub API rather than git refs: a PR from a fork has no
+    branch under ``origin``, and merged draft branches are deleted, so a branch
+    scan sees almost nothing. Only ADDED files count — modifying an existing
+    hunt is not a claim on a new ID.
+
+    Returns ``{}`` when ``gh`` is unavailable or returns nothing usable. This
+    check then degrades to its main-only behaviour rather than blocking: a real
+    duplicate still collides on filename when the second PR merges.
+    """
+    listed = subprocess.run(
+        ["gh", "pr", "list", "--state", "open", "--json", "number,files"],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    if listed.returncode != 0:
+        print(
+            "note: `gh` unavailable; skipping the cross-PR hunt ID check "
+            "(main-only checks still apply)."
+        )
+        return {}
+
+    try:
+        prs = json.loads(listed.stdout or "[]")
+    except json.JSONDecodeError:
+        return {}
+
+    claims: dict[str, int] = {}
+    for pr in prs:
+        number = pr.get("number")
+        if number is None or number == current_pr:
+            continue
+        for entry in pr.get("files") or []:
+            if entry.get("changeType") != "ADDED":
+                continue
+            match = _HUNT_PATH_RE.match(entry.get("path", ""))
+            if not match:
+                continue
+            stem = match.group(1)
+            if stem not in claims or number < claims[stem]:
+                claims[stem] = number
+    return claims
+
+
+def suggest_free_id(stem: str, main_ids: set[str], claims: dict[str, int]) -> str:
+    """Next unclaimed ID sharing ``stem``'s prefix, given main and open PRs."""
+    prefix = stem[0]
+    taken = existing_numbers(main_ids, prefix) | existing_numbers(claims, prefix)
+    num = parse_hunt_number(stem, prefix)
+    if num is not None:
+        taken.add(num)
+    return format_hunt_id(next_free_number(taken), prefix)
+
+
+def cross_pr_problems(
+    added: list[tuple[str, str | None]], main_ids: set[str], current_pr: int
+) -> list[str]:
+    """Problems for IDs this PR adds that an OLDER open PR already claims.
+
+    Only the newer PR is failed, so a contested ID has exactly one side to fix
+    and an untouched PR never starts failing because a later one appeared.
+    """
+    if not current_pr:
+        return []
+    claims = open_pr_claims(current_pr)
+    problems = []
+    for stem, _declared in added:
+        other = claims.get(stem)
+        if other is not None and other < current_pr:
+            suggestion = suggest_free_id(stem, main_ids, claims)
+            problems.append(
+                f"{stem} is already claimed by the older PR #{other}. "
+                f"Renumber this hunt to {suggestion} "
+                f"(scripts/reassign_hunt_id.py rewrites the ID in place)."
+            )
+    return problems
+
+
 def main() -> int:
     # Establish the baseline first, and fail closed if it looks empty. ``main``
     # always has hunts, so an empty result means ``origin/main`` didn't resolve
@@ -117,6 +211,9 @@ def main() -> int:
     all_stems = [p.stem for d in DIRS for p in Path(d).glob("*.md")]
 
     problems = find_id_problems(added, main_ids, all_stems, modified)
+    problems += cross_pr_problems(
+        added, main_ids, int(os.environ.get("PR_NUMBER", "0") or "0")
+    )
     if problems:
         print("Hunt ID collision check FAILED:")
         for problem in problems:

--- a/scripts/tests/test_check_hunt_id_collisions.py
+++ b/scripts/tests/test_check_hunt_id_collisions.py
@@ -1,5 +1,9 @@
 """Tests for identity extraction used by the hunt-ID collision check."""
 
+import json
+
+import pytest
+
 from scripts import check_hunt_id_collisions as collisions
 from scripts.check_hunt_id_collisions import extract_identity
 
@@ -71,3 +75,91 @@ def test_main_fails_closed_when_origin_main_empty(monkeypatch, capsys):
     monkeypatch.setattr(collisions, "_git", lambda *args: "")
     assert collisions.main() == 1
     assert "no hunts on origin/main" in capsys.readouterr().out
+
+
+# --- cross-PR claims -------------------------------------------------------
+#
+# Regression for PRs #404/#405, which both added Flames/H294.md. Each PR was
+# only ever compared against main, so both passed and the duplicate surfaced
+# as a merge conflict that had to be renumbered by hand.
+
+
+class _GhResult:
+    def __init__(self, stdout, returncode=0):
+        self.stdout = stdout
+        self.returncode = returncode
+
+
+def _stub_gh(monkeypatch, payload, returncode=0):
+    monkeypatch.setattr(
+        collisions.subprocess,
+        "run",
+        lambda *a, **k: _GhResult(json.dumps(payload), returncode),
+    )
+
+
+def _pr(number, *paths, change_type="ADDED"):
+    return {
+        "number": number,
+        "files": [{"path": p, "changeType": change_type} for p in paths],
+    }
+
+
+def test_open_pr_claims_reads_added_hunt_files(monkeypatch):
+    _stub_gh(monkeypatch, [_pr(404, "Flames/H294.md"), _pr(400, "Embers/B040.md")])
+    assert collisions.open_pr_claims(405) == {"H294": 404, "B040": 400}
+
+
+def test_open_pr_claims_ignores_modified_files(monkeypatch):
+    # Editing an existing hunt is not a claim on a new ID.
+    _stub_gh(monkeypatch, [_pr(404, "Flames/H294.md", change_type="MODIFIED")])
+    assert collisions.open_pr_claims(405) == {}
+
+
+def test_open_pr_claims_ignores_non_hunt_paths_and_self(monkeypatch):
+    _stub_gh(
+        monkeypatch,
+        [_pr(404, "scripts/hunt_ids.py", "docs/H999.md"), _pr(405, "Flames/H295.md")],
+    )
+    assert collisions.open_pr_claims(405) == {}
+
+
+def test_open_pr_claims_empty_when_gh_unavailable(monkeypatch, capsys):
+    _stub_gh(monkeypatch, [], returncode=1)
+    assert collisions.open_pr_claims(405) == {}
+    assert "skipping the cross-PR hunt ID check" in capsys.readouterr().out
+
+
+def test_cross_pr_problem_reported_against_older_pr(monkeypatch):
+    _stub_gh(monkeypatch, [_pr(404, "Flames/H294.md")])
+    problems = collisions.cross_pr_problems(
+        [("H294", "H294")], {"H292", "H293"}, current_pr=405
+    )
+    assert len(problems) == 1
+    assert "claimed by the older PR #404" in problems[0]
+    assert "H295" in problems[0]
+
+
+def test_older_pr_is_not_failed_by_a_newer_claim(monkeypatch):
+    # PR #404 keeps H294; only the newer PR #405 is asked to move.
+    _stub_gh(monkeypatch, [_pr(405, "Flames/H294.md")])
+    assert (
+        collisions.cross_pr_problems([("H294", "H294")], {"H293"}, current_pr=404) == []
+    )
+
+
+def test_cross_pr_check_skipped_without_pr_number(monkeypatch):
+    monkeypatch.setattr(
+        collisions.subprocess,
+        "run",
+        lambda *a, **k: pytest.fail("must not call gh without a PR number"),
+    )
+    assert collisions.cross_pr_problems([("H294", "H294")], {"H293"}, current_pr=0) == []
+
+
+def test_suggestion_skips_ids_claimed_by_other_open_prs():
+    # H295 is taken by another PR, so the next free ID is H296.
+    suggestion = collisions.suggest_free_id(
+        "H294", {"H292", "H293"}, {"H294": 404, "H295": 406}
+    )
+    assert suggestion == "H296"


### PR DESCRIPTION
Replaces #406 with a smaller, better-targeted fix.

## Problem

`check_hunt_id_collisions.py` compares each PR's added hunt IDs against **main only**. Two open PRs adding the same ID both pass, and the duplicate doesn't surface until the second one hits a filename conflict at merge and gets renumbered by hand.

That's exactly what happened with #404 and #405 — both added `Flames/H294.md`.

## Fix

Also flag an added ID that an **older open PR** already claims.

- Claims come from the GitHub API, not git refs — a fork PR has no branch under `origin`, and merged draft branches are deleted, so a branch scan sees almost nothing (`origin` currently has exactly one branch).
- Only `ADDED` files count; editing an existing hunt isn't a claim on a new ID.
- Only the **newer** PR fails (lower PR number = earlier claim = priority), so a contested ID has one side to fix, and an untouched PR never starts failing because a later one appeared.
- The failure message names the next free ID.

## Why here rather than in `reassign_hunt_id.py` (#406)

`reassign_hunt_id.py` only ever runs on `draft/issue-*` branches — about **7 of 28** recent hunt PRs. The other 21 (`hearth/*` from a fork, `feat/cti-pipeline-*`) would still have been unprotected.

This check already runs on **every** PR as a required status check, so one change covers both paths, needs no renumbering logic, and no priority rules beyond "older PR wins".

## Safety

Degrades to the previous main-only behaviour if `gh` is unavailable, rather than blocking — a real duplicate still conflicts on filename at merge, so this is an earlier warning, not the only guard.

Workflow now passes `PR_NUMBER` + `GH_TOKEN` and needs `pull-requests: read`. Repo is public, so fork PRs still get a read token.

## Verification

- 8 new tests; full suite **133 passed**; `flake8` clean on CI's selection
- **Replayed against the real #404 API payload**: PR #405 fails with `H294 is already claimed by the older PR #404 ... Renumber this hunt to H295` — matching the manual fix
- Smoke-tested on clean main with `PR_NUMBER` unset: passes, `gh` never called

🤖 Generated with [Claude Code](https://claude.com/claude-code)