### PR TITLE
fix(scripts): keep created_date across a hunt rename

### DIFF
--- a/scripts/build_hunt_database.py
+++ b/scripts/build_hunt_database.py
@@ -92,15 +92,19 @@ def get_git_dates(filepath):
     import subprocess
 
     try:
-        # Get first commit date (creation)
+        # Get first commit date (creation).
+        # No --reverse: git silently returns only the newest commit when it is
+        # combined with --follow, which drops everything before a rename and
+        # makes created_date the rename date. Take the last line instead --
+        # git log is newest-first, so that is the oldest commit.
         result = subprocess.run(
-            ['git', 'log', '--follow', '--format=%aI', '--reverse', '--', str(filepath)],
+            ['git', 'log', '--follow', '--format=%aI', '--', str(filepath)],
             capture_output=True,
             text=True,
             timeout=5
         )
         dates = result.stdout.strip().split('\n')
-        created_date = dates[0] if dates and dates[0] else None
+        created_date = dates[-1] if dates and dates[-1] else None
 
         # Get last commit date (modification)
         result = subprocess.run(

--- a/scripts/tests/test_build_hunt_database.py
+++ b/scripts/tests/test_build_hunt_database.py
@@ -1,0 +1,92 @@
+"""Tests for git-derived hunt dates.
+
+get_git_dates shells out to git, so these drive a real throwaway repository —
+the bug being guarded against is in the git invocation itself, not in logic
+around it.
+"""
+
+import subprocess
+
+from scripts.build_hunt_database import get_git_dates
+
+
+def _git(repo, *args):
+    subprocess.run(["git", *args], cwd=repo, check=True, capture_output=True, text=True)
+
+
+def _repo(tmp_path):
+    _git(tmp_path, "init", "-q", ".")
+    _git(tmp_path, "config", "user.email", "t@example.com")
+    _git(tmp_path, "config", "user.name", "Test")
+    return tmp_path
+
+
+def _commit(repo, path, text, message, when):
+    target = repo / path
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_text(text, encoding="utf-8")
+    _git(repo, "add", "-A")
+    subprocess.run(
+        ["git", "commit", "-q", "-m", message],
+        cwd=repo,
+        check=True,
+        capture_output=True,
+        text=True,
+        env={
+            "GIT_AUTHOR_DATE": when,
+            "GIT_COMMITTER_DATE": when,
+            "PATH": "/usr/bin:/bin:/usr/local/bin",
+            "HOME": str(repo),
+        },
+    )
+
+
+# Realistic size matters: git detects a rename by content similarity, so a
+# two-byte file plus an inserted line falls under the threshold and --follow
+# would not track it regardless of the flags.
+BODY = "\n".join(
+    [
+        "category: Flames",
+        "title: Artifactory admin token minting",
+        "hypothesis: An adversary mints administrator-scoped tokens.",
+        "",
+        "## Why",
+    ]
+    + [f"- Reason number {n} that this is worth hunting for." for n in range(20)]
+)
+
+
+def test_created_date_survives_a_rename(tmp_path, monkeypatch):
+    # Regression: `git log --follow --reverse` silently returns only the newest
+    # commit, so created_date became the rename date rather than the date the
+    # hunt was first added. Hunts are renamed whenever an ID is assigned or
+    # reassigned, so this affected real rows.
+    repo = _repo(tmp_path)
+    _commit(repo, "Incoming/draft.md", BODY, "add draft", "2024-01-01T00:00:00+00:00")
+    (repo / "Flames").mkdir()
+    _git(repo, "mv", "Incoming/draft.md", "Flames/H001.md")
+    _commit(
+        repo,
+        "Flames/H001.md",
+        "id: H001\n" + BODY,
+        "assign",
+        "2026-06-01T00:00:00+00:00",
+    )
+
+    monkeypatch.chdir(repo)
+    created, modified = get_git_dates("Flames/H001.md")
+
+    assert created.startswith("2024-01-01")
+    assert modified.startswith("2026-06-01")
+
+
+def test_created_date_for_a_file_never_renamed(tmp_path, monkeypatch):
+    repo = _repo(tmp_path)
+    _commit(repo, "Flames/H001.md", BODY, "add", "2024-01-01T00:00:00+00:00")
+    _commit(repo, "Flames/H001.md", BODY + "\n- one more", "edit", "2025-01-01T00:00:00+00:00")
+
+    monkeypatch.chdir(repo)
+    created, modified = get_git_dates("Flames/H001.md")
+
+    assert created.startswith("2024-01-01")
+    assert modified.startswith("2025-01-01")


### PR DESCRIPTION
## Problem

`get_git_dates` (`build_hunt_database.py:88`) asked git for `log --follow --reverse`. **Those two flags don't compose** — git silently returns only the newest commit, dropping everything before a rename. So `created_date` became the date a hunt was *renamed*, not the date it was added.

Reproduced on git 2.55.0, one file renamed once:

```
$ git log --follow --format=%aI --reverse -- b/g.md
2026-09-09T20:13:01-05:00                 # 1 commit

$ git log --follow --format=%aI -- b/g.md
2026-09-09T20:13:01-05:00                 # 3 commits
2026-09-09T20:13:01-05:00
2026-09-09T20:13:01-05:00
```

No error, no warning — just a truncated history.

Hunts get renamed whenever an ID is assigned or reassigned (`reassign_hunt_id.py`), so this affects real rows in `database/hunts.db`.

## Fix

Drop `--reverse` and take the last line. `git log` is newest-first, so that's the oldest commit.

## Verification

Two tests against a real throwaway git repo, since the bug is in the git invocation rather than in logic around it. **Confirmed the rename test fails against the old flags and passes against the fix.**

The fixtures are deliberately realistic in size: git detects a rename by content similarity, so a two-byte fixture would fall below the threshold and fail to track the rename regardless of flags — a test that would have passed either way and proved nothing.

Found while verifying #408, but independent of it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)