### PR TITLE
feat(generators): emit ID-less drafts instead of allocating hunt IDs

### DIFF
--- a/.github/workflows/issue-generate-hunts.yml
+++ b/.github/workflows/issue-generate-hunts.yml
@@ -334,7 +334,7 @@ jobs:
         run: |
           git config --global user.name 'hearthbot'
           git config --global user.email 'hearthbot@users.noreply.github.com'
-          git add Flames/*.md
+          git add Incoming/ Flames/*.md
           git commit -m "feat(draft): Update hunt from issue #${{ github.event.issue.number }}"
           git remote set-url origin https://x-access-token:${{ secrets.HEARTH_TOKEN }}@github.com/${{ github.repository }}
           # Draft branches are disposable: a fresh submission or a regeneration

--- a/.github/workflows/process-hunt-submission.yml
+++ b/.github/workflows/process-hunt-submission.yml
@@ -47,7 +47,7 @@ jobs:
         run: |
           git config --global user.name 'hearthbot'
           git config --global user.email 'hearthbot@users.noreply.github.com'
-          git add Flames/*.md Embers/*.md Alchemy/*.md
+          git add Incoming/
           git commit -m "feat(draft): Create hunt from submission form in issue #${{ github.event.issue.number }}"
           git remote set-url origin https://x-access-token:${{ secrets.HEARTH_TOKEN }}@github.com/${{ github.repository }}
           git push --set-upstream origin draft/issue-${{ github.event.issue.number }}

--- a/Incoming/README.md
+++ b/Incoming/README.md
@@ -51,9 +51,9 @@ submitter:
 - https://example.com/report
 ```
 
-`title` is required here even though full hunts don't require it: assignment
-rewrites the body heading to `# <your-id>`, so the readable name has to survive
-in the frontmatter.
+`title` is optional, but worth setting: assignment rewrites the body heading to
+`# <your-id>`, so a name that lives only in an H1 is lost. In frontmatter it
+survives and is what the hunt is listed under.
 
 Pick a filename distinctive enough that two open PRs won't collide on it — if
 they do, the second gets an ordinary git conflict. Adding a `-YYYY-MM` suffix

--- a/scripts/drafts.py
+++ b/scripts/drafts.py
@@ -1,0 +1,98 @@
+"""Render an ID-less hunt draft for ``Incoming/``.
+
+Both generators produce legacy table-format markdown from an AI prompt. Rather
+than rewriting those prompts — and changing what the model returns — this
+parses their existing output with the same `_parse_legacy_table` the rest of
+the codebase trusts, and re-emits it as frontmatter with no ``id``.
+
+The ID is assigned when the PR merges (see scripts/assign_hunt_ids.py), so no
+generator has to guess a number that may be taken by the time it lands.
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+import yaml
+
+_REPO_ROOT = str(Path(__file__).resolve().parent.parent)
+if _REPO_ROOT not in sys.path:
+    sys.path.insert(0, _REPO_ROOT)
+
+from scripts.hunt_parser import _parse_legacy_table
+
+# Frontmatter key order, matching canonical hunts. `id` is deliberately absent.
+_FIELD_ORDER = (
+    "category",
+    "title",
+    "hypothesis",
+    "tactics",
+    "techniques",
+    "tags",
+    "submitter",
+    "notes",
+    "references",
+)
+
+_STOPWORDS = {"a", "an", "the", "are", "is", "to", "of", "for", "and", "with", "in"}
+
+
+def slugify(text: str, max_words: int = 8) -> str:
+    """A short, filesystem-safe, ID-free filename stem.
+
+    Never returns something matching ``[HBM]\\d+``: parse_draft_file rejects a
+    draft named like a hunt ID, and find_stray_hunts exits 1 on one.
+    """
+    words = re.findall(r"[a-z0-9]+", text.lower())
+    words = [w for w in words if w not in _STOPWORDS] or words
+    slug = "-".join(words[:max_words]).strip("-")
+    if not slug:
+        slug = "hunt"
+    if re.fullmatch(r"[hbm]\d+", slug):
+        slug = f"{slug}-draft"
+    return slug
+
+
+def draft_from_legacy_markdown(markdown: str, category: str) -> tuple[str, str]:
+    """Convert generator output into ``(filename, draft_text)``.
+
+    ``markdown`` is the legacy shape both generators emit: hypothesis text, a
+    six-column table, then ``## Why`` / ``## References`` sections.
+    """
+    data = _parse_legacy_table(markdown, hunt_id="draft", category=category)
+
+    front: dict = {"category": category}
+    for key in _FIELD_ORDER:
+        if key == "category":
+            continue
+        value = data.get(key)
+        if value in (None, "", [], {}):
+            continue
+        front[key] = value
+    front.pop("id", None)
+
+    # Keep the prose sections; drop the hypothesis line and the table, which
+    # frontmatter now carries.
+    body = _strip_table_and_lead(markdown)
+
+    text = (
+        "---\n"
+        + yaml.safe_dump(front, sort_keys=False, allow_unicode=True, width=100).strip()
+        + "\n---\n\n"
+        + body.strip()
+        + "\n"
+    )
+    stem = slugify(str(data.get("title") or data.get("hypothesis") or "hunt"))
+    return f"{stem}.md", text
+
+
+def _strip_table_and_lead(markdown: str) -> str:
+    """Drop everything before the first ``##`` section."""
+    lines = markdown.splitlines()
+    for i, line in enumerate(lines):
+        if line.startswith("## "):
+            return "\n".join(lines[i:])
+    # No sections at all: drop just the table rows.
+    return "\n".join(ln for ln in lines if not ln.lstrip().startswith("|"))

--- a/scripts/generate_from_cti.py
+++ b/scripts/generate_from_cti.py
@@ -1,8 +1,15 @@
 import os
 import random
 import re
+import sys
 import time
 from pathlib import Path
+
+_REPO_ROOT = str(Path(__file__).resolve().parent.parent)
+if _REPO_ROOT not in sys.path:
+    sys.path.insert(0, _REPO_ROOT)
+
+from scripts.drafts import draft_from_legacy_markdown
 
 from dotenv import load_dotenv
 from pypdf import PdfReader
@@ -191,19 +198,6 @@ def extract_technique_and_tactic(content: str) -> tuple:
         return (None, "Credential Access", 0.3)
     else:
         return (None, "Command And Control", 0.2)  # Default fallback
-
-
-def get_next_hunt_id():
-    """Next Flames hunt number: max existing ``HNNN`` + 1."""
-    flames_dir = Path("Flames/")
-    flames_dir.mkdir(exist_ok=True)
-    max_id = 0
-    hunt_pattern = re.compile(r"^H(\d+)$")
-    for f in flames_dir.glob("H*.md"):
-        match = hunt_pattern.match(f.stem)
-        if match:
-            max_id = max(max_id, int(match.group(1)))
-    return max_id + 1
 
 
 SYSTEM_PROMPT = """You are a threat hunter generating HEARTH markdown files.
@@ -530,10 +524,10 @@ if __name__ == "__main__":
         hunt_id = out_md_path.stem
         print(f"🔄 Regenerating hunt for {hunt_id} at {out_md_path}")
     else:
-        # Determine the next hunt number (HNNN, continuing the Flames sequence)
-        hunt_id = f"H{get_next_hunt_id():03d}"
-        out_md_path = Path(f"Flames/{hunt_id}.md")
-        print(f"🌱 Generating new hunt: {hunt_id}")
+        # No ID and no path yet: both are settled once the draft is rendered.
+        hunt_id = None
+        out_md_path = None
+        print("🌱 Generating new hunt draft (ID assigned at merge)")
 
     cti_source_url = os.getenv("CTI_SOURCE_URL")
     if not cti_source_url:
@@ -583,22 +577,36 @@ if __name__ == "__main__":
                 # Remove markdown headers
                 hypothesis = hypothesis.lstrip("#").strip()
 
-            # 4. Construct the final markdown content
-            final_content = f"# {hunt_id}\n\n"
-            final_content += cleaned_body.replace(
-                "| [Leave blank] |", f"| {hunt_id}    |"
-            )
+            # 4. Construct the final content.
+            #    A regeneration keeps its existing ID and file; a new hunt is
+            #    written as an ID-less draft, because an ID chosen now is
+            #    chosen against a main that keeps moving while the PR is open
+            #    (which is how two PRs came to claim H294). assign_hunt_ids.py
+            #    mints it at merge instead.
+            if is_regeneration:
+                final_content = f"# {hunt_id}\n\n"
+                final_content += cleaned_body.replace(
+                    "| [Leave blank] |", f"| {hunt_id}    |"
+                )
+            else:
+                filename, final_content = draft_from_legacy_markdown(
+                    cleaned_body, "Flames"
+                )
+                incoming = Path("Incoming")
+                incoming.mkdir(exist_ok=True)
+                out_md_path = incoming / filename
 
             # 5. Save the hunt file
             with open(out_md_path, "w") as f:
                 f.write(final_content)
-            print(f"✅ Successfully wrote hunt to {out_md_path}")
+            print(f"✅ Successfully wrote {'hunt' if is_regeneration else 'draft'} to {out_md_path}")
 
             # 6. Set the output for the GitHub Action
             if "GITHUB_OUTPUT" in os.environ:
                 with open(os.environ["GITHUB_OUTPUT"], "a") as f:
                     print(f"HUNT_FILE_PATH={out_md_path}", file=f)
-                    print(f"HUNT_ID={hunt_id}", file=f)
+                    if is_regeneration:
+                        print(f"HUNT_ID={hunt_id}", file=f)
                     print("HYPOTHESIS<<EOF", file=f)
                     print(hypothesis, file=f)
                     print("EOF", file=f)

--- a/scripts/hunt_schema.py
+++ b/scripts/hunt_schema.py
@@ -93,13 +93,18 @@ HUNT_SCHEMA: dict = {
 
 # A draft is a hunt submitted without an ID. The ID is assigned by
 # scripts/assign_hunt_ids.py when the PR merges, so that two PRs can never name
-# the same file and collide. `title` is required here (but not on a full hunt)
-# because assignment rewrites the body H1 to `# <new_id>`; the human-readable
-# name has to survive somewhere.
+# the same file and collide.
+#
+# `title` is optional, matching HUNT_SCHEMA. It was briefly required, on the
+# reasoning that assignment rewrites the body H1 to `# <new_id>` and the
+# readable name should survive. But generated hunts have no heading at all --
+# both generator prompts say "DO NOT include a title or markdown heading", and
+# the body opens with the hypothesis -- so there is nothing to preserve and the
+# requirement only blocked them.
 DRAFT_SCHEMA: dict = {
     **HUNT_SCHEMA,
     "title": "HEARTH Hunt Draft",
-    "required": sorted(set(HUNT_SCHEMA["required"]) - {"id"} | {"title"}),
+    "required": sorted(set(HUNT_SCHEMA["required"]) - {"id"}),
     # `id` stays in `properties` so a stray one still reports a pattern error
     # alongside this, rather than only an opaque "not allowed".
     "not": {"required": ["id"]},

--- a/scripts/process_hunt_submission.py
+++ b/scripts/process_hunt_submission.py
@@ -1,6 +1,13 @@
 import os
 import re
+import sys
 from pathlib import Path
+
+_REPO_ROOT = str(Path(__file__).resolve().parent.parent)
+if _REPO_ROOT not in sys.path:
+    sys.path.insert(0, _REPO_ROOT)
+
+from scripts.drafts import draft_from_legacy_markdown
 
 from dotenv import load_dotenv
 
@@ -162,17 +169,6 @@ def generate_hunt_file(details):
     return response.choices[0].message.content.strip()
 
 
-def get_next_hunt_id(hunt_type_prefix, hunt_dir):
-    """Next number for a prefix: max existing ``<prefix>NNN`` + 1 (1 if none)."""
-    stem_re = re.compile(rf"^{re.escape(hunt_type_prefix)}(\d+)$")
-    numbers = [
-        int(m.group(1))
-        for f in Path(hunt_dir).glob(f"{hunt_type_prefix}*.md")
-        if (m := stem_re.match(f.stem))
-    ]
-    return max(numbers) + 1 if numbers else 1
-
-
 if __name__ == "__main__":
     issue_body = os.getenv("ISSUE_BODY")
     if not issue_body:
@@ -192,27 +188,22 @@ if __name__ == "__main__":
     else:
         prefix, directory = "H", "Flames"  # Default to Flames
 
-    Path(directory).mkdir(exist_ok=True)
-
-    # 3. Determine next hunt ID (HNNN / BNNN / MNNN, continuing the sequence)
-    next_id = get_next_hunt_id(prefix, directory)
-    hunt_id = f"{prefix}{next_id:03d}"
-    out_md_path = Path(f"{directory}/{hunt_id}.md")
-
-    # 4. Generate the core content
+    # 3. Generate the core content
     hunt_content = generate_hunt_file(hunt_details)
 
-    # 5. Assemble the final file
-    final_content = f"# {hunt_id}\n\n"
-    final_content += hunt_content.replace("| [Leave blank] |", f"| {hunt_id}    |")
+    # 4. Emit an ID-less draft. No ID is allocated here: one chosen now is
+    #    chosen against a main that keeps moving while the PR is open, which is
+    #    how two PRs came to claim H294. assign_hunt_ids.py mints it at merge.
+    filename, draft_text = draft_from_legacy_markdown(hunt_content, directory)
+    incoming = Path("Incoming")
+    incoming.mkdir(exist_ok=True)
+    out_md_path = incoming / filename
 
-    # 6. Save the file
-    with open(out_md_path, "w") as f:
-        f.write(final_content)
-    print(f"✅ Successfully wrote hunt to {out_md_path}")
+    # 5. Save the file
+    out_md_path.write_text(draft_text, encoding="utf-8")
+    print(f"✅ Successfully wrote draft to {out_md_path}")
 
-    # 7. Set output for the workflow
+    # 6. Set output for the workflow
     if "GITHUB_OUTPUT" in os.environ:
         with open(os.environ["GITHUB_OUTPUT"], "a") as f:
             print(f"HUNT_FILE_PATH={out_md_path}", file=f)
-            print(f"HUNT_ID={hunt_id}", file=f)

--- a/scripts/tests/test_drafts.py
+++ b/scripts/tests/test_drafts.py
@@ -1,0 +1,89 @@
+"""Tests for turning generator output into an ID-less draft.
+
+Both generators emit legacy table markdown from an AI prompt. Rather than
+rewriting those prompts, drafts.py re-parses that output and re-emits it as
+frontmatter, so these drive the real shape the prompts ask the model for.
+"""
+
+import pytest
+
+from scripts.drafts import draft_from_legacy_markdown, slugify
+from scripts.hunt_parser import parse_draft_file
+
+GENERATED = """Threat actors are using PowerShell's Invoke-WebRequest cmdlet to \
+download encrypted payloads from Discord CDN to evade network detection.
+
+| Hunt #       | Idea / Hypothesis | Tactic | Notes | Tags | Submitter |
+|--------------|-------------------|--------|-------|------|-----------|
+| [Leave blank] | Threat actors are using PowerShell's Invoke-WebRequest cmdlet \
+to download encrypted payloads from Discord CDN. | Command and Control | Look for \
+Invoke-WebRequest to discord CDN domains. | #commandandcontrol #T1105 #powershell | \
+[th3CyF0x](https://x.com/th3cyf0x) |
+
+## Why
+- Discord CDN is trusted infrastructure and often allowlisted.
+
+## References
+- https://attack.mitre.org/techniques/T1105/
+"""
+
+
+def test_generated_output_becomes_a_valid_draft(tmp_path):
+    name, text = draft_from_legacy_markdown(GENERATED, "Flames")
+    path = tmp_path / name
+    path.write_text(text, encoding="utf-8")
+
+    # The real gate: it must survive the same validation CI runs on Incoming/.
+    draft = parse_draft_file(path)
+    assert "id" not in draft
+    assert draft["category"] == "Flames"
+    assert draft["tactics"] == ["Command and Control"]
+    assert "powershell" in draft["tags"]
+    assert draft["submitter"]["name"] == "th3CyF0x"
+
+
+def test_draft_declares_no_id_and_drops_the_table():
+    _, text = draft_from_legacy_markdown(GENERATED, "Flames")
+    assert "id:" not in text.split("---")[1]
+    assert "[Leave blank]" not in text
+    assert "| Hunt #" not in text
+
+
+def test_prose_sections_survive():
+    _, text = draft_from_legacy_markdown(GENERATED, "Flames")
+    assert "## Why" in text
+    assert "Discord CDN is trusted infrastructure" in text
+    assert "## References" in text
+
+
+def test_filename_is_a_slug_not_a_hunt_id():
+    name, _ = draft_from_legacy_markdown(GENERATED, "Flames")
+    assert name.endswith(".md")
+    assert "powershell" in name
+    # An HNNN-looking name would be rejected by parse_draft_file and would trip
+    # find_stray_hunts.
+    assert not name[0].isupper()
+
+
+def test_category_is_honoured():
+    _, text = draft_from_legacy_markdown(GENERATED, "Embers")
+    assert "category: Embers" in text
+
+
+@pytest.mark.parametrize(
+    "text,expected",
+    [
+        ("Threat actors are using PowerShell", "threat-actors-using-powershell"),
+        ("  Multiple   spaces  ", "multiple-spaces"),
+        ("!!!", "hunt"),
+        ("", "hunt"),
+    ],
+)
+def test_slugify(text, expected):
+    assert slugify(text) == expected
+
+
+def test_slugify_never_produces_a_hunt_id():
+    # find_stray_hunts exits 1 on an [HBM]NNN.md outside a category directory.
+    assert slugify("H294") == "h294-draft"
+    assert slugify("B045") == "b045-draft"

--- a/scripts/tests/test_hunt_schema.py
+++ b/scripts/tests/test_hunt_schema.py
@@ -172,10 +172,13 @@ def test_draft_must_not_declare_an_id():
     assert not any("should not be valid under" in e for e in errors)
 
 
-def test_draft_requires_title():
+def test_draft_title_is_optional():
+    # Generated hunts have no heading and no title: both generator prompts say
+    # "DO NOT include a title or markdown heading". Requiring one blocked them
+    # while preserving nothing.
     draft = _valid_draft()
     draft.pop("title")
-    assert any("'title' is a required property" in e for e in validate_draft(draft))
+    assert validate_draft(draft) == []
 
 
 def test_draft_requires_category_and_rejects_unknown_one():


### PR DESCRIPTION
Follow-up to #408. Makes the draft pipeline live for automated submissions — until now nothing automated emitted drafts, so #408's infrastructure had no traffic.

## Problem

Both generators picked an ID with `max(existing) + 1` against whatever `main` looked like at generation time, then sat in an open PR while other hunts merged. That's how #404 and #405 both came to claim `H294`.

## Approach

The obvious move — rewrite the AI prompts to emit frontmatter — would change what the model returns, and there's no way to test that here without an API key.

Instead `scripts/drafts.py` re-parses the generators' existing legacy-table output using the same `_parse_legacy_table` the rest of the codebase already relies on, and re-emits it as frontmatter with no `id`. **No prompt changes, no AI-behavior risk, and fully testable** against the exact shape the prompts ask for.

`generate_from_cti.py`'s `EXISTING_HUNT_FILE` branch is untouched — regenerating a hunt in place legitimately keeps its ID. Only the new-hunt path drafts.

## Revises one decision from #408

`title` was required on drafts, reasoning that assignment rewrites the body H1 to `# <id>` so the readable name must survive in frontmatter.

That was wrong for exactly the case this PR enables: **both generator prompts say "DO NOT include a title or markdown heading"** and the body opens with the hypothesis. There's no heading to destroy and no title to preserve — the requirement only blocked them. It's optional on full hunts, so drafts now match. The README still recommends setting it.

## Verification

178 tests (168 baseline + 10); `flake8` clean.

End-to-end in a scratch clone, exercising the whole path:

```
generator output (legacy table)
  -> Incoming/threat-actors-abusing-npm-lifecycle-hooks-launch-alternate.md
  -> passes the Incoming/ validation step CI runs
  -> assign_hunt_ids.py -> Flames/H296.md, "# H296" inserted
  -> rebuild_hunts_data.py -> indexed with tactic, tags, techniques intact
```

The strongest test round-trips generated output through `parse_draft_file` — the same gate CI applies — rather than just asserting on strings.

`slugify` is guarded against ever producing an `[HBM]NNN` stem, which `parse_draft_file` rejects and `find_stray_hunts` exits 1 on.

## Cleanup

`get_next_hunt_id` removed from both generators and `HUNT_ID` dropped from the submission generator's outputs — orphaned by this change, and nothing read `HUNT_ID`.

## Still to come

Phase 2: flip `REQUIRE_DRAFT_SUBMISSIONS` in `scripts/hunt_policy.py`, once the outside `hunt-cli` tooling emits drafts too. That also unlocks retiring `reassign_hunt_id.py` and its `pr-from-approval.yml` steps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)